### PR TITLE
Update Alpha v3.3 release notes

### DIFF
--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -24,7 +24,7 @@ for transaction fees.
 
 There are minor differences in the way Linea handles gas calculations when compared with Ethereum:
 
-- **The base fee uses a set price of 7 wei.** Blocks created by Linea use up to 30 million gas
+- **The base fee uses a set price of 7 wei.** Blocks created by Linea use up to 24 million gas
     (less than 50% of the maximum Linea block size of 61 million gas), and the fee decreases by 
     12.5% per block, effectively keeping it at a stable 7 wei.
 - **Transactions won't be sequenced if the `gasPrice` or `maxPriorityFeePerGas` falls below a 

--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -25,9 +25,10 @@ Reducing block time to 2 seconds, with a target block size of 24M gas.
 The change will increase transaction throughput by approximately 20%, improving user experience by 
 making Linea faster and more responsive.
 
-:::warning[Actions required for node runners]
+:::warning[Actions recommended for node runners]
 
-These changes require you to adjust your node configurations to keep the node(s) running smoothly.
+We recommend you adjust your node configurations to ensure any submitted transactions are handled 
+in line with the sequencer.
 
 **Besu:**
 

--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -18,12 +18,30 @@ Find out all you need to know about the latest Linea versions.
 
 **Mainnet: June 11, 10:00 UTC**
 
+### Breaking change: block time and block size reduction
+
 Reducing block time to 2 seconds, with a target block size of 24M gas.
 
 The change will increase transaction throughput by approximately 20%, improving user experience by 
 making Linea faster and more responsive.
 
-There will be no impacts for node runners.
+:::warning[Actions required for node runners]
+
+These changes require you to adjust your node configurations to keep the node(s) running smoothly.
+
+**Besu:**
+
+In the `besu-sequencer` plugin, adjust:
+- `plugin-linea-max-tx-gas-limit` to `24000000`
+- `plugin-linea-max-block-gas` to `24000000`
+
+**Geth:**
+
+- Set environment variable `MAX_BLOCK_GAS` to `24000000`
+- In the config `.toml` file, set `[Eth]RPCGasCap` to `24000000`
+  - Or use `—rpc.gascap` in the command line, again specifying `24000000`
+
+:::
 
 ## Alpha v3.2
 


### PR DESCRIPTION
Amends the release notes, adding instructions for how node runners should update their configurations to keep nodes running properly. 

Also corrects a mention elsewhere of a 30m block size. 