### PR TITLE
Update `ethereum-differences.mdx`

### DIFF
--- a/docs/get-started/build/ethereum-differences.mdx
+++ b/docs/get-started/build/ethereum-differences.mdx
@@ -102,4 +102,9 @@ The point evaluation precompile was introduced in [EIP-4844](https://eips.ethere
 ## JSON RPC API
 
 Linea uses the standard Ethereum JSON RPC API methods. However, in a few cases, methods differ from 
-those on Ethereum. These methods are documented in the [reference section](../../api/reference/index.mdx).
+those on Ethereum. These methods are documented in the [reference section](../../api/reference/index.mdx),
+and include:
+- `linea_estimateGas`
+- `linea_getProof`
+- `linea_getTransactionExclusionStatusV1`
+- `eth_sendRawTransaction`


### PR DESCRIPTION
Adds a few lines to specify the JSON-RPC API methods that behave uniquely on Linea. 