### PR TITLE
Add "Get Linea Sepolia ETH" page

### DIFF
--- a/docs/get-started/build/network-info.mdx
+++ b/docs/get-started/build/network-info.mdx
@@ -38,7 +38,7 @@ import TabItem from "@theme/TabItem";
   <TabItem value="Linea Sepolia" label="Linea Sepolia">
   <table>
       <tr>
-          <td align="left"><b>Network Name</b></td>
+          <td align="left"><b>Network</b></td>
           <td align="left">Linea</td>
       </tr>
       <tr>
@@ -50,11 +50,11 @@ import TabItem from "@theme/TabItem";
           <td align="left">59141</td>
       </tr>
       <tr>
-          <td align="left"><b>Currency Symbol</b></td>
+          <td align="left"><b>Symbol</b></td>
           <td align="left">ETH</td>
       </tr>
       <tr>
-          <td align="left"><b>Block Explorer URL</b></td>
+          <td align="left"><b>Block explorer</b></td>
           <td align="left"> <a href="https://sepolia.lineascan.build">Lineascan</a> </td>
       </tr>
   </table>
@@ -67,30 +67,3 @@ If your dapp is using public endpoints, it may encounter rate limiting. You can 
 [here](../tooling/node-providers/index.mdx).
 
 We recommend connecting to Linea via [private RPCs](../tooling/node-providers/index.mdx#private-rpc-endpoints).
-
-## Faucets
-
-### MetaMask faucet
-
-We recommend you use the [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/). It
-supports using Linea ENS names, and using one guarantees you'll receive the full 0.5 ETH daily 
-maximum.
-
-### Other faucets
-
-You can use one of the following Linea Sepolia faucets to drip testnet ETH directly to your
-Linea Sepolia address:
-
-- [Covalent](https://www.covalenthq.com/faucet/)
-- [Infura](https://www.infura.io/faucet/linea)
-- [GetBlock](https://getblock.io/faucet/linea-sepolia/)
-- [HackQuest](https://www.hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://www.hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
-
-Alternatively, [use the Linea native bridge to bridge tokens between Sepolia and Linea Sepolia](../how-to/bridge/how-to-bridge-eth.mdx).
-
-### Get testnet ERC-20 tokens
-
-Testnet ERC-20 tokens may be useful for development purposes.
-
-One method is to use the [OKX faucet](https://www.okx.com/xlayer/faucet/sepoliafaucet), which 
-enables you to select from a handful of different testnet ERC-20 tokens.

--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -1,0 +1,29 @@
+---
+title: Get Linea testnet ETH
+description: Learn how to get testnet ETH for Linea Sepolia.
+---
+
+To get started with building on Linea you'll need some Linea Sepolia ETH. The most efficient method
+is to use one the many available faucets to drip testnet ETH directly to your chosen account.
+
+## MetaMask faucet
+
+We recommend you use the [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/). It
+supports using Linea ENS names, and using one guarantees you'll receive the full 0.5 ETH daily 
+maximum.
+
+## Other faucets
+
+- [Covalent](https://www.covalenthq.com/faucet/)
+- [Infura](https://www.infura.io/faucet/linea)
+- [GetBlock](https://getblock.io/faucet/linea-sepolia/)
+- [HackQuest](https://www.hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://www.hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
+
+Alternatively, [use the Linea native bridge to bridge testnet ETH between Sepolia and Linea Sepolia](../how-to/bridge/how-to-bridge-eth.mdx).
+
+## Get testnet ERC-20 tokens
+
+Testnet ERC-20 tokens may be useful for development purposes.
+
+One method is to use the [OKX faucet](https://www.okx.com/xlayer/faucet/sepoliafaucet), which 
+enables you to select from a handful of different testnet ERC-20 tokens.

--- a/sidebars.js
+++ b/sidebars.js
@@ -25,6 +25,7 @@ const sidebars = {
       link: null,
       collapsible: false,
       items: [
+        "get-started/how-to/get-testnet-eth",
         {
           type: "category",
           label: "Deploy a smart contract",

--- a/src/components/HomepageCards/index.tsx
+++ b/src/components/HomepageCards/index.tsx
@@ -42,7 +42,7 @@ const CardList: CardItem[] = [
   },
   {
     title: "Get Linea Testnet ETH",
-    link: "/get-started/build/network-info#faucets",
+    link: "/get-started/how-to/get-testnet-eth",
     description: (
       <>
         Learn how to get Linea Testnet ETH so you can deploy on Linea Sepolia.


### PR DESCRIPTION
Adds a new page in `get-started/how-to` and populates it with content that was previously in `get-started/build/network-info#faucets`.