### PR TITLE
Add note to Docker instructions

### DIFF
--- a/docs/developers/guides/run-a-node/besu.mdx
+++ b/docs/developers/guides/run-a-node/besu.mdx
@@ -115,7 +115,8 @@ The Besu Docker image doesn't run on Windows.
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/).
+Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+running.
 
 ### Step 1. Download configuration files
 

--- a/docs/developers/guides/run-a-node/erigon.mdx
+++ b/docs/developers/guides/run-a-node/erigon.mdx
@@ -150,7 +150,8 @@ The Erigon node will attempt to find peers to begin synchronizing and to downloa
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/).
+Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+running.
 
 ### Step 1. Download configuration files
 

--- a/docs/developers/guides/run-a-node/geth.mdx
+++ b/docs/developers/guides/run-a-node/geth.mdx
@@ -166,7 +166,8 @@ otherwise, you might not be connected to the Linea network.
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/).
+Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+running.
 
 ### Step 1. Download configuration files
 

--- a/docs/developers/guides/run-a-node/linea-besu.mdx
+++ b/docs/developers/guides/run-a-node/linea-besu.mdx
@@ -115,7 +115,8 @@ The node will attempt to find peers to begin synchronizing and to download the w
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/).
+Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+running.
 
 ### Step 1. Download the relevant `docker-compose.yaml` file
 


### PR DESCRIPTION
Adds a note that users should keep Docker running in order for the subsequent steps to work.

Fixes #792 