### PR TITLE
Add note to clarify `linea_estimateGas` availability

### DIFF
--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -9,6 +9,12 @@ import TabItem from '@theme/TabItem';
 
 # `linea_estimateGas`
 
+:::warning
+
+`linea_estimateGas` is currently only available on Linea Sepolia.
+
+:::
+
 :::info
 
 `linea_estimateGas` is only fully compatible with endpoints using the Besu client with the 


### PR DESCRIPTION
Added note to clarify that `linea_estimateGas` is currently only fully functional on Linea Sepolia. Mainnet full function to come in future.