### PR TITLE
Clarify that the `finalized` tag is not available on Mainnet

### DIFF
--- a/docs/developers/guides/finalized-block.mdx
+++ b/docs/developers/guides/finalized-block.mdx
@@ -3,6 +3,12 @@ title: Retrieve finalized L2 blocks
 image: /img/socialCards/retrieve-finalized-l2-blocks.jpg
 ---
 
+:::info
+
+The `finalized` tag is only available on Linea Sepolia, and will be activated on Mainnet soon.
+
+:::
+
 A finalized L2 block is a block on an L2 blockchain (Linea) that has been confirmed and validated
 by the L1 blockchain (Ethereum), ensuring its immutability and security.
 

--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -38,7 +38,7 @@ Upgrades the [Linea bridge](https://bridge.linea.build/) UI.
 
 ### `finalized` tag
 
-**Mainnet: September 18**
+**Mainnet: October 9**
 
 **Linea Sepolia: September 17**
 


### PR DESCRIPTION
The `finalized` tag is being activated on October 9. The PR updates the release notes accordingly and adds a callout to the guide page to mention it's only available on Linea Sepolia currently.