### PR TITLE
Correct Linea Names usage

### DIFF
--- a/docs/get-started/how-to/deploy-subdomain.mdx
+++ b/docs/get-started/how-to/deploy-subdomain.mdx
@@ -18,10 +18,10 @@ across both layers.
 - [L1 contracts](https://github.com/Consensys/linea-ens/tree/main/packages/linea-ens-resolver): 
     These contracts enable subdomains created on Linea to resolve on L1. You can reuse the
     existing Linea contracts, unless you require customizations.
-- User interface (UI): The UI for managing subdomains; you can adapt the [Linea ENS app](https://names.linea.build/)
-    in the [Linea ENS GitHub repository](https://github.com/Consensys/linea-ens/tree/main/packages/linea-ens-app). 
+- User interface (UI): The UI for managing subdomains; you can adapt the [Linea Names app](https://names.linea.build/)
+    in the [Linea Names GitHub repository](https://github.com/Consensys/linea-ens/tree/main/packages/linea-ens-app). 
     If you decide to deploy this UI, you will also need to deploy the
-    [Linea ENS Subgraph](https://github.com/Consensys/linea-ens/tree/main/packages/linea-ens-subgraph), and
+    [Linea Names Subgraph](https://github.com/Consensys/linea-ens/tree/main/packages/linea-ens-subgraph), and
     include your own values into the [`env.ts`](https://github.com/Consensys/linea-ens/blob/main/packages/linea-ens-subgraph/src/env.ts)
     file.
 
@@ -70,7 +70,7 @@ they were used to create the `linea.eth` subdomain.
 
 Deploy the subdomain contracts on the Linea network:
 
-1. Clone the [Linea ENS repository](https://github.com/Consensys/linea-ens) and execute the 
+1. Clone the [Linea Names repository](https://github.com/Consensys/linea-ens) and execute the 
     following commands:
 
     ```bash

--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -14,13 +14,13 @@ Head to the [Linea Discord](https://discord.gg/linea) and request some Linea Sep
 
 ## MetaMask faucet
 
-The [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/) supports using Linea ENS 
-names, and using one guarantees you'll receive the full 0.5 ETH daily maximum. [Learn how to get a
-Linea ENS name](https://support.linea.build/explore/ens).
+The [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/) supports using Linea Names 
+domains, and using one guarantees you'll receive the full 0.5 ETH daily maximum. [Learn how to get a
+Linea Names domain](https://support.linea.build/explore/ens).
 
 :::tip
 
-See our [support guide to getting a Linea ENS name](https://support.linea.build/explore/ens).
+See our [support guide to getting a Linea Names domain](https://support.linea.build/explore/ens).
 
 :::
 

--- a/docs/get-started/tooling/cross-chain/ccip-read.mdx
+++ b/docs/get-started/tooling/cross-chain/ccip-read.mdx
@@ -18,7 +18,7 @@ which is immune from any intervention or tampering.
 
 Linea adapted the functionality of the relevant ENS contract, [`evm-gateway`](https://github.com/ensdomains/evmgateway),
 so that it would function correctly with Linea's sparse Merkle tree design. The 
-Linea ENS repository therefore adds support for CCIP Read to Linea.
+Linea Names repository therefore adds support for CCIP Read to Linea.
 
 :::info 
 
@@ -36,18 +36,18 @@ larger audience.
 
 Read more about CCIP in the [Chainlink documentation](https://docs.chain.link/ccip).
 
-## Linea ENS
+## Linea Names
 
-Linea ENS allows Linea users to register human-readable domains for considerably 
+Linea Names allows Linea users to register human-readable domains for considerably 
 lower fees than on Ethereum Mainnet, it also leverages smart contracts with 
 considerable utility for developers by enabling CCIP Read. See the user guide 
 [here](https://support.linea.build/explore/ens).
 
-The [Linea ENS repository](https://github.com/Consensys/linea-ens) contains a 
+The [Linea Names repository](https://github.com/Consensys/linea-ens) contains a 
 frontend and associated contracts for ENS to work on Linea, including 
 functionality that enables any L1 application to query L2 data using CCIP Read. 
 
-However, Linea ENS is just one example use case; CCIP Read is beneficial in any 
+However, Linea Names is just one example use case; CCIP Read is beneficial in any 
 scenario where it's advantageous to store data on L2. In addition to ENS-like 
 systems, the library enables L1 applications to create allowlists that use 
 cross-chain Verax attestations to determine eligibility for NFT mints or 
@@ -55,7 +55,7 @@ governance voting, for example.
 
 :::tip[Deploy a subdomain on Linea]
 
-You can use the building blocks of Linea ENS to [deploy your own subdomain on Linea](../../how-to/deploy-subdomain.mdx).
+You can use the building blocks of Linea Names to [deploy your own subdomain on Linea](../../how-to/deploy-subdomain.mdx).
 
 :::
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -166,18 +166,18 @@ mode.
 
 ### ENS on Linea
 
-Adds support for Linea ENS domains, including a frontend app for users to register and manage their
-domains. The Linea ENS system is comparable to ENS on Ethereum Mainnet, except that domains are 
+Adds support for Linea Names domains, including a frontend app for users to register and manage their
+domains. The Linea Names system is comparable to ENS on Ethereum Mainnet, except that domains are 
 limited to one per account and registering requires completion of [Proof of Humanity](https://poh.linea.build/).
-As the system leverages CCIP Read, which enables L1 to trustlessly query the Linea ENS registry 
-through an offchain gateway, Linea ENS domains resolve on L1. 
+As the system leverages CCIP Read, which enables L1 to trustlessly query the Linea Names registry 
+through an offchain gateway, Linea Names domains resolve on L1. 
 
 Read more about ENS in the user guide [here](https://support.linea.build/general/ens).
 
 ### CCIP Read
 
 One of the building blocks of ENS on Linea is a custom implementation of CCIP Read, which uses the
-gateway system introduced in EIP-3668 to enable Linea ENS names to resolve on L1. The key 
+gateway system introduced in EIP-3668 to enable Linea Names domains to resolve on L1. The key 
 contracts created by ENS have been adjusted by the Linea team to ensure they work with Linea's
 Sparse Merkle Tree system. 
 
@@ -187,7 +187,7 @@ for more information and guidance on how to use the relevant contracts.
 
 The Linea repository containing the relevant contracts is [here](https://github.com/Consensys/linea-ens).
 
-Consensys Diligence carried out an audit on Linea ENS, available [here](https://consensys.io/diligence/audits/2024/06/linea-ens/).
+Consensys Diligence carried out an audit on Linea Names, available [here](https://consensys.io/diligence/audits/2024/06/linea-ens/).
 
 ### `linea_estimateGas` mainnet activation
 


### PR DESCRIPTION
The app is officially called `Linea Names`, not `Linea ENS`. Amending docs accordingly.