### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
 # SPDX-License-Identifier: Apache-2.0
-
-# Doc team
-* @ConsenSys/protocol-pliny


### PR DESCRIPTION
Update codeowners file to remove Pliny team as required PR reviewer.