### PR TITLE
Add callout about supported Geth versions

### DIFF
--- a/docs/build-on-linea/run-a-node/use-binary.mdx
+++ b/docs/build-on-linea/run-a-node/use-binary.mdx
@@ -118,8 +118,15 @@ The Besu node will attempt to find peers to begin synchronizing and to download 
 
 ### Step 1. Install Geth
 
-Download v1.11.6 [Geth](https://geth.ethereum.org/downloads) (latest untested) and install using the instructions provided
-[here](https://geth.ethereum.org/docs/getting-started/installing-geth)
+Download [Geth](https://geth.ethereum.org/downloads) and install using the instructions provided
+[here](https://geth.ethereum.org/docs/getting-started/installing-geth). 
+
+:::warning
+
+Linea only supports Geth _up to_ v1.13.15 or lower. v1.14.0 and subsequent versions are not 
+supported. 
+
+:::
 
 ### Step 2. Download the genesis file
 


### PR DESCRIPTION
With v1.14.0, Geth [dropped support for pre-merge—like networks](https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0). As a result, it's no longer possible to run a Linea node. Users need to stay to v1.13.15 or lower for the node to function. 

The PR adds a callout to the relevant page to make this clear.