### PR TITLE
Remove instruction from Alpha v3.3 block size reduction guidance

### DIFF
--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -38,7 +38,6 @@ In the `besu-sequencer` plugin, adjust:
 
 **Geth:**
 
-- Set environment variable `MAX_BLOCK_GAS` to `24000000`
 - In the config `.toml` file, set `[Eth]RPCGasCap` to `24000000`
   - Or use `—rpc.gascap` in the command line, again specifying `24000000`
 


### PR DESCRIPTION
Removes a line relating to `MAX_BLOCK_GAS`, as this was specific to linea-geth, rather than standard Geth. 