### PR TITLE
Update RPC endpoints in `node-providers`

### DIFF
--- a/docs/developers/tooling/node-providers.md
+++ b/docs/developers/tooling/node-providers.md
@@ -32,12 +32,12 @@ Public endpoints are rate limited, and not meant for production systems.
 
 | Mainnet                                       | Testnet                                              |
 |-----------------------------------------------|------------------------------------------------------|
-| `https://linea-mainnet.public.blastapi.io`    | `https://linea-goerli.public.blastapi.io`            |
+| `https://linea-mainnet.public.blastapi.io`    | `https://linea-sepolia.public.blastapi.io`           |
 | `https://rpc.linea.build`                     | `https://rpc.sepolia.linea.build`                    |
 | `https://linea.rpc.thirdweb.com`              | `https://linea-sepolia.rpc.thirdweb.com`             |
 | `https://linea.blockpi.network/v1/rpc/public` | `https://linea-sepolia.blockpi.network/v1/rpc/public`|
 | `https://linea-mainnet-public.unifra.io`      | `N/A`                                                |
-| `https://linea.getblock.io/your_api_key`      | `https://linea.getblock.io/your_api_key`             |
+| `https://go.getblock.io/ACCESS_TOKEN`         | `https://go.getblock.io/ACCESS_TOKEN`                |
 | `https://site1.moralis-nodes.com/linea/`      | `https://site1.moralis-nodes.com/linea-sepolia/`     |
 
 If you're an RPC endpoint provider and would like to be added to the list, reach out to our team, 


### PR DESCRIPTION
Fixes the Getblock and Blast endpoints.