### PR TITLE
fix: Changing ERC20 references to ERC-20

### DIFF
--- a/docs/api/linea-smart-contracts/tokenbridge/bridgedtoken.mdx
+++ b/docs/api/linea-smart-contracts/tokenbridge/bridgedtoken.mdx
@@ -1,6 +1,6 @@
 # `BridgedToken`
 
-ERC20 token created when a native token is bridged to a target chain.
+ERC-20 token created when a native token is bridged to a target chain.
 
 ### bridge
 
@@ -79,7 +79,7 @@ User should first have allowed the bridge to spend tokens on their behalf._
 function decimals() public view returns (uint8)
 ```
 
-_Overrides ERC20 default function to support tokens with different decimals._
+_Overrides ERC-20 default function to support tokens with different decimals._
 
 #### Return Values
 

--- a/docs/api/linea-smart-contracts/tokenbridge/custombridgedtoken.mdx
+++ b/docs/api/linea-smart-contracts/tokenbridge/custombridgedtoken.mdx
@@ -1,6 +1,6 @@
 # `CustomBridgedToken`
 
-Custom ERC20 token manually deployed for the Linea TokenBridge.
+Custom ERC-20 token manually deployed for the Linea TokenBridge.
 
 ### initializeV2
 

--- a/docs/api/linea-smart-contracts/tokenbridge/interfaces/itokenbridge.mdx
+++ b/docs/api/linea-smart-contracts/tokenbridge/interfaces/itokenbridge.mdx
@@ -344,7 +344,7 @@ function bridgeTokenWithPermit(address _token, uint256 _amount, address _recipie
 ```
 
 Similar to `bridgeToken` function but allows to pass additional
-  permit data to do the ERC20 approval in a single transaction.
+  permit data to do the ERC-20 approval in a single transaction.
 
 #### Parameters
 
@@ -473,7 +473,7 @@ _Removes a token from the reserved list._
 function setCustomContract(address _nativeToken, address _targetContract) external
 ```
 
-_Linea can set a custom ERC20 contract for specific ERC20.
+_Linea can set a custom ERC-20 contract for specific ERC-20.
   For security purpose, Linea can only call this function if the token has
   not been bridged yet._
 

--- a/docs/api/linea-smart-contracts/tokenbridge/tokenbridge.mdx
+++ b/docs/api/linea-smart-contracts/tokenbridge/tokenbridge.mdx
@@ -1,6 +1,6 @@
 # `TokenBridge`
 
-Contract to manage cross-chain ERC20 bridging.
+Contract to manage cross-chain ERC-20 bridging.
 
 ### CONTRACT_VERSION
 
@@ -217,7 +217,7 @@ function bridgeToken(address _token, uint256 _amount, address _recipient) public
 
 This function is the single entry point to bridge tokens to the
   other chain, both for native and already bridged tokens. You can use it
-  to bridge any ERC20. If the token is bridged for the first time an ERC20
+  to bridge any ERC-20. If the token is bridged for the first time an ERC-20
   (BridgedToken.sol) will be automatically deployed on the target chain.
 
 _User should first allow the bridge to transfer tokens on his behalf.
@@ -230,7 +230,7 @@ _User should first allow the bridge to transfer tokens on his behalf.
   Linea can pause the bridge for security reason. In this case new bridge
   transaction would revert.
 Note: If, when bridging an unbridged token and decimals are unknown,
-the call will revert to prevent mismatched decimals. Only those ERC20s,
+the call will revert to prevent mismatched decimals. Only those ERC-20s,
 with a decimals function are supported._
 
 #### Parameters
@@ -248,7 +248,7 @@ function bridgeTokenWithPermit(address _token, uint256 _amount, address _recipie
 ```
 
 Similar to `bridgeToken` function but allows to pass additional
-  permit data to do the ERC20 approval in a single transaction.
+  permit data to do the ERC-20 approval in a single transaction.
 _permit can fail silently, don't rely on this function passing as a form
   of authentication
 
@@ -412,7 +412,7 @@ REMOVE_RESERVED_TOKEN_ROLE is required to execute._
 function setCustomContract(address _nativeToken, address _targetContract) external
 ```
 
-_Linea can set a custom ERC20 contract for specific ERC20.
+_Linea can set a custom ERC-20 contract for specific ERC-20.
   For security purpose, Linea can only call this function if the token has
   not been bridged yet.
 SET_CUSTOM_CONTRACT_ROLE is required to execute._
@@ -430,7 +430,7 @@ SET_CUSTOM_CONTRACT_ROLE is required to execute._
 function _safeName(address _token) internal view returns (string tokenName)
 ```
 
-_Provides a safe ERC20.name version which returns 'NO_NAME' as fallback string._
+_Provides a safe ERC-20.name version which returns 'NO_NAME' as fallback string._
 
 #### Parameters
 
@@ -450,7 +450,7 @@ _Provides a safe ERC20.name version which returns 'NO_NAME' as fallback string._
 function _safeSymbol(address _token) internal view returns (string symbol)
 ```
 
-_Provides a safe ERC20.symbol version which returns 'NO_SYMBOL' as fallback string_
+_Provides a safe ERC-20.symbol version which returns 'NO_SYMBOL' as fallback string_
 
 #### Parameters
 
@@ -470,7 +470,7 @@ _Provides a safe ERC20.symbol version which returns 'NO_SYMBOL' as fallback stri
 function _safeDecimals(address _token) internal view returns (uint8)
 ```
 
-Provides a safe ERC20.decimals version which reverts when decimals are unknown
+Provides a safe ERC-20.decimals version which reverts when decimals are unknown
   Note Tokens with (decimals > 255) are not supported
 
 #### Parameters
