### PR TITLE
Create HTML redirects to Support site

### DIFF
--- a/docs/users/linea-voyage/linea-surge/linea-surge-model.mdx
+++ b/docs/users/linea-voyage/linea-surge/linea-surge-model.mdx
@@ -1,9 +1,18 @@
 ---
 title: Point incentive design
+description: Redirecting page...
+custom_edit_url: null
 sidebar_position: 2
 image: /img/socialCards/point-incentive-design.jpg
+pagination_prev: null
+pagination_next: null
 ---
 
+import RedirectPage from '@site/src/components/RedirectPage';
+
+<RedirectPage />
+
+{/* 
 :::note 
 
 This allocation methodology is subject to minimal change.
@@ -247,4 +256,4 @@ demonstrated notable activity and partnership in the past, inviting active block
 to join the Linea network.
 
 This is a recurring function of ecosystem points, acting as an additional multiplier only for a 
-specific list of addresses provided by the Linea team.
+specific list of addresses provided by the Linea team. */}

--- a/src/components/RedirectPage.js
+++ b/src/components/RedirectPage.js
@@ -1,0 +1,22 @@
+// src/components/RedirectPage.js
+import React, { useEffect } from 'react';
+
+export default function RedirectPage() {
+  // Redirect the user to the new URL using HTML meta redirect.
+  useEffect(() => {
+    setTimeout(() => {
+      window.location.href = 'https://linea-voyage/linea-surge/linea-surge-model.mdx';
+    }, 0); // Redirect immediately.
+  }, []);
+
+  return (
+    <html>
+      <head>
+        <meta http-equiv="refresh" content="0;url=https://linea-voyage/linea-surge/linea-surge-model.mdx" />
+      </head>
+      <body>
+        <p>If you are not redirected automatically, click <a href="https://linea-voyage/linea-surge/linea-surge-model.mdx">here</a>.</p>
+      </body>
+    </html>
+  );
+}

--- a/src/components/RedirectPage.js
+++ b/src/components/RedirectPage.js
@@ -5,17 +5,17 @@ export default function RedirectPage() {
   // Redirect the user to the new URL using HTML meta redirect.
   useEffect(() => {
     setTimeout(() => {
-      window.location.href = 'https://linea-voyage/linea-surge/linea-surge-model.mdx';
+      window.location.href = 'https://support.linea.build/linea-voyage/linea-surge/linea-surge-model.mdx';
     }, 0); // Redirect immediately.
   }, []);
 
   return (
     <html>
       <head>
-        <meta http-equiv="refresh" content="0;url=https://linea-voyage/linea-surge/linea-surge-model.mdx" />
+        <meta http-equiv="refresh" content="0;url=https://support.linea.build/linea-voyage/linea-surge/linea-surge-model.mdx" />
       </head>
       <body>
-        <p>If you are not redirected automatically, click <a href="https://linea-voyage/linea-surge/linea-surge-model.mdx">here</a>.</p>
+        <p>If you are not redirected automatically, click <a href="https://support.linea.build/linea-voyage/linea-surge/linea-surge-model.mdx">here</a>.</p>
       </body>
     </html>
   );


### PR DESCRIPTION
In order to move content from docs.linea.build to support.linea.build and not break any existing links, we need to go beyond our `redirects` plugin.

We could do this via DNS, but doing it this way leaves it inside our control.

It might have SEO impacts. It might have slight performance impacts. It might not work at all.