### PR TITLE
Fix `run-a-node` links

### DIFF
--- a/docs/get-started/how-to/run-a-node/index.mdx
+++ b/docs/get-started/how-to/run-a-node/index.mdx
@@ -41,7 +41,7 @@ to Linea-specific features.
     </tr>
     <tr>
       <td>[Linea Besu](./linea-besu.mdx)</td>
-      <td>Besu client with plugins that implement Linea-specific features, such as <a href="../../../api/reference/index.mdx">API methods</a> and <a href="../finalized-block.mdx">finalized</a> tag.</td>
+      <td>Besu client with plugins that implement Linea-specific features, such as [API methods](../../../api/reference/index.mdx) and a [finalized](../finalized-block.mdx) tag.</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/docs/get-started/tooling/cross-chain/layerzero.mdx
+++ b/docs/get-started/tooling/cross-chain/layerzero.mdx
@@ -1,7 +1,10 @@
 ---
 title: LayerZero Omnichain Messaging
 image: /img/socialCards/layerzero-omnichain-messaging.jpg
-description: "Omnichain interoperability protocol enabling secure cross-chain communication for Linea applications. Connect to 100+ blockchains, send messages, and deploy omnichain tokens."
+description: >-
+  Omnichain interoperability protocol enabling secure cross-chain communication
+  for Linea applications. Connect to 100+ blockchains, send messages, and deploy
+  omnichain tokens.
 ---
 
 [LayerZero](https://layerzero.network) is an **omnichain interoperability protocol** that enables smart contracts to seamlessly communicate between different blockchain networks. With LayerZero V2, applications deployed on Linea can connect and interact with 100+ supported blockchains through secure, configurable messaging channels.


### PR DESCRIPTION
These links weren't working, potentially because they're a blend of Markdown-native paths with HTML-style `<a>` tags. Fixed and confirmed they work in local build.