### PR TITLE
Miscellaneous adjustments

### DIFF
--- a/docs/get-started/build/quickstart/deploy.mdx
+++ b/docs/get-started/build/quickstart/deploy.mdx
@@ -20,6 +20,12 @@ This involves:
 
 > _Estimated time to complete: ~20 minutes._
 
+:::note Hardhat
+
+If you'd prefer to deploy your contract using Hardhat rather than Foundry, see our [guide](../../how-to/deploy-smart-contract/hardhat.mdx).
+
+:::
+
 ## Prerequisites
 
 A Linea-compatible wallet with some Linea Sepolia ETH. We recommend using [MetaMask](https://metamask.io/).

--- a/src/components/HomepageCards/index.tsx
+++ b/src/components/HomepageCards/index.tsx
@@ -28,7 +28,7 @@ type CardItem = {
 const CardList: CardItem[] = [
   {
     title: "Deploy a smart contract",
-    link: "/get-started/how-to/deploy-smart-contract",
+    link: "/get-started/build/quickstart/deploy",
     description: (
       <>
         Learn how to deploy a smart contract on Linea.


### PR DESCRIPTION
- Edit homepage "Deploy contract" link to point to the quickstart deployment guide rather than the `/getting-started/how-to/deploy-smart-contract` index page
- Add admonition to this page to clarify that we have guides for Hardhat too, in case the user would prefer