### PR TITLE
Fix filepath in Besu Sepolia config file

### DIFF
--- a/static/files/besu/config-sepolia.toml
+++ b/static/files/besu/config-sepolia.toml
@@ -9,7 +9,7 @@ Xsnapsync-synchronizer-flat-db-healing-enabled=true
 
 
 # genesis file 
-genesis-file="/path/to/genesis-mainnet.json"
+genesis-file="/path/to/genesis-sepolia.json"
 
 
 # Boot nodes


### PR DESCRIPTION
Incorrectly pointed to `genesis-mainnet.json`. Fixed