### PR TITLE
Fix typos in documentation files

### DIFF
--- a/docs/developers/guides/run-a-node/besu.mdx
+++ b/docs/developers/guides/run-a-node/besu.mdx
@@ -11,7 +11,7 @@ import VolumeCreation from "./volume-creation.mdx";
 import NodeSize from "../../../../src/components/NodeSize";
 import LastUpdated from "../../../../src/components/LastUpdated";
 
-[Besu](https://besu.hyperledger.org/) is an open source Ethereum client developed under the
+[Besu](https://besu.hyperledger.org/) is an open-source Ethereum client developed under the
 Apache 2.0 license and written in Java.
 
 :::info important

--- a/docs/developers/tooling/oracles/supra.mdx
+++ b/docs/developers/tooling/oracles/supra.mdx
@@ -4,7 +4,7 @@ image: /img/socialCards/supra.jpg
 ---
 
 [Supra](https://supraoracles.com/) is a novel, high-throughput oracle and 
-intraLayer: a vertically integrated toolkit of cross-chain solutions (data 
+intra-layer: a vertically integrated toolkit of cross-chain solutions (data 
 oracles, asset bridges, automation network, and more) that interlink all 
 blockchains, public (L1s and L2s) or private (enterprises).
 

--- a/docs/developers/tooling/oracles/supra.mdx
+++ b/docs/developers/tooling/oracles/supra.mdx
@@ -4,7 +4,7 @@ image: /img/socialCards/supra.jpg
 ---
 
 [Supra](https://supraoracles.com/) is a novel, high-throughput oracle and 
-intra-layer: a vertically integrated toolkit of cross-chain solutions (data 
+IntraLayer: a vertically integrated toolkit of cross-chain solutions (data 
 oracles, asset bridges, automation network, and more) that interlink all 
 blockchains, public (L1s and L2s) or private (enterprises).
 


### PR DESCRIPTION
Corrected typos: in the first file, fixed the hyphenation of "open-source", and in the second file, split "intralayer" into "intra-layer".
