### PR TITLE
Re-enable GetFeedback widgets

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,7 @@ export default [
       "react/require-default-props": 0,
       "react/jsx-props-no-spreading": 0,
       "react/button-has-type": 0,
+      "react/no-unknown-property": [2, { ignore: ["ub-in-page"] }],
       "jsx-a11y/label-has-associated-control": [
         "error",
         {

--- a/src/theme/DocItem/Layout/GetFeedback.jsx
+++ b/src/theme/DocItem/Layout/GetFeedback.jsx
@@ -19,13 +19,13 @@ const GetFeedback = (props) => {
     <div className="getfeedback-container">
       {/*Light*/}
       <div
-        data-ub-in-page="66fd19777582bd0f0b3f8314"
+        ub-in-page="66fd19777582bd0f0b3f8314"
         className={theme === "dark" ? "getfeedback-hidden" : undefined}
         ref={feedbackContRef}
       />
       {/*Dark*/}
       <div
-        data-ub-in-page="66fd1931467c23680b03167d"
+        ub-in-page="66fd1931467c23680b03167d"
         className={theme === "light" ? "getfeedback-hidden" : undefined}
         ref={feedbackContRef}
       />


### PR DESCRIPTION
Addressing `eslint` errors in #847 erroneously disabled the widgets. 

This reinstates them and updates the appropriate rule in `eslint` to ensure these specific instances are ignored in future.