### PR TITLE
Remove Babel loader

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
-};


### PR DESCRIPTION
Removes the `babel.config.js` file that is no longer needed following our update to Docusuaurus ^3.6.0.

Fixes #834 