### PR TITLE
Improve formatting of architecture overview page

### DIFF
--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -9,17 +9,17 @@ image: /img/socialCards/architecture-of-linea.jpg
 
 ## Linea's ideal state
 
-Linea has the goal of being a fully decentralized, permissionless network. To that end, we are building towards an architecture made up of three main elements:
+Linea has the goal of being a fully decentralized, permissionless network. To that end, we are 
+building towards an architecture made up of three main elements:
 
 - Sequencer
 - Prover
-- Bridge Relayer
-
-(Don't worry, if this isn't making sense to you yet, we'll explain further below 😎)
+- Bridge relayer
 
 ## Current state
 
-Linea is in mainnet status, and the team is fervently working towards full decentralization. Currently, this is a good representation of the main components of Linea, and how they interact:
+Linea is in mainnet status, and the team is fervently working towards full decentralization. 
+Currently, this is a good representation of the main components of Linea, and how they interact:
 
 <div class="center-container">
   <div class="img-large">
@@ -32,25 +32,50 @@ Linea is in mainnet status, and the team is fervently working towards full decen
 
 ## First of all: what _is_ Linea, anyway? What's a zkEVM L2?
 
-There are a number of different mental models that people in web3 use to explain these different networks and how they relate to one another. Some people prefer to call them "rollup networks", or "scaling solutions"; probably the most popular way of discussing them is by imagining them as "layers", where one network is "built on top of another". Let's try and set metaphor aside for a moment, and speak in clear terms:
+There are a number of different mental models that people in web3 use to explain these different 
+networks and how they relate to one another. Some people prefer to call them "rollup networks", 
+or "scaling solutions"; probably the most popular way of discussing them is by imagining them as 
+"layers", where one network is "built on top of another". Let's try and set metaphor aside for 
+a moment, and speak in clear terms:
 
 **The Ethereum network has several functional areas:**
 
-> - It has the _blockchain_, where it keeps track of addresses, and which tokens are allocated to which addresses.
-> - It has the _consensus_ mechanism, wherein many many nodes communicate about the movement of tokens from one address to another, and each keeps their local copy of the ledger up to date.
-> - And it has the _execution environment_, wherein computer programs can be run. That's the "EVM", or "Ethereum Virtual Machine", part of things.
+- It has the _blockchain_, where it keeps track of addresses, and which tokens are allocated to 
+which addresses;
+- It has the _consensus_ mechanism, wherein many many nodes communicate about the movement of 
+tokens from one address to another, and each keeps their local copy of the ledger up to date;
+- And it has the _execution environment_, wherein computer programs can be run. That's the "EVM", 
+or "Ethereum Virtual Machine", part of things.
 
-**These three areas are heavily interconnected, and this is a simplification, but it's a helpful one to understand what's going on with other networks.**
+These three areas are heavily interconnected, and this is a simplification, but it's a helpful 
+one to understand what's going on with other networks.
 
-Ethereum prioritizes security: that consensus mechanism is designed to ensure that no one can singlehandedly alter the state of the network. This is a very impressive feat of engineering, and it comes with a tradeoff: the execution environment is highly limited in the amount of work it can do, because the consensus mechanism intentionally runs slowly, to keep everything safe.
+Ethereum prioritizes security: that consensus mechanism is designed to ensure that no one can 
+singlehandedly alter the state of the network. This is a very impressive feat of engineering, 
+and it comes with a tradeoff: the execution environment is highly limited in the amount of work 
+it can do, because the consensus mechanism intentionally runs slowly, to keep everything safe.
 
-Linea, and other networks like it, is designed to participate in the security mechanism of Ethereum, while optimizing for execution. In other words, it allows people to do lots of transactions, run lots of programs, deploy contracts, mint NFTs, absolutely go to town--fast, and cheap--and then report all that back to Ethereum, and include it in Ethereum's blockchain. By sending regular reports of activity on Linea to Ethereum, the network can optimize for execution without being as limited by security.
+Linea, and other networks like it, is designed to participate in the security mechanism of Ethereum, 
+while optimizing for execution. In other words, it allows people to do lots of transactions, run 
+lots of programs, deploy contracts, mint NFTs, absolutely go to town—fast, and cheap-and then 
+report all that back to Ethereum, and include it in Ethereum's blockchain. By sending regular 
+reports of activity on Linea to Ethereum, the network can optimize for execution without being as 
+limited by security.
 
-This is the action known as "rolling up": we would say that Linea "rolls up its transactions to Ethereum". And the fact that it relies on Ethereum for something--the security--leads people to say that it's "built on top of Ethereum": it's a "second-layer network", an L2. And before you ask, yes, Ethereum is an L1, and L3s exist, too: networks that roll up to Linea would roll up to Ethereum...
+This is the action known as "rolling up": we would say that Linea "rolls up its transactions to 
+Ethereum". And the fact that it relies on Ethereum for something-the security-leads people to say 
+that it's "built on top of Ethereum": it's a "second-layer network", an L2. And before you ask, 
+yes, Ethereum is an L1, and L3s exist, too: networks that roll up to Linea would roll up to 
+Ethereum.
 
-The trick is in how that _rollup_ happens. Linea is special: it uses cutting-edge developments in a branch of mathematics and computer science often referred to as **zero-knowledge**, or _zero-knowledge cryptography_, to **prove to the Ethereum network that everything that is happening on the Linea network is, in fact, happening, without having to submit a complete record of every last transaction and check each one.** That's the 'zk' part.
+The trick is in how that _rollup_ happens. Linea is special: it uses cutting-edge developments in 
+a branch of mathematics and computer science often referred to as zero-knowledge, or 
+_zero-knowledge cryptography_, to prove to the Ethereum network that everything that is happening 
+on the Linea network is, in fact, happening, without having to submit a complete record of every 
+last transaction and check each one. That's the 'zk' part.
 
-So, now that we've walked through some concepts, we can roll it all up: **Linea is a zkEVM L2 network**.
+So, now that we've walked through some concepts, we can roll it all up: Linea is a zkEVM L2 
+network.
 
 <div class="center-container">
   <div class="img-xsmall">
@@ -61,37 +86,25 @@ So, now that we've walked through some concepts, we can roll it all up: **Linea 
   </div>
 </div>
 
-### OK... But what's a _sequencer_ and a _prover_? How does all this actually work?
+## OK... But what's a _sequencer_ and a _prover_? How does all this actually work?
 
 At a high level, if you were to follow a flow from Ethereum, through Linea, and back to Ethereum, it would go like this:
 
-> #### Ethereum bridge contract >
->
-> #### Linea bridge contract >
->
-> #### Coordinator >
->
-> #### Sequencer (Block building > Execution > Trace data generation) >
->
-> #### Coordinator >
->
-> #### Trace Conflation >
->
-> #### EVM State Manager >
->
-> #### Trace Expansion and Proving (Corset > gnark) >
->
-> #### Coordinator >
->
-> #### zk-proof and updated Merkle tree >
->
-> #### Linea bridge contract >
->
-> #### Ethereum bridge contract >
->
-> #### Ethereum blockchain
+1. Ethereum bridge contract >
+2. Linea bridge contract >
+3. Coordinator >
+4. Sequencer (Block building > Execution > Trace data generation) >
+5. Coordinator >
+6. Trace Conflation >
+7. EVM State Manager >
+8. Trace Expansion and Proving (Corset > gnark) >
+9. Coordinator >
+10. zk-proof and updated Merkle tree >
+11. Linea bridge contract >
+12. Ethereum bridge contract >
+13. Ethereum blockchain
 
-_...in other words, there's a lot involved. _
+_...in other words, there's a lot involved._
 
 <div class="center-container">
   <div class="img-xsmall">
@@ -102,16 +115,18 @@ _...in other words, there's a lot involved. _
   </div>
 </div>
 
-### Simplifying things
+## Simplifying things
 
-In order to make this explanation as clear and navigable as possible, we'll break each component down, and explain it in three steps:
+In order to make this explanation as clear and navigable as possible, in the [Linea Stack section](architecture/stack)
+we'll break each component down, and explain it in three steps:
 
-> #### What is it?
->
-> #### What does it do?
->
-> #### How does it do it?
+- What is it?
+- What does it do?
+- How does it do it?
 
-Let's start with the thing that a lot of users encounter when trying to access an L2 for the first time: **a bridge**.
+Let's start with the thing that a lot of users encounter when trying to access an L2 for the first 
+time: a bridge.
 
-But not just any bridge; there are a lot of data to pass back and forth between Linea and other networks, and therefore, Linea has more than one bridge; and that number is likely to continue to grow. But there's one in particular that matters: the [**Linea Canonical Message Service**](architecture/stack/canonical-msg-service).
+But not just any bridge; there are a lot of data to pass back and forth between Linea and other 
+networks, and therefore, Linea has more than one bridge; and that number is likely to continue to 
+grow. But there's one in particular that matters: the [Linea canonical message service](architecture/stack/canonical-msg-service).


### PR DESCRIPTION
The page had some erratic formatting (causing an excess of subheadings) and an error here or there; this PR fixes and improves the page.