@@ -511,13 +511,13 @@ _Converts returned data to string. Returns 'NOT_VALID_ENCODING' as fallback valu
 function _permit(address _token, bytes _permitData) internal
 ```
 
-Call the token permit method of extended ERC20
+Call the token permit method of extended ERC-20
 Only support tokens implementing ERC-2612
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _token | address | ERC20 token address |
+| _token | address | ERC-20 token address |
 | _permitData | bytes | Raw data of the call `permit` of the token |
 

--- a/docs/get-started/how-to/bridge/index.mdx
+++ b/docs/get-started/how-to/bridge/index.mdx
@@ -12,7 +12,7 @@ You can bridge bridge tokens (ETH or ERC-20) to provide liquidity in different w
 canonical token bridge allows you to bridge ETH or ERC-20 tokens using a UI.
 
 The default canonical token bridge is suited for protocols that need their tokens on L2 for
-DeFi and other uses without any special requirement for custom features (Vanilla ERC20). For protocols
+DeFi and other uses without any special requirement for custom features (Vanilla ERC-20). For protocols
 that require custom features or want to implement complex cross-chain logic, consider a custom
 implementation or building a dedicated token bridge.
 
@@ -30,13 +30,13 @@ Select one of the following cards for instructions to bridge using the default c
 
 ### Use the canonical token bridge with a custom `BridgedToken` implementation
 
-This is suited for protocols that want to implement special features for the bridged ERC20 on L2.
+This is suited for protocols that want to implement special features for the bridged ERC-20 on L2.
 **This is only possible if the token has not yet been bridged from L1 to L2 in order to avoid
 unexpected changes for end-users.**
 
 Protocols that want to use a custom BridgedToken will be able to incorporate arbitrary logic on the L2
-ERC20, while still relying on the Token Bridge lock and mint logic and cross-chain communication.
-**For this to work, protocols need to keep compatibility with the Token Bridge by enabling it to call the ERC20 mint and burn functions.**
+ERC-20, while still relying on the Token Bridge lock and mint logic and cross-chain communication.
+**For this to work, protocols need to keep compatibility with the Token Bridge by enabling it to call the ERC-20 mint and burn functions.**
 
 If you are interested in this option, please contact the Linea team to get started. The process is as follows:
 

--- a/docs/get-started/tooling/data-indexers/covalent.mdx
+++ b/docs/get-started/tooling/data-indexers/covalent.mdx
@@ -38,7 +38,7 @@ agnostic. Available APIs and corresponding use cases include:
 
 ### Wallet API
 
-- **Features:** All token balances (ERC20, 721, 1155, native), token transfers
+- **Features:** All token balances (ERC-20, 721, 1155, native), token transfers
   and prices (spot and historical) for a wallet.
 - **Use cases:** [Wallets, portfolio trackers](https://goldrush-wallet-portfolio-ui.vercel.app/?utm_source=linea&utm_medium=partner-docs),
   token gating, airdrop snapshots.
@@ -65,7 +65,7 @@ agnostic. Available APIs and corresponding use cases include:
 
 ### Security API
 
-- **Features:** NFT and ERC20 token allowances, including value-at-risk.
+- **Features:** NFT and ERC-20 token allowances, including value-at-risk.
 - **Use cases:** [Revoke features](https://goldrush-revokehub.vercel.app/?utm_source=linea&utm_medium=partner-docs)
   in wallets, security applications.
 

--- a/docs/get-started/tooling/data-indexers/moralis.mdx
+++ b/docs/get-started/tooling/data-indexers/moralis.mdx
@@ -35,10 +35,10 @@ Moralis' Linea API integration supports:
 Moralis indexed data APIs can be used for:
 
 - Fetching all NFTs for a user's wallet
-- Fetching all ERC20 tokens, with prices, for a user's wallet
+- Fetching all ERC-20 tokens, with prices, for a user's wallet
 - Fetching a decoded transaction history for a user's wallet
 - Fetching NFT metadata for a given token
-- Fetching the current price of an ERC20 token
+- Fetching the current price of an ERC-20 token
 - Detecting which chain(s) a given user wallet is active on
 
 ### Example use cases
@@ -67,7 +67,7 @@ Moralis' Linea real-time data integration supports:
 
 Moralis real-time data APIs can be used for:
 
-- Listening to transfer events for a given ERC20 token
+- Listening to transfer events for a given ERC-20 token
 - Listening to native transfer events for a given wallet
 - Listening to token mints or burns
 - Listening to transfer events for a given NFT collection

--- a/static/files/testnet/ITokenBridge.sol
+++ b/static/files/testnet/ITokenBridge.sol
@@ -37,7 +37,7 @@ interface ITokenBridge {
 
   /**
    * @notice Similar to `bridgeToken` function but allows to pass additional
-   *   permit data to do the ERC20 approval in a single transaction.
+   *   permit data to do the ERC-20 approval in a single transaction.
    * @param _token The address of the token to be bridged.
    * @param _amount The amount of the token to be bridged.
    * @param _recipient The address that will receive the tokens on the other chain.
@@ -97,7 +97,7 @@ interface ITokenBridge {
   function removeReserved(address _token) external;
 
   /**
-   * @dev Linea can set a custom ERC20 contract for specific ERC20.
+   * @dev Linea can set a custom ERC-20 contract for specific ERC-20.
    *   For security purpose, Linea can only call this function if the token has
    *   not been bridged yet.
    * @param _nativeToken address of the token on the source chain.


### PR DESCRIPTION
This PR addresses this issue: https://github.com/Consensys/doc.linea/issues/940

- Changes mentions of ERC20 across documentation and function descriptions to ERC-20
- Leaves all internal links using erc20 untouched