### PR TITLE
Remove `linea_estimateGas` ethers example

### DIFF
--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -11,8 +11,6 @@ import TabItem from '@theme/TabItem';
 
 :::info Compatibility mode
 
-`linea_estimateGas` is available on Linea Mainnet and Sepolia.
-
 If you're an infrastructure provider you must deactivate compatibility mode in your node 
 configurations to ensure `linea_estimateGas` functions fully. See our [guide](#compatibility-mode).
 

--- a/docs/developers/reference/api/linea-estimategas.mdx
+++ b/docs/developers/reference/api/linea-estimategas.mdx
@@ -82,7 +82,7 @@ You can also call the API using [Infura's supported Linea endpoints](https://doc
   ```
 
   </TabItem>
-  <TabItem value="ethers.js">
+  {/* <TabItem value="ethers.js">
   ```javascript
   type LineaEstimateGasResponse = {
     baseFeePerGas: string;
@@ -102,7 +102,7 @@ You can also call the API using [Infura's supported Linea endpoints](https://doc
   const fees: LineaEstimateGasResponse = await provider.send("linea_estimateGas", [params]);
   console.log(fees);
   ``` 
-  </TabItem>
+  </TabItem> */}
   <TabItem value="viem">
   ```javascript
   import { createPublicClient, http, parseEther } from 'viem'


### PR DESCRIPTION
Support for `linea_estimateGas` hasn't been merged to ethers yet, so commenting out the example until we can reinstate.