### PR TITLE
Typo Update index.md

### DIFF
--- a/docs/developers/guides/linea-sdk/index.md
+++ b/docs/developers/guides/linea-sdk/index.md
@@ -47,8 +47,8 @@ A new L1ClaimingService class that includes the following functions:
 
 Two new functions in the L1 contract:
 
-- estimateClaimWithProofGas: This functions estimates the gas cost for new claim transactions.
-- claimWithProof: This functions claims a message using the new claimMessageWithProof function.
+- estimateClaimWithProofGas: This function estimates the gas cost for new claim transactions.
+- claimWithProof: This function claims a message using the new claimMessageWithProof function.
 
 :::
 


### PR DESCRIPTION
**Description:**

This pull request addresses a minor typo in the documentation for the Linea SDK. In the section listing new functions, there was an inconsistency in verb usage. Specifically, the word "functions" was incorrectly used instead of "function" in the descriptions of two functions. This small typo could confuse readers and affect the overall clarity and professionalism of the documentation.

**Changes made:**
- Corrected the verb "functions" to "function" in the descriptions of the following functions:
  - `estimateClaimWithProofGas`: This **function** estimates the gas cost for new claim transactions.
  - `claimWithProof`: This **function** claims a message using the new claimMessageWithProof function.

**Importance:**
This fix is important for maintaining proper subject-verb agreement and consistency in the documentation. Although the error is minor, using the correct terminology ensures that the documentation is clear, precise, and easier to follow for developers reading it. Proper grammar and attention to detail in documentation help avoid misunderstandings and enhance the credibility of the project.
