### PR TITLE
Add Nethermind binary dist instructions

### DIFF
--- a/docs/get-started/how-to/run-a-node/nethermind.mdx
+++ b/docs/get-started/how-to/run-a-node/nethermind.mdx
@@ -15,13 +15,14 @@ maintaining a local copy of the blockchain. However, if you want to interact wit
 Linea-specific methods and features, you should [install Linea Besu](./linea-besu.mdx) instead.
 :::
 
-{/* Run using the binary distribution
+## Run using the binary distribution
 
 :::info
 Ensure you review [Nethermind's installation Guidelines](https://docs.nethermind.io/get-started/installing-nethermind) 
 before installing the Nethermind client.
 
-If you're not comfortable with installing the binary distribution, consider using [Docker](#run-using-docker) instead.
+If you're not comfortable with installing the binary distribution, consider using [Docker](#run-using-docker) 
+instead.
 :::
 
 ### Step 1. Install Nethermind
@@ -62,7 +63,8 @@ Start the node using the following command:
   </TabItem>
 </Tabs>
 
-The Nethermind node will attempt to find peers to begin synchronizing and to download the world state. */}
+The Nethermind node will attempt to find peers to begin synchronizing and to download the world 
+state.
 
 ## Run using Docker
 


### PR DESCRIPTION
Now that Nethermind 1.30.0 is out (the release that adds Linea), we've been able to test the instructions and confirm they work. Removing the comment that had obscured them until now.