### PR TITLE
Fix grammatical error Update index.mdx

### DIFF
--- a/docs/risk-disclosures/index.mdx
+++ b/docs/risk-disclosures/index.mdx
@@ -38,7 +38,7 @@ For more details on the Linea Decentralization and Trust Minimization Roadmap, s
 
 ### Third-party dapps
 
-Just as Ethereum, Linea also operates on a permissionless framework, meaning that any individual is free to launch any smart contract code they choose. When engaging with contracts on Linea, users should adhere to the same precautions as with Ethereum - that is, they should only interact with an application if they are confident in its security and trustworthiness.
+Just as Ethereum does, Linea also operates on a permissionless framework, meaning that any individual is free to launch any smart contract code they choose. When engaging with contracts on Linea, users should adhere to the same precautions as with Ethereum - that is, they should only interact with an application if they are confident in its security and trustworthiness.
 
 ### Audits and security checks
 


### PR DESCRIPTION
**Description:**

This pull request addresses a grammatical issue in the **"Third-party dapps"** section of the document. Specifically, the phrase:

> "Just as Ethereum, Linea also operates on a permissionless framework..."

was missing the auxiliary verb **"does"**. The correct form of the sentence is:

> "Just as Ethereum **does**, Linea also operates on a permissionless framework..."

**Importance of the Fix:**
This correction ensures that the sentence follows proper grammatical structure and improves the overall readability and professionalism of the document. Clear and correct grammar is important in technical documentation to avoid confusion and ensure that the content is easily understood by all readers.