### PR TITLE
correct curl and link fixed

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -69,14 +69,6 @@ an inconvenience for users at best, or leave a negative impression of your proje
 includes keeping links to external sites up-to-date and returning for updates as your project
 matures.
 
-### Contribute to community tutorials
-
-If you've created fleshed-out guides and tutorials, or intend to, we'd love to feature your content
-in our [community tutorials section](./docs/developers/guides/community/index.mdx).
-
-First, create an issue describing the content you want to see added or intend to add. If you're
-representing an organization (such as a dapp), please use the ecosystem contribution issue form.
-
 ### Contribute to the Zero-Knowledge Glossary
 
 Diving into zero-knowledge rollups and getting stumped by the technical jargon? We've started an
@@ -84,7 +76,7 @@ open source Zero-Knowledge glossary to define some common terms you might encoun
 into the L2 landscape.
 
 [Fork our repo](https://github.com/Consensys/doc.linea/fork), and add a term in alphabetical
-order to `docs/reference/glossary.md`. Then, make a pull request and tag us for review!
+order to `docs/zero-knowledge-glossary/index.mdx`. Then, make a pull request and tag us for review!
 
 ### Additional resources
 

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -41,7 +41,7 @@ View the [list of node providers](../get-started/tooling/node-providers/index.md
 :::
 
 
-### cURL
+### curl
 
 Run the [`curl`](https://curl.se/) command in a terminal:
 

--- a/docs/api/reference/linea-estimategas.mdx
+++ b/docs/api/reference/linea-estimategas.mdx
@@ -63,7 +63,7 @@ You can also call the API using [Infura's supported Linea endpoints](https://doc
 ### Request
 
 <Tabs>
-  <TabItem value="cURL">
+  <TabItem value="curl">
 
   ```bash
   curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY \

--- a/docs/api/reference/linea-gettransactionexclusionstatusv1.mdx
+++ b/docs/api/reference/linea-gettransactionexclusionstatusv1.mdx
@@ -47,7 +47,7 @@ returned for transactions rejected by the sequencer.
 ### Request
 
 <Tabs>
-    <TabItem value="cURL">
+    <TabItem value="curl">
         ```bash
         curl https://linea-mainnet.infura.io/v3/YOUR-API-KEY \
         -X POST \


### PR DESCRIPTION
- Edited correct curl usage (https://github.com/Consensys/doc.linea/issues/866#issue-2704431433)

- The link “Contribute to community tutorials” is not yet active, the text has been removed as it is misleading, 

- Added the correct redirect “docs/zero-knowledge-glossary/index.mdx”.
