### PR TITLE
Clarify `PUSH0` in opcodes table

### DIFF
--- a/docs/developers/quickstart/ethereum-differences.mdx
+++ b/docs/developers/quickstart/ethereum-differences.mdx
@@ -59,12 +59,10 @@ forks, and updates to the blockchain.
         <tr>
         <td>`PUSH0`</td>
         <td>Pushes the constant value 0 onto the stack</td>
-        <td>Pushes the constant value 0 onto the stack if correct version of Solidity compiler is 
-        configured</td>
-        <td>The PUSH0 opcode compatibility was introduced in Solidity compiler version 0.8.20, 
-        which came after the London release. However, Linea currently supports Solidity compiler 
-        version 0.8.19 and lower, which aligns with the London release of the Ethereum mainnet. 
-        To resolve this issue, recompile your contract using Solidity version 0.8.19 or lower.</td>
+        <td>n/a</td>
+        <td>Introduced in Solidity compiler version 0.8.20, which came after the London release. 
+        However, Linea currently supports Solidity compiler version 0.8.19 and lower, aligning with 
+        the London release of the Ethereum Mainnet.</td>
     </tr>
     <tr>
         <td>`TLOAD`</td>
@@ -80,8 +78,8 @@ forks, and updates to the blockchain.
     </tr>
 </table>
 
-_Consult the Ethereum Foundation's_ [Opcode Reference](https://ethereum.org/en/developers/docs/evm/opcodes/) 
-_for more._
+_Consult the Ethereum Foundation's [Opcode Reference](https://ethereum.org/en/developers/docs/evm/opcodes/) 
+for more._
 
 [Evmdiff](https://www.evmdiff.com) is also a useful resource for comparing Linea with Ethereum.
 


### PR DESCRIPTION
The existing copy around `PUSH0` was ambiguous. Amended to make clear that Linea does not support `PUSH0`.