### PR TITLE
Remove Discord faucet route

### DIFF
--- a/docs/get-started/build/quickstart/app.mdx
+++ b/docs/get-started/build/quickstart/app.mdx
@@ -22,8 +22,7 @@ In this guide, we will:
 
 A wallet that can connect to Linea Sepolia. We recommend [MetaMask](https://metamask.io/).
 
-Get some Linea Sepolia ETH by heading to our [Discord server](https://discord.gg/linea) and asking 
-in the `#testnet-faucet` channel.
+[Get some Linea Sepolia ETH](../../how-to/get-testnet-eth.mdx).
 
 ## Set up a Next.js app using Dynamic
 

--- a/docs/get-started/build/quickstart/deploy.mdx
+++ b/docs/get-started/build/quickstart/deploy.mdx
@@ -30,8 +30,7 @@ If you'd prefer to deploy your contract using Hardhat rather than Foundry, see o
 
 A Linea-compatible wallet with some Linea Sepolia ETH. We recommend using [MetaMask](https://metamask.io/).
 
-Get some testnet ETH by heading to our [Discord server](https://discord.gg/linea) and asking in 
-the `#testnet-faucet` channel. Our admins or other community members will help you out.
+[Get some Linea Sepolia ETH](../../how-to/get-testnet-eth.mdx).
 
 ## Create your project
 

--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -7,11 +7,6 @@ image: /img/socialCards/get-linea-testnet-eth.jpg
 To get started with building on Linea you'll need some Linea Sepolia ETH. The most efficient method
 is to use one of the many available faucets to drip testnet ETH directly to your chosen account.
 
-## Linea Discord
-
-Head to the [Linea Discord](https://discord.gg/linea) and request some Linea Sepolia ETH in the 
-`#testnet-faucet` channel.
-
 ## MetaMask faucet
 
 The [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/) supports using Linea Names 


### PR DESCRIPTION
Removes a few recommendations to go to Discord to get Linea Sepolia ETH. 