### PR TITLE
Clarify public endpoints' capabilities

### DIFF
--- a/docs/developers/tooling/node-providers/index.mdx
+++ b/docs/developers/tooling/node-providers/index.mdx
@@ -35,15 +35,53 @@ Public endpoints are rate limited, and not meant for production systems.
 
 :::
 
-| Mainnet                                       | Testnet                                              |
-|-----------------------------------------------|------------------------------------------------------|
-| `https://linea-mainnet.public.blastapi.io`    | `https://linea-sepolia.public.blastapi.io`           |
-| `https://rpc.linea.build`                     | `https://rpc.sepolia.linea.build`                    |
-| `https://linea.rpc.thirdweb.com`              | `https://linea-sepolia.rpc.thirdweb.com`             |
-| `https://linea.blockpi.network/v1/rpc/public` | `https://linea-sepolia.blockpi.network/v1/rpc/public`|
-| `https://linea-mainnet-public.unifra.io`      | `N/A`                                                |
-| `https://go.getblock.io/ACCESS_TOKEN`         | `https://go.getblock.io/ACCESS_TOKEN`                |
-| `https://site1.moralis-nodes.com/linea/`      | `https://site1.moralis-nodes.com/linea-sepolia/`     |
+<table>
+  <tr>
+    <th>Mainnet</th>
+    <th>Testnet</th>
+    <th>Linea feature support*</th>
+  </tr>
+  <tr>
+    <td><code>https://linea-mainnet.public.blastapi.io</code></td>
+    <td><code>https://linea-sepolia.public.blastapi.io</code></td>
+    <td>:white_check_mark:</td>
+  </tr>
+  <tr>
+    <td><code>https://rpc.linea.build</code></td>
+    <td><code>https://rpc.sepolia.linea.build</code></td>
+    <td>:white_check_mark:</td>
+  </tr>
+  <tr>
+    <td><code>https://linea.rpc.thirdweb.com</code></td>
+    <td><code>https://linea-sepolia.rpc.thirdweb.com</code></td>
+    <td>:x:</td>
+  </tr>
+  <tr>
+    <td><code>https://linea.blockpi.network/v1/rpc/public</code></td>
+    <td><code>https://linea-sepolia.blockpi.network/v1/rpc/public</code></td>
+    <td>:white_check_mark:</td>
+  </tr>
+  <tr>
+    <td><code>https://linea-mainnet-public.unifra.io</code></td>
+    <td>N/A</td>
+    <td>:x:</td>
+  </tr>
+  <tr>
+    <td><code>https://go.getblock.io/ACCESS_TOKEN</code></td>
+    <td><code>https://go.getblock.io/ACCESS_TOKEN</code></td>
+    <td>:x:</td>
+  </tr>
+  <tr>
+    <td><code>https://site1.moralis-nodes.com/linea/API_KEY</code></td>
+    <td><code>https://site1.moralis-nodes.com/linea-sepolia/API_KEY</code></td>
+    <td>:x:</td>
+  </tr>
+</table>
+
+> \* _"Linea feature support" indicates endpoints that support custom features beyond standard 
+Ethereum functionality, such as the [`linea_estimateGas`](../../reference/api/linea-estimategas.mdx) 
+API method, or features that require a specific implementation to work on Linea, such as use of the 
+[`finalized` tag](../../guides/finalized-block.mdx)._
 
 If you're an RPC endpoint provider and would like to be added to the list, reach out to our team, 
 or make a PR to the docs.


### PR DESCRIPTION
Adds a column to the public endpoints table specifying whether each supports Linea-specific API methods and features. To our knowledge, correct at the time of publication.