### PR TITLE
Fixing Spelling Errors

### DIFF
--- a/docs/zero-knowledge-glossary/index.mdx
+++ b/docs/zero-knowledge-glossary/index.mdx
@@ -27,11 +27,11 @@ See also: "blockchain trilemma", "modular blockchain", "Layer 2", "Layer 3".
 
 Blockchain network builders face a tradeoff between three factors: decentralization, security, and scalability (or speed). Often, designing a system that optimizes for one compromises another.
 
-### Brakedown
+### Breakedown
 
-The first built system that provides linear-time SNARKs for NP, meaning the prover incurs O(N) finite field operations to prove the satisfiability of an N-sized R1CS instance. Brakedown’s prover is faster, both concretely and asymptotically, than prior SNARK implementations.
+The first built system that provides linear-time SNARKs for NP, meaning the prover incurs O(N) finite field operations to prove the satisfiability of an N-sized R1CS instance. Breakedown’s prover is faster, both concretely and asymptotically, than prior SNARK implementations.
 
-Brakedown doesn't require a trusted setup and is plausibly post-quantum secure.
+Breakedown doesn't require a trusted setup and is plausibly post-quantum secure.
 
 ## C
 


### PR DESCRIPTION
Fixed spelling error: 'brakedown' corrected to 'breakdown'.