### PR TITLE
Update action to run both file types.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,30 +6,35 @@
       - cron: "0 0 * * *"
     workflow_dispatch: {}
   
-  concurrency:
-    group: nightly-${{ github.ref }}
-    cancel-in-progress: true
-  
   jobs:
-    linkCheck:
-      name: Run link check
+    linkCheckMdx:
+      name: Run link check on .mdx files
       runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          file-extensions: [".md", ".mdx"]
-          check-modified-files-only: [no]
       permissions:
         contents: read
       steps:
         - uses: actions/checkout@v4
-        - name: LinkCheck
+        - name: LinkCheck mdx files
           uses: ConsenSys/docs-gha/linkcheck@main
           with:
-              FILE_EXTENSION: ${{ matrix.file-extensions }}
-              MODIFIED_FILES_ONLY: ${{ matrix.check-modified-files-only }}
-
+              FILE_EXTENSION: mdx
+              MODIFIED_FILES_ONLY: no
+    linkCheckMd:
+      needs: linkCheckMdx
+      name: Run link check on .md files
+      if: always()
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+      steps:
+        - uses: actions/checkout@v4
+        - name: LinkCheck md files
+          uses: ConsenSys/docs-gha/linkcheck@main
+          with:
+              FILE_EXTENSION: md
+              MODIFIED_FILES_ONLY: no
     slackNotification:
-      needs: linkCheck
+      needs: [linkCheckMdx, linkCheckMd]
       if: ${{ failure() }}
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
The previous version kept auto-cancelling the `.mdx` file check.
This solution ensures both checks work (for .md and .mdx files), although it is a lot less elegant. 