### PR TITLE
Rectify repo used in `build` GHA script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        uses: Consensys/docs-gha-2023/build@main
+        uses: Consensys/docs-gha/build@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I realized last night that our `build` GH Actions script still uses a fork that I made of @joshuafernandes ' canonical version last summer. I made that fork when we were troubleshooting the weird issues we had with the link checker, which we've since resolved. 

We should update to the canonical repo, because I'm not working on or maintaining that fork anymore. :pray: 