### PR TITLE
Add redirect for node providers page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -444,6 +444,10 @@ const config = {
             to: "/developers/tooling/cross-chain/shortcuts",
             from: "/build-on-linea/tooling/cross-chain/shortcuts",
           },
+          {
+            to: "/developers/tooling/node-providers",
+            from: "/build-on-linea/tooling/node-providers",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Fix missing redirect rerouting visitors from old path to the new.