### PR TITLE
Mark Infura faucet as available in transition page

### DIFF
--- a/docs/build-on-linea/goerli-to-sepolia.mdx
+++ b/docs/build-on-linea/goerli-to-sepolia.mdx
@@ -56,9 +56,9 @@ Here are the key details:
 
 Live: 
 - [Covalent](https://www.covalenthq.com/faucet/)
+- [Infura](https://www.infura.io/faucet/linea)
 
 Coming soon:
-- [Infura](https://www.infura.io/faucet/linea)
 - [LearnWeb3](https://learnweb3.io/faucets/)
 
 ### Infura


### PR DESCRIPTION
Moves the Infura faucet from the 'coming soon' list to the 'live' list.