### PR TITLE
Fix redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -436,6 +436,10 @@ const config = {
             to: "/developers/guides/gas/gas-on-linea",
             from: "/use-mainnet/gas-on-linea",
           },
+          {
+            to: "/developers/tooling/cross-chain/shortcuts",
+            from: "/build-on-linea/tooling/cross-chain/shortcuts",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Fixing a broken link occurring on bridge.linea.build that resulted from renaming the directory from `build-on-linea` to `developers`. 