### PR TITLE
Remove backticks from reference section sidebar

### DIFF
--- a/docs/developers/reference/api/eth-sendrawtransaction.mdx
+++ b/docs/developers/reference/api/eth-sendrawtransaction.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`eth_sendRawTransaction`'
+title: eth_sendRawTransaction
 description: Simulate transaction submission to help prevent failed transactions.
 image: /img/socialCards/ethsendrawtransaction.jpg
 ---

--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`linea_estimateGas`'
+title: linea_estimateGas
 description: Reference content for the linea_estimateGas method.
 image: /img/socialCards/lineaestimategas.jpg
 ---


### PR DESCRIPTION
Fixes issue #675 

It seems that removing the backticks from the metadata `title` alone _while_ leaving them in the title defined in body text via h1/`#` is the happy medium we wanted: no backticks in the sidebar, but proper in-line code on the page title itself.