### PR TITLE
Amend Alpha v3.3 block size command 

### DIFF
--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -39,7 +39,7 @@ In the `besu-sequencer` plugin, adjust:
 **Geth:**
 
 - In the config `.toml` file, set `[Eth]RPCGasCap` to `24000000`
-  - Or use `—rpc.gascap` in the command line, again specifying `24000000`
+  - Or use `—-rpc.gascap` in the command line, again specifying `24000000`
 
 :::
 


### PR DESCRIPTION
Adds a missing `-` to the geth command.