### PR TITLE
Update node size workflow logic

### DIFF
--- a/.github/workflows/update-node-size.yml
+++ b/.github/workflows/update-node-size.yml
@@ -25,15 +25,20 @@ jobs:
         LINEA_OBSERVABILITY_PASS: ${{ secrets.LINEA_OBSERVABILITY_PASS }}
       run: node scripts/fetchNodeSize.js
 
-    - name: Check for changes
-      id: git-check
+    - name: Check for existing PR
+      id: check-pr
       run: |
-        git add linea-node-size/data.json
-        git diff --staged --exit-code
-      continue-on-error: true
+        PR_BRANCH="update-node-size-data"
+        EXISTING_PR=$(gh pr list --head $PR_BRANCH --json number,title,state | jq -r '.[0]')
+        if [ "$EXISTING_PR" != "null" ]; then
+          echo "Found existing PR: $EXISTING_PR"
+          echo "pr_number=$(echo $EXISTING_PR | jq -r '.number')" >> $GITHUB_OUTPUT
+        else
+          echo "No existing PR found"
+        fi
 
-    - name: Create Pull Request
-      if: steps.git-check.outcome == 'failure'
+    - name: Update existing PR or create new one
+      if: steps.check-pr.outputs.pr_number == ''
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,6 +49,15 @@ jobs:
           Please review the changes and merge if everything looks correct.
         branch: update-node-size-data
         delete-branch: true
+
+    - name: Update existing PR
+      if: steps.check-pr.outputs.pr_number != ''
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add linea-node-size/data.json
+        git commit -m "Update node size data"
+        git push origin update-node-size-data
 
   slackNotification:
     needs: [update-data]


### PR DESCRIPTION
Updating the logic since I identified an issue where, if the created PR is not merged before the workflow runs again, the data it added is overwritten on the branch via force push. This can create gaps in the data if the PR is not merged in time. 

This update intends to fix by adding logic that checks for an existing PR first before creating a new one on the branch — so if there is a PR with data from week A, data from week B will be appended, rather than overwriting week A. 