### PR TITLE
Amend ERC-20 bridging copy

### DIFF
--- a/docs/get-started/how-to/bridge/how-to-bridge-erc20-tokens.mdx
+++ b/docs/get-started/how-to/bridge/how-to-bridge-erc20-tokens.mdx
@@ -12,8 +12,7 @@ transfer ERC-20 tokens.
 
 For everyday bridge transfers, we recommend you use the
 [MetaMask Portfolio bridge](https://portfolio.metamask.io/bridge), which aggregates bridging options
-across Linea and shows you the best rates. Alternatively, use one of the
-[third-party bridges](https://bridge.linea.build/) available to users.
+across Linea and shows you the best rates.
 
 :::
 


### PR DESCRIPTION
Removes a sentence pointing users towards third-party bridges.