### PR TITLE
Add details of the Onthis Snap

### DIFF
--- a/docs/developers/tooling/cross-chain/shortcuts.mdx
+++ b/docs/developers/tooling/cross-chain/shortcuts.mdx
@@ -47,6 +47,27 @@ intent-based listeners and paths that will execute the action on the destination
 The output token(s) from the automation are returned to `msg.sender` (the account that called the 
 function; in this case, the person using the Shortcut).
 
+## Onthis Snap
+
+A MetaMask Snap has been built specifically to help you verify that a Shortcut is behaving as 
+intended.
+
+:::info[MetaMask Snaps]
+
+MetaMask Snaps is a system that enables third-party developers to add features and functionality
+to MetaMask. Read more in the [MetaMask Help Center](https://support.metamask.io/metamask-snaps), 
+or visit the [Snaps directory](https://snaps.metamask.io/) to browse what's available.
+
+:::
+
+Before you send funds to the Shortcut, the Snap automatically recognizes that the transaction
+involves an Onthis Shortcut, and provides a breakdown of:
+- The contract address, enabling you to confirm it is correct
+- A description of what will happen once you send funds to the Shortcut. 
+
+Install the Snap by heading either to the [Snaps Directory](https://snaps.metamask.io/snap/npm/onthis-snap/) 
+or the [dedicated Onthis page](https://www.onthis.xyz/snap), and then hitting 'Add to MetaMask'.
+
 ## Fees
 
 Shortcuts are provided by [onthis.xyz](https://www.onthis.xyz/) and are built on top of [Across](https://across.to/). 


### PR DESCRIPTION
Updates Onthis Shortcuts page under tooling with a brief overview of how to install the purpose-built Snap. 