### PR TITLE
Amend `finalized` tag guide callout

### DIFF
--- a/docs/developers/guides/finalized-block.mdx
+++ b/docs/developers/guides/finalized-block.mdx
@@ -5,10 +5,9 @@ image: /img/socialCards/retrieve-finalized-l2-blocks.jpg
 
 :::info
 
-The `finalized` tag is only available on Linea Sepolia, and [will be fully activated on Mainnet 
-on October 9](../linea-version/index.mdx#alpha-v350). 
-
-`eth_getBlockByNumber` is the exception, and is already active on Linea Mainnet.
+The `finalized` tag is available on Mainnet and Linea Sepolia, with the exception of:
+- `eth_call`
+- `eth_getProof` 
 
 :::
 


### PR DESCRIPTION
The `finalized` tag was activated on Mainnet today, Oct 9th, so the PR amends the callout accordingly. Also clarifies two methods that currently do not support it.