### PR TITLE
Add notice to smart contract reference pages

### DIFF
--- a/docs/get-started/how-to/migrate-dapp.mdx
+++ b/docs/get-started/how-to/migrate-dapp.mdx
@@ -1,6 +1,7 @@
 ---
 title: Migrate a dapp to Linea
 description: An overview of the steps to move a dapp from an EVM-compatible chain to Linea.
+image: /img/socialCards/migrate-a-dapp-to-linea.jpg
 ---
 
 Linea is EVM-equivalent, which means any dapp running on another chain compatible with the 

--- a/src/components/ContractsWarning.jsx
+++ b/src/components/ContractsWarning.jsx
@@ -13,7 +13,7 @@ export default function ContractsWarning() {
   return (
     <div style={{ marginTop: "2rem" }}>
       <Admonition type="warning" title="Contributions not accepted">
-        These reference pages are automatically generated based on Linea&#39s{" "}
+        These reference pages are automatically generated based on Linea's{" "}
         <a href="https://github.com/Consensys/linea-monorepo/tree/main/contracts/src">
           smart contracts
         </a>

--- a/src/components/ContractsWarning.jsx
+++ b/src/components/ContractsWarning.jsx
@@ -13,12 +13,12 @@ export default function ContractsWarning() {
   return (
     <div style={{ marginTop: "2rem" }}>
       <Admonition type="warning" title="Contributions not accepted">
-        These reference pages are automatically generated based on Linea's {" "}
-        <a href="https://github.com/Consensys/linea-monorepo/tree/main/contracts/src">smart contracts
+        These reference pages are automatically generated based on Linea&#39s{" "}
+        <a href="https://github.com/Consensys/linea-monorepo/tree/main/contracts/src">
+          smart contracts
         </a>
-        .
-        To ensure they accurately match the deployed smart contracts, we cannot accept any 
-        contributions that edit these pages.
+        . To ensure they accurately match the deployed smart contracts, we
+        cannot accept any contributions that edit these pages.
       </Admonition>
     </div>
   );

--- a/src/components/ContractsWarning.jsx
+++ b/src/components/ContractsWarning.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useLocation } from "@docusaurus/router";
+import Admonition from "@theme/Admonition";
+
+export default function ContractsWarning() {
+  const location = useLocation();
+
+  // Only show on relevant pages
+  if (!location.pathname.includes("/api/linea-smart-contracts")) {
+    return null;
+  }
+
+  return (
+    <div style={{ marginTop: "2rem" }}>
+      <Admonition type="warning" title="Contributions not accepted">
+        These reference pages are automatically generated based on Linea's {" "}
+        <a href="https://github.com/Consensys/linea-monorepo/tree/main/contracts/src">smart contracts
+        </a>
+        .
+        To ensure they accurately match the deployed smart contracts, we cannot accept any 
+        contributions that edit these pages.
+      </Admonition>
+    </div>
+  );
+}

--- a/src/components/ContractsWarning.jsx
+++ b/src/components/ContractsWarning.jsx
@@ -13,7 +13,7 @@ export default function ContractsWarning() {
   return (
     <div style={{ marginTop: "2rem" }}>
       <Admonition type="warning" title="Contributions not accepted">
-        These reference pages are automatically generated based on Linea's{" "}
+        These reference pages are automatically generated based on Linea&apos;s{" "}
         <a href="https://github.com/Consensys/linea-monorepo/tree/main/contracts/src">
           smart contracts
         </a>

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -14,6 +14,7 @@ import ContentVisibility from "@theme/ContentVisibility";
 import styles from "./styles.module.css";
 import GetFeedback from "./GetFeedback";
 import ToolingCTA from "../../../components/ToolingCTA";
+import ContractsWarning from "../../../components/ContractsWarning";
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -49,6 +50,7 @@ export default function DocItemLayout({ children }) {
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <ToolingCTA />
+            <ContractsWarning />
             <GetFeedback />
             <DocItemFooter />
           </article>


### PR DESCRIPTION
Unfortunately these pages should not be edited by contributors as they're automatically generated based on the source contracts. Not only do edits mean that they no longer reflect deployed contracts, but also that any merged changes on this docs site will simply be lost the next time the contracts are updated and a new set of docs generated. 