### PR TITLE
Adding EasyNode to the projects list

### DIFF
--- a/docs/developers/tooling/node-providers.md
+++ b/docs/developers/tooling/node-providers.md
@@ -18,9 +18,9 @@ image: /img/socialCards/node-providers.jpg
 ## Run your own node
 
 - [Set it up yourself](../guides/run-a-node)
-- [One-click deploy with Mintair](https://mintair.xyz/)
 - [One-click deploy with EasyNode](https://app.easy-node.xyz/)
 - [One-click deploy with RapidNode](https://rapidnode.xyz/dashboard)
+- [One-click deploy with Mintair](https://mintair.xyz/)
 
 ## Public RPC endpoints
 

--- a/docs/developers/tooling/node-providers.md
+++ b/docs/developers/tooling/node-providers.md
@@ -19,8 +19,8 @@ image: /img/socialCards/node-providers.jpg
 
 - [Set it up yourself](../guides/run-a-node)
 - [One-click deploy with EasyNode](https://app.easy-node.xyz/)
-- [One-click deploy with RapidNode](https://rapidnode.xyz/dashboard)
 - [One-click deploy with Mintair](https://mintair.xyz/)
+- [One-click deploy with RapidNode](https://rapidnode.xyz/dashboard)
 
 ## Public RPC endpoints
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -206,6 +206,8 @@ DRPC
 DSLA
 DVF
 EACCES
+EasyNode
+easynode
 easyops
 EBSCSI
 efrog


### PR DESCRIPTION
Adding EasyNode to the projects list 
And keep the original order of the Node providers list.
None is more legitimate than the other so the initial order should not be altered here.