### PR TITLE
Add testnet link to Safe page

### DIFF
--- a/docs/developers/guides/linea-safe.mdx
+++ b/docs/developers/guides/linea-safe.mdx
@@ -15,5 +15,6 @@ contract deployed for the wallet has complete control over the wallet's contents
 rely on any trusted external party for execution.
 
 To create your Safe wallet click [here](https://app.safe.global/), and select Linea as the network.
+To use the app on Linea Sepolia, click [here](https://safe.linea.build).
 
 If you need guidance on using the Safe app, check out their support page [here](https://help.safe.global/).


### PR DESCRIPTION
The former location of Linea Safe at https://safe.linea.build is being retained for testnet. Adding this information to distinguish from the mainnet app available on the Safe site. 