### PR TITLE
Explain gas pricing mechanism

### DIFF
--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -43,16 +43,17 @@ Linea also supports:
 
 ## Gas pricing
 
-The gas price you retrieve using methods such as `linea_estimateGas` is based on values calculated
-by the [coordinator](../../../architecture/stack/coordinator/index.mdx), and uses the gas price of 
+The gas price you retrieve using methods such as `linea_estimateGas` is based on the gas price of 
 the previous block with a profitability multiplier applied.
 
-Firstly, the coordinator records:
-- A fixed cost of 0.03 Gwei, which reflects infrastructure costs, and;
-- Variable cost, which is the cost per byte of data submitted to L1. 
+The first stage of returning gas price values with `linea_estimateGas` is to populate values in an
+object called `extraData`. The two most relevant values here are:
+- A `FIXED_COST` of 0.03 Gwei, which reflects infrastructure costs, and;
+- `VARIABLE_COST`, which is the cost per byte of data submitted to L1. 
 
-These values are sent to the sequencer so that it can compute the gas prices for the upcoming 
-block and ensure that included transactions are profitable.
+These values are inserted into each block's `extraData` field—32 bytes available in every Ethereum 
+block to store any data—and then used by the sequencer and Linea Besu nodes running the correct 
+plugins to expose `linea_estimateGas`, in both cases with the same logic.
 
 Variable cost is calculated with the following formula:
 
