### PR TITLE
Add alternative gas estimation methods

### DIFF
--- a/docs/build-on-linea/gas-fees.mdx
+++ b/docs/build-on-linea/gas-fees.mdx
@@ -8,13 +8,15 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 # Estimate transaction costs
 
-:::info [Reducing gas fees]
+:::info[Reducing gas fees]
 
 Building on gas optimizations introduced with Alpha v2 in February 2024, Linea implemented 
 EIP-4844 with Alpha v3 on March 26 2024. Gas fees are anticipated to be a fraction of what they 
 were. See [here](../use-mainnet/gas-on-linea.mdx) for details.
 
 :::
+
+## How gas works on Linea
 
 Linea supports the [Ethereum EIP-1559 gas price model](https://ethereum.org/developers/docs/gas). 
 However, as a layer 2 blockchain, Linea provides a more stable and cost-effective solution 
@@ -38,9 +40,20 @@ components:
 - **Layer 1 fee** - The L1 fee is the cost to publish your L2 transaction onto Ethereum and can 
     vary based on the blob fee market.
 
+## Estimating transaction costs
+
 :::warning Method deactivated
 
 The `linea_estimateGas` method used to estimate transaction fees has been temporarily deactivated
 on Linea Mainnet and testnets.
 
 :::
+
+As Linea supports all but a few [Ethereum JSON-RPC API methods](quickstart/rpc), there are several 
+options for estimating gas. Click through for Infura's guides on their usage:
+- [`eth_estimateGas`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_estimategas) — 
+Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+- [`eth_gasPrice`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_gasprice) — Returns 
+the current gas price in wei.
+- [`eth_feeHistory`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_feehistory) — 
+Returns historical gas information.


### PR DESCRIPTION
Adds detail to the `gas-fees` page to clarify the available methods for calculating gas whilst `linea_estimateGas` is unavailable.