### PR TITLE
fix: typo in setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ to manage Node.js versions on your machine.
 
    ```bash
    npm install
-   npm run prepare
+   npm run prebuild
    ```
 
 3. To preview and for every time afterwards:


### PR DESCRIPTION
The command is not `npm run prepare` but `npm run prebuild` I think (the command specified doesn't exist)