### PR TITLE
Add redirect for release notes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -452,6 +452,10 @@ const config = {
             to: "/developers/tooling/node-providers",
             from: "/build-on-linea/tooling/node-providers",
           },
+          {
+            to: "/developers/linea-version",
+            from: "/build-on-linea/linea-version"
+          },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -454,7 +454,7 @@ const config = {
           },
           {
             to: "/developers/linea-version",
-            from: "/build-on-linea/linea-version"
+            from: "/build-on-linea/linea-version",
           },
         ],
       },


### PR DESCRIPTION
Google still has our release notes page indexed under the old path `/build-on-linea/linea-version`. This fix adds a redirect so that the indexed page still leads to the correct place.

![image](https://github.com/Consensys/doc.linea/assets/95916148/d742581a-cd78-4dca-b1fa-42fc670fd64f)
