### PR TITLE
Fix Grammar and Remove Redundant Words Changes Made

### DIFF
--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -41,7 +41,7 @@ Let's set metaphor aside for a moment, and clarify:
 
 - _Blockchain_: keeps track of addresses, and which tokens are allocated to 
 which addresses
-- _Consensus_ mechanism: wherein many many nodes communicate about the movement of 
+- _Consensus_ mechanism: wherein many nodes communicate about the movement of 
 tokens from one address to another, and each keeps their local copy of the ledger up to date
 - _Execution environment_: the EVM (Ethereum Virtual Machine) wherein computer programs can be run. 
 

--- a/docs/developers/tooling/oracles/pyth.mdx
+++ b/docs/developers/tooling/oracles/pyth.mdx
@@ -46,7 +46,7 @@ atomically updates the price and then interacts with an application powered by
 Pyth, the price that the application will read will be equal to the price the
 user submitted.
 
-[Read an an in-depth explanation from one of our contributors, Jayant](https://www.youtube.com/watch?v=qdwrs23Qc9g), and [read more about on-demand updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand).
+[Read an in-depth explanation from one of our contributors, Jayant](https://www.youtube.com/watch?v=qdwrs23Qc9g), and [read more about on-demand updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand).
 
 ## Use price feeds
 


### PR DESCRIPTION
1. File: docs/developers/tooling/oracles/pyth.mdx
- [Read an an in-depth explanation from one of our contributors, Jayant]
+ [Read an in-depth explanation from one of our contributors, Jayant]
Reason: Fixed duplicate word "an" to improve readability and correct grammar.

2. File: docs/architecture/index.mdx
- _Consensus_ mechanism: wherein many many nodes communicate about the movement of
+ _Consensus_ mechanism: wherein many nodes communicate about the movement of
Reason: Removed duplicate word "many" to improve clarity and maintain professional documentation standards.