### PR TITLE
Update index.mdx

### DIFF
--- a/docs/developers/linea-version/index.mdx
+++ b/docs/developers/linea-version/index.mdx
@@ -281,10 +281,10 @@ None.
 ### February 12
 
 **Testnet:**
-- Updated Bridge UI to v0,5.4 to support the new claiming method via Linea SDK v0.2.1 
+- Updated Bridge UI to v0.5.4 to support the new claiming method via Linea SDK v0.2.1 
 
 **Mainnet:**
-- Updated Bridge UI to v0,5.4 to support the new claiming method via Linea SDK v0.2.1 
+- Updated Bridge UI to v0.5.4 to support the new claiming method via Linea SDK v0.2.1 
 
 ### February 5
 


### PR DESCRIPTION
Description
This PR fixes the version number format in the Bridge UI documentation to follow the Semantic Versioning standard.
Changes
Changed version number format from v0,5.4 to v0.5.4 in both Testnet and Mainnet sections.
Before
![image](https://github.com/user-attachments/assets/bd7127d6-5856-4dd1-a857-bf9014e5c23f)

After
![image](https://github.com/user-attachments/assets/2b5b69b3-fbc2-467e-8ff5-779f42226438)

Why important?
- Follows standard Semantic Versioning (SemVer) format used in software industry
- Maintains consistency with other version numbers in docs (like SDK v0.2.1)
- Prevents potential issues with automated documentation parsing
- Makes documentation more professional and easier to read