### PR TITLE
Clarify solidity compilation in `ethereum-differences.mdx`

### DIFF
--- a/docs/get-started/build/ethereum-differences.mdx
+++ b/docs/get-started/build/ethereum-differences.mdx
@@ -60,9 +60,8 @@ forks, and updates to the blockchain.
         <td>n/a</td>
         <td>PUSH0 was introduced in the Ethereum Mainnet Shanghai upgrade and became available in 
         Solidity compiler version 0.8.20, which came after the London release. However, Linea 
-        currently supports compiled code targeting the London release of the Ethereum Mainnet. Using 
-        the EVM Version of London when compiling, or using Solidity compiler 0.8.19 or lower will 
-        align with Linea's capabilities.</td>
+        currently supports compiled code targeting the London release of the Ethereum Mainnet. Use 
+        the EVM Version of London when compiling to align with Linea's capabilities.</td>
     </tr>
     <tr>
         <td>`TLOAD`</td>


### PR DESCRIPTION
Removes text suggesting to use older versions of Solidity; you can, in fact, use whatever version you want, as long as you compile for the London version of the EVM 