### PR TITLE
Add redirect for Linea Surge index page

### DIFF
--- a/docs/build-on-linea/tooling/privacy/index.mdx
+++ b/docs/build-on-linea/tooling/privacy/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Security
-image: /img/socialCards/privacy.jpg
+image: /img/socialCards/security.jpg
 ---
 
 

--- a/docs/build-on-linea/tooling/privacy/secret.md
+++ b/docs/build-on-linea/tooling/privacy/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret Network
-image: /img/socialCards/secret.jpg
+image: /img/socialCards/secret-network.jpg
 ---
 
 ## Decentralized Confidential Computing​

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -333,6 +333,10 @@ const config = {
             from: "/use-mainnet/linea-surge-model",
           },
           {
+            to: "/users/linea-voyage/linea-surge",
+            from: "/use-mainnet/linea-surge",
+          },
+          {
             to: "/developers/guides/gas/gas-fees",
             from: "/reference/api/linea-estimategas",
           },


### PR DESCRIPTION
With the restructure implemented in #554, we added a host of redirects for files we'd moved. We missed one: the index page for the Linea Surge directory. This PR adds it back. 