@@ -60,22 +61,22 @@ Variable cost is calculated with the following formula:
 VARIABLE_COST (4 bytes) = min(max(
 (
   (
-    ((averageWeightedBaseFee + averageWeigthedPriorityFee) * 
+    ((averageWeightedBaseFee + averageWeightedPriorityFee) * 
     blob-submission-expected-execution-gas + averageWeightedBlobBaseFee * expected-blob-gas
   ) / bytes-per-data-submission) * profit-margin
 )
 , min-bound), max-bound)
 ```
 
-The `profit-margin` is `5`, ensuring sustainable network profitability. `min-bound` is `0.050000000` 
-Gwei, and `max-bound` is `0.127500000` Gwei, and together guarantee the gas price stays within a 
-reasonable range.
+The `profit-margin` is `3`, ensuring sustainable network profitability. `min-bound` and `max-bound` 
+are variable, and guarantee the gas price stays within a reasonable range.
 
 The variable cost formula is similar to the standard Ethereum gas price formula that Linea uses, 
 except that it allows `linea_estimateGas` to price according to the variable costs of submitting 
 blob data to L1. The amount of the blob data in each block stays roughly consistent, though the 
 amount _per transaction_ varies, so the `linea_estimateGas` API accounts for this, and ensures a 
-gas price is returned for the transaction that reflects the amount of data it contains. 
+gas price is returned for the transaction that reflects the amount of data it contains. In turn,
+it ensures that transactions are profitable. 
 
 To determine the priority fee per gas, `linea_estimateGas` takes the previous block's `VARIABLE_COST` 
 into account:
@@ -86,7 +87,7 @@ priorityFeePerGas = MINIMUM_MARGIN * (min-gas-price * L2_compressed_tx_size_in_b
 ```
 
 Where:
-- `extraData.variable_cost` is the way the coordinator stores the `VARIABLE_COST` for the previous 
+- `extraData.variable_cost` is where the previous block's `VARIABLE_COST` is stored
 block
 - `MINIMUM_MARGIN` varies depending on the stage of the transaction:
   - RPC method, i.e. calling `linea_estimateGas`: `1.2`
@@ -95,8 +96,8 @@ block
 
 The `linea_estimateGas` formula above essentially ensures that transactions are checked for 
 profitability for inclusion in a block. However, the nonce order of transactions submitted from the 
-same account takes precedence, so there may be occasions where less profitable tranasctions are 
-favored for inclusion. 
+same account takes precedence, so there may be occasions where less profitable transactions must be
+included first. 
 
 ## [`linea_estimateGas`](../../reference/api/linea-estimategas.mdx)
 

--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -43,17 +43,24 @@ Linea also supports:
 
 ## Gas pricing
 
-The gas price you retrieve using methods such as `linea_estimateGas` is based on the variable data
-cost of the previous block with a profitability multiplier applied.
+The gas price returned by `linea_estimateGas` is based on the variable data cost of the previous 
+block with a profitability multiplier applied.
 
-The first stage of returning gas price values with `linea_estimateGas` is to populate values in an
-object called `extraData`. The two most relevant values here are:
-- A `FIXED_COST` of 0.03 Gwei, which reflects infrastructure costs, and;
-- `VARIABLE_COST`, which is the cost per byte of data submitted to L1. 
+Each Linea block's `extraData` field is populated with the following gas price values that are used 
+by `linea_estimateGas` to calculate the cost of a transaction:
+- A `FIXED_COST` of 0.03 Gwei, which reflects infrastructure costs;
+- `VARIABLE_COST`, which is the cost per byte of data submitted to L1, and;
+- `ETH_GAS_PRICE`, used to set a more accurate return value for any `eth_gasPrice` calls. 
 
-These values are inserted into each block's `extraData` field—32 bytes available in every Ethereum 
-block to store any data—and then used by the sequencer and Linea Besu nodes running the correct 
-plugins to expose `linea_estimateGas`, in both cases with the same logic.
+:::note
+
+The `extraData` field is a 32-byte space used to store arbitrary data, such as metadata or 
+additional information relevant to the block. 
+
+On Linea, it is used by the sequencer and Linea Besu nodes running the correct plugins to expose 
+`linea_estimateGas`.
+
+:::
 
 Variable cost is calculated with the following formula:
 
@@ -94,13 +101,15 @@ block
   - At transaction selection stage: `1.0`
 
 :::note
-The RPC method and transaction pool values are configurable by node runners according to preference;
-the transaction selection stage value is fixed. For example, it may be preferable to set a lower
-margin to facilitate lower gas prices, but this risks transactions not being included.
+The RPC method and transaction pool values are configurable by RPC providers or those running their 
+own nodes according to preference; the transaction selection stage value is fixed. For example, 
+it may be preferable to set a lower margin to facilitate lower gas prices, but this risks 
+transactions not being included.
 :::
 
-The `linea_estimateGas` formula above essentially ensures that transactions are checked for 
-profitability for inclusion in a block. However, the nonce order of transactions submitted from the 
+`linea_estimateGas` enables its users to reproduce on demand the transaction profitability logic 
+that the sequencer applies to all transactions when building blocks, ensuring that the transaction
+is profitable enough for inclusion. However, the nonce order of transactions submitted from the 
 same account takes precedence, so there may be occasions where less profitable transactions must be
 included first. 
 

--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -36,12 +36,67 @@ and gas used.
 `linea_estimateGas` is the recommended method for estimating gas on Linea. See our 
 [reference page](../../reference/api/linea-estimategas.mdx) for more information. 
 
-Linea also supports [`eth_estimateGas`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_estimategas),
-[`eth_gasPrice`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_gasprice), and
-[`eth_feeHistory`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_feehistory).
+Linea also supports:
+- [`eth_estimateGas`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_estimategas)
+- [`eth_gasPrice`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_gasprice)
+- [`eth_feeHistory`](https://docs.infura.io/api/networks/linea/json-rpc-methods/eth_feehistory).
 
-You can use `eth_gasPrice` or `eth_feeHistory` to get the gas price, in wei, and you can use 
-`eth_estimateGas` to find out how many units of gas a specific transaction will need. 
+## Gas pricing
+
+The gas price you retrieve using methods such as `linea_estimateGas` is based on values calculated
+by the [coordinator](../../../architecture/stack/coordinator/index.mdx), and uses the gas price of 
+the previous block with a profitability multiplier applied.
+
+Firstly, the coordinator records:
+- A fixed cost of 0.03 Gwei, which reflects infrastructure costs, and;
+- Variable cost, which is the cost per byte of data submitted to L1. 
+
+These values are sent to the sequencer so that it can compute the gas prices for the upcoming 
+block and ensure that included transactions are profitable.
+
+Variable cost is calculated with the following formula:
+
+```python
+VARIABLE_COST (4 bytes) = min(max(
+(
+  (
+    ((averageWeightedBaseFee + averageWeigthedPriorityFee) * 
+    blob-submission-expected-execution-gas + averageWeightedBlobBaseFee * expected-blob-gas
+  ) / bytes-per-data-submission) * profit-margin
+)
+, min-bound), max-bound)
+```
+
+The `profit-margin` is `5`, ensuring sustainable network profitability. `min-bound` is `0.050000000` 
+Gwei, and `max-bound` is `0.127500000` Gwei, and together guarantee the gas price stays within a 
+reasonable range.
+
+The variable cost formula is similar to the standard Ethereum gas price formula that Linea uses, 
+except that it allows `linea_estimateGas` to price according to the variable costs of submitting 
+blob data to L1. The amount of the blob data in each block stays roughly consistent, though the 
+amount _per transaction_ varies, so the `linea_estimateGas` API accounts for this, and ensures a 
+gas price is returned for the transaction that reflects the amount of data it contains. 
+
+To determine the priority fee per gas, `linea_estimateGas` takes the previous block's `VARIABLE_COST` 
+into account:
+```python
+min-gas-price = previousBlock.extraData.variable_cost
+baseFeePerGas = vanillaProtocolBaseFee
+priorityFeePerGas = MINIMUM_MARGIN * (min-gas-price * L2_compressed_tx_size_in_bytes / L2_tx_gas_used + extraData.fixed_cost)
+```
+
+Where:
+- `extraData.variable_cost` is the way the coordinator stores the `VARIABLE_COST` for the previous 
+block
+- `MINIMUM_MARGIN` varies depending on the stage of the transaction:
+  - RPC method, i.e. calling `linea_estimateGas`: `1.2`
+  - In the transaction pool: `0.8`
+  - At transaction selection stage: `1.0`
+
+The `linea_estimateGas` formula above essentially ensures that transactions are checked for 
+profitability for inclusion in a block. However, the nonce order of transactions submitted from the 
+same account takes precedence, so there may be occasions where less profitable tranasctions are 
+favored for inclusion. 
 
 ## [`linea_estimateGas`](../../reference/api/linea-estimategas.mdx)
 

--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -43,8 +43,8 @@ Linea also supports:
 
 ## Gas pricing
 
-The gas price you retrieve using methods such as `linea_estimateGas` is based on the gas price of 
-the previous block with a profitability multiplier applied.
+The gas price you retrieve using methods such as `linea_estimateGas` is based on the variable data
+cost of the previous block with a profitability multiplier applied.
 
 The first stage of returning gas price values with `linea_estimateGas` is to populate values in an
 object called `extraData`. The two most relevant values here are:
@@ -71,12 +71,11 @@ VARIABLE_COST (4 bytes) = min(max(
 The `profit-margin` is `3`, ensuring sustainable network profitability. `min-bound` and `max-bound` 
 are variable, and guarantee the gas price stays within a reasonable range.
 
-The variable cost formula is similar to the standard Ethereum gas price formula that Linea uses, 
-except that it allows `linea_estimateGas` to price according to the variable costs of submitting 
-blob data to L1. The amount of the blob data in each block stays roughly consistent, though the 
-amount _per transaction_ varies, so the `linea_estimateGas` API accounts for this, and ensures a 
-gas price is returned for the transaction that reflects the amount of data it contains. In turn,
-it ensures that transactions are profitable. 
+The variable cost formula enables `linea_estimateGas` to price according to the variable costs of 
+submitting blob data to L1, working out the per-byte cost of that data. The amount of the blob data 
+in each block stays roughly consistent, though the amount _per transaction_ varies, so the 
+`linea_estimateGas` API accounts for this, and ensures a gas price is returned for the transaction 
+that reflects the amount of data it contains. In turn, it ensures that transactions are profitable. 
 
 To determine the priority fee per gas, `linea_estimateGas` takes the previous block's `VARIABLE_COST` 
 into account:
@@ -93,6 +92,12 @@ block
   - RPC method, i.e. calling `linea_estimateGas`: `1.2`
   - In the transaction pool: `0.8`
   - At transaction selection stage: `1.0`
+
+:::note
+The RPC method and transaction pool values are configurable by node runners according to preference;
+the transaction selection stage value is fixed. For example, it may be preferable to set a lower
+margin to facilitate lower gas prices, but this risks transactions not being included.
+:::
 
 The `linea_estimateGas` formula above essentially ensures that transactions are checked for 
 profitability for inclusion in a block. However, the nonce order of transactions submitted from the 

--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -11,8 +11,7 @@ import TabItem from '@theme/TabItem';
 
 :::info Compatibility mode
 
-`linea_estimateGas` is currently only available on Linea Sepolia fully activated and on Mainnet in compatibility mode, which means it 
-returns the same results as `eth_gasPrice` on mainnet. 
+`linea_estimateGas` is available on Linea Mainnet and Sepolia.
 
 If you're an infrastructure provider you must deactivate compatibility mode in your node 
 configurations to ensure `linea_estimateGas` functions fully. See our [guide](#compatibility-mode).


### PR DESCRIPTION
Adds detail to the gas estimation guide that explains how the prices returned by `linea_estimateGas` are calculated, and touches on how this relates to transaction sequencing.

Also amends callout in `linea_estimateGas` reference page to reflect its activation.