### PR TITLE
Fix faucet channel name

### DIFF
--- a/docs/get-started/build/quickstart/app.mdx
+++ b/docs/get-started/build/quickstart/app.mdx
@@ -23,7 +23,7 @@ In this guide, we will:
 A wallet that can connect to Linea Sepolia. We recommend [MetaMask](https://metamask.io/).
 
 Get some Linea Sepolia ETH by heading to our [Discord server](https://discord.gg/linea) and asking 
-in the `#developer-chat` channel.
+in the `#testnet-faucet` channel.
 
 ## Set up a Next.js app using Dynamic
 

--- a/docs/get-started/build/quickstart/deploy.mdx
+++ b/docs/get-started/build/quickstart/deploy.mdx
@@ -62,8 +62,7 @@ testing library.
 :::note
 
 If you already have a project set up, clone the project and run `forge install` in the directory to
-use Foundry. See the [Foundry guide](https://book.getfoundry.sh/projects/working-on-an-existing-project#working-on-an-existing-project) 
-for more information.
+use Foundry.
 
 :::
 

--- a/docs/get-started/build/quickstart/deploy.mdx
+++ b/docs/get-started/build/quickstart/deploy.mdx
@@ -31,7 +31,7 @@ If you'd prefer to deploy your contract using Hardhat rather than Foundry, see o
 A Linea-compatible wallet with some Linea Sepolia ETH. We recommend using [MetaMask](https://metamask.io/).
 
 Get some testnet ETH by heading to our [Discord server](https://discord.gg/linea) and asking in 
-the `#developer-chat` channel. Our admins or other community members will help you out.
+the `#testnet-faucet` channel. Our admins or other community members will help you out.
 
 ## Create your project
 

--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -10,7 +10,7 @@ is to use one of the many available faucets to drip testnet ETH directly to your
 ## Linea Discord
 
 Head to the [Linea Discord](https://discord.gg/linea) and request some Linea Sepolia ETH in the 
-`#developer-chat` channel.
+`#testnet-faucet` channel.
 
 ## MetaMask faucet
 


### PR DESCRIPTION
Adjusting the name of the recommended Discord channel for builders to request Linea Sepolia ETH. 