### PR TITLE
Remove Linea Goerli block explorer links

### DIFF
--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -609,8 +609,8 @@ Contracts audit is in progress. This does not reflect final versions.
     </details>
 
   - Contracts
-    - [Transparent Proxy](https://goerli.lineascan.build/address/0xC499a572640B64eA1C8c194c43Bc3E19940719dC/contracts#address-tabs)
-    - [Implementation](https://goerli.lineascan.build/address/0xc0557e2149751e201749b87f86acd91DB22e2662/contracts#address-tabs)
+    - Transparent Proxy: `0xC499a572640B64eA1C8c194c43Bc3E19940719dC` 
+    - Implementation: `0xc0557e2149751e201749b87f86acd91DB22e2662`
 
 - Bridging partners, before sending messages on L2, need to retrieve the service protection fee before sending messages and include it in the value sent.
 
@@ -637,7 +637,7 @@ Major changes are applied to the Canonical Token Bridge as described in our [doc
   </details>
 
   - Contracts
-    - [Transparent Proxy](https://goerli.lineascan.build/address/0xB191E3d98074f92584E5205B99c3F17fB2068927)
-    - [Implementation](https://goerli.lineascan.build/address/0x6081C1392793e22dA39871D4362c1e7045A5bace)
+    - Transparent Proxy: `0xB191E3d98074f92584E5205B99c3F17fB2068927`
+    - Implementation: `0x6081C1392793e22dA39871D4362c1e7045A5bace`
 
 If you have any questions, please reach out in the **Developer Support** channel in our [community forum](https://community.linea.build/c/developer-support)!


### PR DESCRIPTION
Since the chain and its block explorer no longer exists, these links are causing issues for link linters. Removing.  