### PR TITLE
Remove unlisted status of enodes page

### DIFF
--- a/docs/developers/guides/run-a-node/enodes.mdx
+++ b/docs/developers/guides/run-a-node/enodes.mdx
@@ -1,7 +1,6 @@
 ---
 title: Edge nodes
 description: Edge nodes (enodes) available for Linea Mainnet
-unlisted: true
 image: /img/socialCards/edge-nodes.jpg
 ---
 


### PR DESCRIPTION
Previously added `unlisted` to metadata, but realised this was unnecessary since it won't appear in the sidebar anyway unless added.