### PR TITLE
Enhance Documentation Clarity and Correct Typos

### DIFF
--- a/docs/api/linea-sdk.mdx
+++ b/docs/api/linea-sdk.mdx
@@ -202,8 +202,7 @@ const sdk = new LineaSDK({
       await l1Contract.claim(message);
     } else {
       const proofInfo = // Implement your own function to get a merkle proof
-        // The L1ClaimingService exposes some utility functions to assist you: getFinalizationMessagingInfo, getL2MessageHashesInBlockRange, getMessageSiblings
-
+        // The L1ClaimingService exposes some utility functions to assist you: getFinalizationMessagingInfo, getL2MessageHashesInBlockRange, and getMessageSiblings
         // Follow these steps:
         // 1. Retrieve the MessageSent event on L2 by messageHash
         // 2. Retrieve the L2MessagingBlockAnchored event on L1 using the MessageSent.blockNumber you acquired in step 1. This is used to get the finalization transaction hash where the L2 block number associated to your message has been finalized.

--- a/docs/api/linea-smart-contracts/interfaces/imessageservice.mdx
+++ b/docs/api/linea-smart-contracts/interfaces/imessageservice.mdx
@@ -18,7 +18,7 @@ This event is used on both L1 and L2._
 | ---- | ---- | ----------- |
 | _from | address | The indexed sender address of the message (msg.sender). |
 | _to | address | The indexed intended recipient address of the message on the other layer. |
-| _fee | uint256 | The fee being being paid to deliver the message to the recipient in Wei. |
+| _fee | uint256 | The fee being paid to deliver the message to the recipient in Wei. |
 | _value | uint256 | The value being sent to the recipient in Wei. |
 | _nonce | uint256 | The unique message number. |
 | _calldata | bytes | The calldata being passed to the intended recipient when being called on claiming. |

--- a/docs/api/linea-smart-contracts/interfaces/iratelimiter.mdx
+++ b/docs/api/linea-smart-contracts/interfaces/iratelimiter.mdx
@@ -39,7 +39,7 @@ event LimitAmountChanged(address amountChangeBy, uint256 amount, bool amountUsed
 Emitted when the limit is changed.
 
 _If the current used amount is higher than the new limit, the used amount is lowered to the limit.
-amountUsedLoweredToLimit and usedAmountResetToZero cannot be true at the same time._
+Amount used lowered to limit and used amount reset to zero cannot be true at the same time._
 
 #### Parameters
 

--- a/docs/api/linea-smart-contracts/messageservice/l1/l1messageservice.mdx
+++ b/docs/api/linea-smart-contracts/messageservice/l1/l1messageservice.mdx
@@ -14,7 +14,7 @@ _This is currently not in use, but is reserved for future upgrades._
 function __MessageService_init(uint256 _rateLimitPeriod, uint256 _rateLimitAmount) internal
 ```
 
-Initialises underlying message service dependencies.
+Initializes underlying message service dependencies.
 
 #### Parameters
 


### PR DESCRIPTION
List Item Formatting

Old: getFinalizationMessagingInfo, getL2MessageHashesInBlockRange, getMessageSiblings
New: getFinalizationMessagingInfo, getL2MessageHashesInBlockRange, and getMessageSiblings
File: Documentation (specific location not provided)
Reason: Added "and" before the last item in the list to enhance clarity and adhere to standard English writing conventions.
Fee Description Typo

Old: The fee being being paid to deliver the message to the recipient in Wei.
New: The fee being paid to deliver the message to the recipient in Wei.
File: Code or Documentation (specific location not provided)
Reason: Corrected the repeated word "being" to ensure grammatical accuracy.
Error Message Formatting

Old: amountUsedLoweredToLimit and usedAmountResetToZero cannot be true at the same time.
New: Amount used lowered to limit and used amount reset to zero cannot be true at the same time.
File: Error Handling Code (specific location not provided)
Reason: Improved clarity and readability of the error message by adjusting the phrasing.
Function Initialization Spelling

Old: Initialises underlying message service dependencies.
New: Initializes underlying message service dependencies.
File: Code or Documentation (specific location not provided)
Reason: Changed "Initialises" to "Initializes" for consistency with American English spelling, improving overall readability.
