### PR TITLE
Adjust node providers information

### DIFF
--- a/docs/get-started/tooling/node-providers/index.mdx
+++ b/docs/get-started/tooling/node-providers/index.mdx
@@ -53,7 +53,7 @@ image: /img/socialCards/node-providers.jpg
   </tr>
   <tr>
     <td><a href="https://nownodes.io/nodes">NOWNodes</a></td>
-    <td>:x:</td>
+    <td>:white_check_mark:</td>
     <td>:x:</td>
   </tr>
   <tr>


### PR DESCRIPTION
Update to reflect that NOWNodes support `linea_estimateGas` etc. 