### PR TITLE
Fix node storage size workflow

### DIFF
--- a/linea-node-size/config.json
+++ b/linea-node-size/config.json
@@ -7,7 +7,7 @@
     {
       "network": "mainnet",
       "cluster": "linea-prod-eks",
-      "pvc": "data-linea-besu-archive-v2-0"
+      "pvc": "data-linea-besu-archive-v3-0"
     },
     {
       "network": "mainnet",
@@ -17,6 +17,6 @@
     {
       "network": "mainnet",
       "cluster": "linea-prod-eks",
-      "pvc": "data-linea-geth-archive-0"
+      "pvc": "data-linea-geth-archive-v2-0"
     }
   ]


### PR DESCRIPTION
Some volumes (`pvc`s) were deleted; replacing with the new versions to hopefully restore the workflow to full function. 

Cf. data only returned for 2/4 volumes in #1011 