### PR TITLE
Clarify reorgs in `transaction-lifecycle.mdx`

### DIFF
--- a/docs/architecture/overview/transaction-lifecycle.mdx
+++ b/docs/architecture/overview/transaction-lifecycle.mdx
@@ -10,9 +10,9 @@ image: /img/socialCards/transaction-lifecycle.jpg
 
 Finality has two definitions on Linea:
 - Soft finality: The transaction is confirmed on Linea. This takes two seconds, i.e Linea's block 
-time. See [step 3](#step-3-transaction-data-sent-to-the-state-manager). For simplicity, Linea does 
-not reorg—remove competing versions of blockchain history in favor of a canonical one—when there 
-are reorgs on L1. 
+time. See [step 3](#step-3-transaction-data-sent-to-the-state-manager). For simplicity, Linea is 
+guaranteed to not reorg—remove competing versions of blockchain history in favor of a canonical 
+one—when there are reorgs on L1. 
 - Hard finality: The proof submitted to L1 has been verified, and two epochs have elapsed. The 
 typical time before hard finality is 8-32 hours, although the 8-hour minimum will be reduced to
 zero in a future release. See [step 6](#step-6-batch-finalization).


### PR DESCRIPTION
Adding a word or two to make clear that reorgs never occur.