### PR TITLE
Update Alpha v3.2 dates (bridge to different recipient)

### DIFF
--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -48,7 +48,9 @@ Code in the upgrade has been audited by:
 
 :::note
 
-This feature will be deployed on mainnet and testnet simultaneously, on May 28.
+May 29: Fully functional on testnet; ETH and USDC supported on mainnet.
+
+June 4: Fully functional on mainnet.
 
 ::: 
 


### PR DESCRIPTION
Updates the mainnet and testnet launch dates for the feature.