### PR TITLE
Remove `_category_.json` files

### DIFF
--- a/docs/developers/quickstart/deploy-smart-contract/_category_.json
+++ b/docs/developers/quickstart/deploy-smart-contract/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Deploy a smart contract",
-  "position": 1
-}

--- a/docs/developers/quickstart/verify-smart-contract/_category_.json
+++ b/docs/developers/quickstart/verify-smart-contract/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Verify a smart contract",
-  "position": 2
-}

--- a/docs/developers/tooling/account-abstraction/_category_.json
+++ b/docs/developers/tooling/account-abstraction/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Account abstraction"
-}

--- a/docs/developers/tooling/analytics/_category_.json
+++ b/docs/developers/tooling/analytics/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Analytics"
-}

--- a/docs/developers/tooling/attestations/_category_.json
+++ b/docs/developers/tooling/attestations/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Attestations"
-}

--- a/docs/developers/tooling/cloud-infra/_category_.json
+++ b/docs/developers/tooling/cloud-infra/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Cloud Infrastructure"
-}

--- a/docs/developers/tooling/contracts-templates/_category_.json
+++ b/docs/developers/tooling/contracts-templates/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Contract templates"
-}

--- a/docs/developers/tooling/cross-chain/_category_.json
+++ b/docs/developers/tooling/cross-chain/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Cross Chain Messaging"
-}

--- a/docs/developers/tooling/data-indexers/_category_.json
+++ b/docs/developers/tooling/data-indexers/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Data indexers"
-}

--- a/docs/developers/tooling/libraries/_category_.json
+++ b/docs/developers/tooling/libraries/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Libraries"
-}

--- a/docs/developers/tooling/node-providers/_category_.json
+++ b/docs/developers/tooling/node-providers/_category_.json
@@ -1,3 +1,0 @@
-{
-    "label": "Node Providers"
-}

--- a/docs/developers/tooling/oracles/_category_.json
+++ b/docs/developers/tooling/oracles/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Oracles"
-}

--- a/docs/developers/tooling/privacy/_category_.json
+++ b/docs/developers/tooling/privacy/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Privacy"
-}

--- a/docs/developers/tooling/security/_category_.json
+++ b/docs/developers/tooling/security/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Security"
-}

--- a/docs/developers/tooling/social-login/_category_.json
+++ b/docs/developers/tooling/social-login/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Social Login"
-}


### PR DESCRIPTION
Many subdirectories, mainly in `developers/tooling`, have `_category_.json` files that were previously used to control sidebar ordering back when the sidebar was autogenerated. Since our sidebar is administered manually, we no longer need them. 

Fixes #831 