### PR TITLE
Amend RPC URLs to Infura

### DIFF
--- a/docs/developers/reference/api/eth-sendrawtransaction.mdx
+++ b/docs/developers/reference/api/eth-sendrawtransaction.mdx
@@ -46,7 +46,7 @@ The 32-byte transaction hash, or the zero hash if the transaction is not yet ava
 ### Request
 
 ```bash
-curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY\
+curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params": ["0xf869018203e882520894f17f52151ebef6c7334fad080c5704d77216b732881bc16d674ec80000801ba02da1c48b670996dcb1f447ef9ef00b33033c48a4fe938f420bec3e56bfd24071a062e0aa78a81bf0290afbc3a9d8e9a068e6d74caa66c5e0fa8a46deaae96b0833"],"id":1}'

--- a/docs/developers/reference/api/eth-sendrawtransaction.mdx
+++ b/docs/developers/reference/api/eth-sendrawtransaction.mdx
@@ -46,7 +46,7 @@ The 32-byte transaction hash, or the zero hash if the transaction is not yet ava
 ### Request
 
 ```bash
-curl https://rpc.sepolia.linea.build \
+curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY\
 -X POST \
 -H "Content-Type: application/json" \
 -d '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params": ["0xf869018203e882520894f17f52151ebef6c7334fad080c5704d77216b732881bc16d674ec80000801ba02da1c48b670996dcb1f447ef9ef00b33033c48a4fe938f420bec3e56bfd24071a062e0aa78a81bf0290afbc3a9d8e9a068e6d74caa66c5e0fa8a46deaae96b0833"],"id":1}'

--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -77,7 +77,7 @@ You can also call the API using [Infura's supported Linea endpoints](https://doc
   <TabItem value="cURL">
 
   ```bash
-  curl https://rpc.linea.build \
+  curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0","method": "linea_estimateGas","params": [{"from": "0x971e727e956690b9957be6d51Ec16E73AcAC83A7","gas":"0x21000"}],"id": 53}'

--- a/docs/developers/reference/api/linea-getproof.mdx
+++ b/docs/developers/reference/api/linea-getproof.mdx
@@ -52,7 +52,7 @@ In the [example response](#response) the account exists but the slot does not.
 ### Request
 
 ```bash
-curl https://rpc.linea.build \
+curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{


### PR DESCRIPTION
Changes RPC URLs in reference section pages to Infura endpoints using a personal API key, as this promotes a better user experience and to disincentivize overloading the public Linea RPC endpoint or using it in production.