### PR TITLE
Change repo name from doc.zk-evm to doc.linea

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ See [more](https://docs-template.consensys.net/) information about how Consensys
 
 ## Contribute to the docs
 
-See something missing? Error in our documentation? Create an issue [here](https://github.com/Consensys/doc.zk-evm/issues).
+See something missing? Error in our documentation? Create an issue [here](https://github.com/Consensys/doc.linea/issues).
 
-Alternatively, help us improve our documentation! [Fork our repo](https://github.com/ConsenSys/doc.zk-evm/fork), create a pull request, and tag us for review! (for help on this, see below)
+Alternatively, help us improve our documentation! [Fork our repo](https://github.com/ConsenSys/doc.linea/fork), create a pull request, and tag us for review! (for help on this, see below)
 
-Take a look at some [good first issues](https://github.com/ConsenSys/doc.zk-evm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started.
+Take a look at some [good first issues](https://github.com/ConsenSys/doc.linea/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started.
 
 ### How to submit a suggestion or change
 
@@ -89,7 +89,7 @@ This command generates static content into the `build` directory.
 
 ## Contribute to community tutorials
 
-If you've created more fleshed out guides and tutorials, we'd love to feature your content in our community tutorials section. [Fork our repo](https://github.com/Consensys/doc.zk-evm/fork), create a pull request, and tag us for review!
+If you've created more fleshed out guides and tutorials, we'd love to feature your content in our community tutorials section. [Fork our repo](https://github.com/Consensys/doc.linea/fork), create a pull request, and tag us for review!
 
 You can learn how to add a post under the `/blog` directory by following the Docusaurus instructions for [adding posts](https://docusaurus.io/docs/blog#adding-posts).
 
@@ -97,7 +97,7 @@ You can learn how to add a post under the `/blog` directory by following the Doc
 
 Diving into zero-knowledge rollups and getting stumped by the technical jargon? We've started an open source Zero-Knowledge glossary to define some common terms you might encounter as you dive into the L2 landscape.
 
-[Fork our repo](https://github.com/Consensys/doc.zk-evm/fork), and add a term in alphabetical order to `docs/reference/glossary.md`. Then, make a pull request and tag us for review!
+[Fork our repo](https://github.com/Consensys/doc.linea/fork), and add a term in alphabetical order to `docs/reference/glossary.md`. Then, make a pull request and tag us for review!
 
 ## Additional Resources
 

--- a/blog/2023-04-03-learn-with-linea.md
+++ b/blog/2023-04-03-learn-with-linea.md
@@ -17,6 +17,6 @@ We're excited to share the great educational content the Linea community has bee
 
 ## Contribute
 
-If you're interested in adding your own material, please read our [contribution guidelines](https://github.com/Consensys/doc.zk-evm#linea), and create a pull request.
+If you're interested in adding your own material, please read our [contribution guidelines](https://github.com/Consensys/doc.linea#linea), and create a pull request.
 
 [Join our Discord](https://discord.gg/linea) and [tag us on Twitter](https://twitter.com/lineabuild) to celebrate our community contributions!

--- a/docs/zero-knowledge-glossary/index.mdx
+++ b/docs/zero-knowledge-glossary/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 image: /img/socialCards/glossary.jpg
 ---
 
-This glossary is open source and consistently being updated. If you'd like a term to be added, please [create an issue](https://github.com/Consensys/doc.zk-evm/issues) or create a pull request and define one yourself!
+This glossary is open source and consistently being updated. If you'd like a term to be added, please [create an issue](https://github.com/Consensys/doc.linea/issues) or create a pull request and define one yourself!
 
 ## A
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const katex = require("rehype-katex");
 // const baseUrl = isDev ? "/" : "/";
 
 // const organizationName = "Consensys";
-// const projectName = "doc.zk-evm";
+// const projectName = "doc.linea";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "Consensys", // Usually your GitHub org/user name.
-  projectName: "doc.zk-evm", // Usually your repo name.
+  projectName: "doc.linea", // Usually your repo name.
   deploymentBranch: "gh-pages", // Github Pages deploying branch
 
   // Even if you don't use internalization, you can use this field to set useful
@@ -43,7 +43,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Set a base path separate from default /docs
-          editUrl: "https://github.com/Consensys/doc.zk-evm/tree/main/",
+          editUrl: "https://github.com/Consensys/doc.linea/tree/main/",
           path: "docs",
           routeBasePath: "/",
           // @ts-ignore
@@ -201,7 +201,7 @@ const config = {
             items: [
               {
                 label: "Contribute to our documentation",
-                href: "https://github.com/Consensys/doc.zk-evm",
+                href: "https://github.com/Consensys/doc.linea",
               },
             ],
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "doc.zk-evm",
-  "version": "2.0.0",
+  "name": "doc.linea",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "doc.zk-evm",
-      "version": "2.0.0",
+      "name": "doc.linea",
+      "version": "3.0.0",
       "dependencies": {
         "@docusaurus/core": "3.0.0",
         "@docusaurus/plugin-client-redirects": "3.0.0",
@@ -116,74 +116,74 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.2.tgz",
-      "integrity": "sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.3.tgz",
+      "integrity": "sha512-vRHXYCpPlTDE7i6UOy2xE03zHF2C8MEFjPN2v7fRbqVpcOvAUQK81x3Kc21xyb5aSIpYCjWCZbYZuz8Glyzyyg==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2"
+        "@algolia/cache-common": "4.23.3"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.2.tgz",
-      "integrity": "sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw=="
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.3.tgz",
+      "integrity": "sha512-h9XcNI6lxYStaw32pHpB1TMm0RuxphF+Ik4o7tcQiodEdpKK+wKufY6QXtba7t3k8eseirEMVB83uFFF3Nu54A=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.2.tgz",
-      "integrity": "sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.3.tgz",
+      "integrity": "sha512-yvpbuUXg/+0rbcagxNT7un0eo3czx2Uf0y4eiR4z4SD7SiptwYTpbuS0IHxcLHG3lq22ukx1T6Kjtk/rT+mqNg==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2"
+        "@algolia/cache-common": "4.23.3"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.2.tgz",
-      "integrity": "sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.3.tgz",
+      "integrity": "sha512-hpa6S5d7iQmretHHF40QGq6hz0anWEHGlULcTIT9tbUssWUriN9AUXIFQ8Ei4w9azD0hc1rUok9/DeQQobhQMA==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.23.3",
+        "@algolia/client-search": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.2.tgz",
-      "integrity": "sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.3.tgz",
+      "integrity": "sha512-LBsEARGS9cj8VkTAVEZphjxTjMVCci+zIIiRhpFun9jGDUlS1XmhCW7CTrnaWeIuCQS/2iPyRqSy1nXPjcBLRA==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.23.3",
+        "@algolia/client-search": "4.23.3",
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.2.tgz",
-      "integrity": "sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.3.tgz",
+      "integrity": "sha512-l6EiPxdAlg8CYhroqS5ybfIczsGUIAC47slLPOMDeKSVXYG1n0qGiz4RjAHLw2aD0xzh2EXZ7aRguPfz7UKDKw==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.2.tgz",
-      "integrity": "sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.3.tgz",
+      "integrity": "sha512-3E3yF3Ocr1tB/xOZiuC3doHQBQ2zu2MPTYZ0d4lpfWads2WTKG7ZzmGnsHmm63RflvDeLK/UVx7j2b3QuwKQ2g==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.23.3",
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.2.tgz",
-      "integrity": "sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.3.tgz",
+      "integrity": "sha512-P4VAKFHqU0wx9O+q29Q8YVuaowaZ5EM77rxfmGnkHUJggh28useXQdopokgwMeYw2XUht49WX5RcTQ40rZIabw==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.23.3",
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/events": {
@@ -192,65 +192,65 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.2.tgz",
-      "integrity": "sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw=="
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.3.tgz",
+      "integrity": "sha512-y9kBtmJwiZ9ZZ+1Ek66P0M68mHQzKRxkW5kAAXYN/rdzgDN0d2COsViEFufxJ0pb45K4FRcfC7+33YB4BLrZ+g=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.2.tgz",
-      "integrity": "sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.3.tgz",
+      "integrity": "sha512-8xoiseoWDKuCVnWP8jHthgaeobDLolh00KJAdMe9XPrWPuf1by732jSpgy2BlsLTaT9m32pHI8CRfrOqQzHv3A==",
       "dependencies": {
-        "@algolia/logger-common": "4.23.2"
+        "@algolia/logger-common": "4.23.3"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.2.tgz",
-      "integrity": "sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.3.tgz",
+      "integrity": "sha512-9fK4nXZF0bFkdcLBRDexsnGzVmu4TSYZqxdpgBW2tEyfuSSY54D4qSRkLmNkrrz4YFvdh2GM1gA8vSsnZPR73w==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.2",
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/cache-in-memory": "4.23.2",
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/logger-console": "4.23.2",
-        "@algolia/requester-browser-xhr": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/requester-node-http": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/cache-browser-local-storage": "4.23.3",
+        "@algolia/cache-common": "4.23.3",
+        "@algolia/cache-in-memory": "4.23.3",
+        "@algolia/client-common": "4.23.3",
+        "@algolia/client-search": "4.23.3",
+        "@algolia/logger-common": "4.23.3",
+        "@algolia/logger-console": "4.23.3",
+        "@algolia/requester-browser-xhr": "4.23.3",
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/requester-node-http": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.2.tgz",
-      "integrity": "sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.3.tgz",
+      "integrity": "sha512-jDWGIQ96BhXbmONAQsasIpTYWslyjkiGu0Quydjlowe+ciqySpiDUrJHERIRfELE5+wFc7hc1Q5hqjGoV7yghw==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/requester-common": "4.23.3"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.2.tgz",
-      "integrity": "sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q=="
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.3.tgz",
+      "integrity": "sha512-xloIdr/bedtYEGcXCiF2muajyvRhwop4cMZo+K2qzNht0CMzlRkm8YsDdj5IaBhshqfgmBb3rTg4sL4/PpvLYw=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.2.tgz",
-      "integrity": "sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.3.tgz",
+      "integrity": "sha512-zgu++8Uj03IWDEJM3fuNl34s746JnZOWn1Uz5taV1dFyJhVM/kTNw9Ik7YJWiUNHJQXcaD8IXD1eCb0nq/aByA==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/requester-common": "4.23.3"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.2.tgz",
-      "integrity": "sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.3.tgz",
+      "integrity": "sha512-Wjl5gttqnf/gQKJA+dafnD0Y6Yw97yvfY8R9h0dQltX1GXTgNs1zWgvtWW0tHl1EgMdhAyw189uWiZMnL3QebQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/cache-common": "4.23.3",
+        "@algolia/logger-common": "4.23.3",
+        "@algolia/requester-common": "4.23.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2564,9 +2564,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.17.tgz",
-      "integrity": "sha512-CS0Tb2f2YwQZ4VZ6+WLAO5uOzb0iO/iYSRl34kX4enq6quXxLYzwdfGAwv85wSYHPdga8tGiZFP+p8GPsi2JEg==",
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.19.tgz",
+      "integrity": "sha512-tHcXdkmm0t9LlRct1vgu3+h0KW/wlXCInkTiR4D/rl730q1zu2qVEgiy1saMiTUSNmdu7Hiy+Mhb+1braVqnZQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
@@ -2729,9 +2729,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.3.18.tgz",
-      "integrity": "sha512-LJZGGMGqS8KzgXJrSMs3T+6GoqHG9z8Bc+rqLzLzbtoR3FbsMasE9U8oP2PmS3q7jJLFjQkzmg508DrcuZuo2g==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.3.19.tgz",
+      "integrity": "sha512-nNQiwhXUe+vEBzOpvi2sVycOLrVJw2bNtwRum1Ya1w74nOKgciCE21UU9fkPGA6p45bU9qmwtPoYccMlHsGMSg==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
@@ -2753,9 +2753,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-typescript": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.2.tgz",
-      "integrity": "sha512-lcNOYWjLUvDZdLa0UMNd/LwfVdxhE9rKA+agZBGjL3lTA3uNvH7IUqSJM/IXhJoBpLLMVEOk8v1N9xi+vDuCdA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.3.tgz",
+      "integrity": "sha512-TdD789OWwOImH/IMyz/QRA6LJz7ScI/qbn1YOkcAW3AROvgbc0oKAxzp08+Xu8tj4GROrJ9UqZdh0t9xQCPkPg==",
       "dev": true
     },
     "node_modules/@cspell/dict-vue": {
@@ -6165,9 +6165,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.9",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz",
+      "integrity": "sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6304,9 +6304,9 @@
       }
     },
     "node_modules/@types/mdx": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.12.tgz",
-      "integrity": "sha512-H9VZ9YqE+H28FQVchC83RCs5xQ2J7mAAv6qdDEaWmXEVl3OpdH+xfrSUzQ1lp7U7oSTRZ0RvW08ASPJsYBi7Cw=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -6359,9 +6359,9 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA=="
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -6369,9 +6369,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.74",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
-      "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
+      "version": "18.2.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
+      "integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6961,25 +6961,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.2.tgz",
-      "integrity": "sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.3.tgz",
+      "integrity": "sha512-Le/3YgNvjW9zxIQMRhUHuhiUjAlKY/zsdZpfq4dlLqg6mEm0nL6yk+7f2hDOtLpxsgE4jSzDmvHL7nXdBp5feg==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.2",
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/cache-in-memory": "4.23.2",
-        "@algolia/client-account": "4.23.2",
-        "@algolia/client-analytics": "4.23.2",
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-personalization": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/logger-console": "4.23.2",
-        "@algolia/recommend": "4.23.2",
-        "@algolia/requester-browser-xhr": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/requester-node-http": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/cache-browser-local-storage": "4.23.3",
+        "@algolia/cache-common": "4.23.3",
+        "@algolia/cache-in-memory": "4.23.3",
+        "@algolia/client-account": "4.23.3",
+        "@algolia/client-analytics": "4.23.3",
+        "@algolia/client-common": "4.23.3",
+        "@algolia/client-personalization": "4.23.3",
+        "@algolia/client-search": "4.23.3",
+        "@algolia/logger-common": "4.23.3",
+        "@algolia/logger-console": "4.23.3",
+        "@algolia/recommend": "4.23.3",
+        "@algolia/requester-browser-xhr": "4.23.3",
+        "@algolia/requester-common": "4.23.3",
+        "@algolia/requester-node-http": "4.23.3",
+        "@algolia/transporter": "4.23.3"
       }
     },
     "node_modules/algoliasearch-helper": {
@@ -7896,9 +7896,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001606",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
-      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
+      "version": "1.0.30001610",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
+      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8804,9 +8804,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
-      "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -8814,9 +8814,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dependencies": {
         "browserslist": "^4.23.0"
       },
@@ -8826,9 +8826,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.36.1.tgz",
-      "integrity": "sha512-NXCvHvSVYSrewP0L5OhltzXeWFJLo2AL2TYnj6iLV3Bw8mM62wAQMNgUCRI6EBu6hVVpbCxmOPlxh1Ikw2PfUA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.0.tgz",
+      "integrity": "sha512-d3BrpyFr5eD4KcbRvQ3FTUx/KWmaDesr7+a3+1+P46IUnNoEt+oiLijPINZMEon7w9oGkIINWxrBAU9DEciwFQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -10015,9 +10015,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.728",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.728.tgz",
-      "integrity": "sha512-Ud1v7hJJYIqehlUJGqR6PF1Ek8l80zWwxA6nGxigBsGJ9f9M2fciHyrIiNMerSHSH3p+0/Ia7jIlnDkt41h5cw=="
+      "version": "1.4.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.738.tgz",
+      "integrity": "sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -10999,15 +10999,12 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.0.1.tgz",
-      "integrity": "sha512-b2tdzTurEIbwRh+mKrEcaWfu1wgb8J1hVsgREg7FFiecWwK/PhO8X0kyc+0bIcKNtD4sqxIdNoRy6/p/TvECEA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.1.1.tgz",
+      "integrity": "sha512-5mvUrF2suuv5f5cGDnDphIy4/gW86z82kl5qG6mM9z04SEQI4FB5Apmaw/TGEf3l55nLtMs5s51dmhUzvAHQCA==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "is-plain-obj": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/remcohaszing"
@@ -12644,9 +12641,9 @@
       }
     },
     "node_modules/hast-util-to-text": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.0.tgz",
-      "integrity": "sha512-EWiE1FSArNBPUo1cKWtzqgnuRQwEeQbQtnFJRYV1hb1BWDgrAlBU0ExptvZMM/KSA82cDpm2sFGf3Dmc5Mza3w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -13794,6 +13791,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17249,9 +17247,9 @@
       ]
     },
     "node_modules/micromark-util-subtokenize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
-      "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.1.tgz",
+      "integrity": "sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -17439,9 +17437,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.1.tgz",
-      "integrity": "sha512-/1HDlyFRxWIZPI1ZpgqlZ8jMw/1Dp/dl3P0L1jtZ+zVcHqwPhGwaJwKL00WVgfnBy6PWCde9W65or7IIETImuA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
+      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
       "dependencies": {
         "schema-utils": "^4.0.0",
         "tapable": "^2.2.1"
@@ -22934,9 +22932,9 @@
       }
     },
     "node_modules/react-player": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.15.1.tgz",
-      "integrity": "sha512-ni1XFuYZuhIKKdeFII+KRLmIPcvCYlyXvtSMhNOgssdfnSovmakBtBTW2bxowPvmpKy5BTR4jC4CF79ucgHT+g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.0.tgz",
+      "integrity": "sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==",
       "dependencies": {
         "deepmerge": "^4.0.0",
         "load-script": "^1.0.0",
@@ -24243,16 +24241,16 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.0.0",
-        "@octokit/request": "^8.0.2",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -24261,12 +24259,12 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/endpoint": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-      "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -24274,13 +24272,13 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/graphql": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/request": "^8.0.1",
-        "@octokit/types": "^12.0.0",
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -24288,9 +24286,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==",
       "dev": true
     },
     "node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest": {
@@ -24306,6 +24304,21 @@
       },
       "peerDependencies": {
         "@octokit/core": "5"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/plugin-retry": {
@@ -24325,6 +24338,21 @@
         "@octokit/core": ">=5"
       }
     },
+    "node_modules/semantic-release/node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "node_modules/semantic-release/node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
     "node_modules/semantic-release/node_modules/@octokit/plugin-throttling": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
@@ -24341,15 +24369,30 @@
         "@octokit/core": "^5.0.0"
       }
     },
-    "node_modules/semantic-release/node_modules/@octokit/request": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-      "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+    "node_modules/semantic-release/node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "node_modules/semantic-release/node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dev": true,
       "dependencies": {
-        "@octokit/endpoint": "^9.0.0",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -24357,12 +24400,12 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
@@ -24371,12 +24414,12 @@
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/openapi-types": "^22.1.0"
       }
     },
     "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
@@ -26865,10 +26908,15 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/traverse": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
-      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.9.tgz",
+      "integrity": "sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==",
       "dev": true,
+      "dependencies": {
+        "gopd": "^1.0.1",
+        "typedarray.prototype.slice": "^1.0.3",
+        "which-typed-array": "^1.1.15"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -27158,10 +27206,30 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedarray.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-errors": "^1.3.0",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-offset": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27988,9 +28056,9 @@
       }
     },
     "node_modules/webpack-bundle-analyzer": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
-      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
       "dependencies": {
         "@discoveryjs/json-ext": "0.5.7",
         "acorn": "^8.0.4",
@@ -28000,7 +28068,6 @@
         "escape-string-regexp": "^4.0.0",
         "gzip-size": "^6.0.0",
         "html-escaper": "^2.0.2",
-        "is-plain-object": "^5.0.0",
         "opener": "^1.5.2",
         "picocolors": "^1.0.0",
         "sirv": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "doc.zk-evm",
-  "version": "2.0.0",
+  "name": "doc.linea",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
This PR supports the repo name change to be in line with current branding.

This includes updating package.json, a bunch of links in docusaurus.confg.js, and a few more links in articles, etc.