### PR TITLE
docs: corrected errors

### DIFF
--- a/docs/developers/guides/gas/gas-fees.mdx
+++ b/docs/developers/guides/gas/gas-fees.mdx
@@ -15,7 +15,7 @@ Linea supports the [Ethereum EIP-1559 gas price model](https://ethereum.org/deve
 total fee = units of gas used * (base fee + priority fee)
 ```
 
-Linea fundamentally works exactly the same as Ethereum. The one difference is that **the base fee 
+Linea fundamentally works exactly the same as Ethereum. The only difference is that **the base fee 
 is constant at 7 wei.** Blocks created by Linea use up to 24 million gas (less than 50% of the 
 maximum Linea block size of 61 million gas), and the fee decreases by 12.5% per block, effectively 
 keeping it at a stable 7 wei.

--- a/docs/developers/guides/run-a-node/use-binary.mdx
+++ b/docs/developers/guides/run-a-node/use-binary.mdx
@@ -19,7 +19,7 @@ infrastructure providers.
 
 ## Prerequisites
 
-Set up the required and recommended hardware and all the utilities. You can find the recommendations for the clients from the
+Set up the required and recommended hardware and all the utilities. You can find the recommendations for the clients in the
 official documentation:
 
 - [Besu](https://besu.hyperledger.org/public-networks/get-started/system-requirements)

--- a/docs/developers/tooling/index.mdx
+++ b/docs/developers/tooling/index.mdx
@@ -14,7 +14,7 @@ _Just as Ethereum, Linea also operates on a permissionless framework, meaning th
 
 Building a dapp can be a complex task, but luckily we have great tools and developer infrastructure that can unlock new use cases and speed up the development of your dapp.
 
-Building on top of existing protocols, tooling, and infrastructure will ensure a faster go-to-market, as the existing library, dapp, or service has gone already through intense testing and adoption.
+Building on top of existing protocols, tooling, and infrastructure will ensure a faster go-to-market, as the existing library, dapp, or service has already gone through intense testing and adoption.
 
 Please read our [Terms of Service](https://linea.build/terms-of-service) and [Privacy Policy](https://consensys.io/privacy-policy/) if you have any additional questions about the disclaimer.
 

--- a/docs/users/linea-voyage/linea-surge/linea-surge-overview.mdx
+++ b/docs/users/linea-voyage/linea-surge/linea-surge-overview.mdx
@@ -13,13 +13,13 @@ content — each Volt a distinct experience.
 ## Early adopters
 
 The points system will start when the program goes live but we already have users and early 
-adopters that have already provided liquidity on the network. It's important to acknowledge what 
+adopters who have provided liquidity on the network. It's important to acknowledge what 
 has been done so far. For this reason, the formula that defines points has an early adopter 
 modifier that provides more points to users that started contributing earlier than others.
 
 ## Dashboard
 
-After the go-live, OpenBlock Labs will provide a dashboard where anyone can verify the number 
+After go-live, OpenBlock Labs will provide a dashboard where anyone can verify the number 
 of LXP-L collected within The Surge. This will feature all necessary information for a user to 
 observe their activity and points received.
 
@@ -30,7 +30,7 @@ to specifically protect the LXP points from bot farms and reduce sybils, in this
 no such need. Providing a unit of points per $ locked is an action that does not incentivize bot 
 activity: a user will get the same amount of points regardless of whether they concentrate all 
 the liquidity in a single wallet or split it among thousands of addresses. This makes the 
-experience even easier and more enjoyable for users that bridge liquidity to Linea.
+experience even easier and more enjoyable for users who bridge liquidity to Linea.
 
 ## Security and UX
 


### PR DESCRIPTION
Сorrected grammar docs errors in the following files:

`docs/developers/guides/gas/gas-fees.mdx`,
`docs/developers/guides/run-a-node/use-binary.mdx`, 
`docs/developers/tooling/index.mdx`,  
`docs/users/linea-voyage/linea-surge/linea-surge-overview.mdx`.