### PR TITLE
Removing Markdown link checker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,16 +19,3 @@ jobs:
         uses: Consensys/docs-gha/lint@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  linkCheck:
-    name: Link Checking
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        file-extensions: [".md", ".mdx"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: LinkCheck
-        uses: Consensys/docs-gha/linkcheck@main
-        with:
-          FILE_EXTENSION: '${{ matrix.file-extensions }}'


### PR DESCRIPTION
I'm testing something here: removing the Markdown linter that's included in the Github Actions script currently. This is an experiment to see if I can get it to, well, not break with Docusaurus-compatible internal linking, like (/managing-my-tokens/article.md)