### PR TITLE
Add documentation for the StorageFiller39 contract in the TokenBridge…

### DIFF
--- a/docs/api/linea-smart-contracts/tokenbridge/lib/storagefiller39.mdx
+++ b/docs/api/linea-smart-contracts/tokenbridge/lib/storagefiller39.mdx
@@ -1,2 +1,15 @@
 # `StorageFiller39`
 
+Contract used to reserve storage slots in the TokenBridge contract. This helps maintain storage layout compatibility during upgrades.
+
+The StorageFiller39 reserves 39 storage slots that can be used in future upgrades without changing the storage layout of existing variables.
+
+```solidity
+contract StorageFiller39 {
+    // Reserved storage slots
+    uint256[39] private __gap;
+}
+```
+
+This pattern is commonly used in upgradeable contracts to ensure that new variables can be added in future versions without causing storage collisions.
+


### PR DESCRIPTION
… library.

This commit adds the missing documentation for the StorageFiller39 contract,  which is used to reserve storage slots in the TokenBridge contract for future  upgrades. The documentation explains the purpose of the contract and its  implementation pattern, making it consistent with other contract documentation  in the repository.