### PR TITLE
Fix sequencer page

### DIFF
--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -5,9 +5,7 @@ image: /img/socialCards/overview.jpg
 ---
 
 Linea is a secure, low-cost, and Ethereum-equivalent layer 2 blockchain built to bring the world 
-onchain without compromising on security and decentralization. 
-
-Linea has been incubated within Consensys and will decentralize in Q1 2025. 
+onchain without compromising on security and decentralization. . 
 
 Our mission is to empower developers to build the next generation of decentralized applications and 
 onboard the next billion users to web3. 

--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -5,7 +5,9 @@ image: /img/socialCards/overview.jpg
 ---
 
 Linea is a secure, low-cost, and Ethereum-equivalent layer 2 blockchain built to bring the world 
-onchain without compromising on security and decentralization. . 
+onchain without compromising on security and decentralization. 
+
+Linea has been incubated within Consensys and will decentralize in 2025. 
 
 Our mission is to empower developers to build the next generation of decentralized applications and 
 onboard the next billion users to web3. 

--- a/docs/technology/coordinator.mdx
+++ b/docs/technology/coordinator.mdx
@@ -4,16 +4,14 @@ sidebar_position: 2
 image: /img/socialCards/coordinator.jpg
 ---
 
-## The Coordinator
-
-### What is it?
+## What is it?
 
 The Coordinator is Linea’s coordination module across a number of functions. It is also the channel through which information on the state of Ethereum comes into Linea, and through which information on the state of Linea returns to Ethereum.
 
-### What does it do?
+## What does it do?
 
 The Coordinator moves information internally, between different parts of Linea’s execution client, and externally, with other blockchains, Linea’s data availability stack, and the nodes syncing its own network state. In this way, **the Coordinator is Linea’s consensus client.**
 
-### How does it do it?
+## How does it do it?
 
 It does these things through a highly modularized internal architecture. These various systems and requirements are broken out into their own environments, each one receiving input from the Coordinator, and returning the corresponding output back to it.

--- a/docs/technology/network-data.mdx
+++ b/docs/technology/network-data.mdx
@@ -4,26 +4,26 @@ sidebar_position: 7
 image: /img/socialCards/network-data.jpg
 ---
 
-### What is it?
+## What is it?
 
 One of the main value propositions of a public blockchain network is that it be, well, _public_. This means that the information about what’s going on the network needs to be readily available. Networks like Ethereum have this more or less built in and available as part of the software: each node has an API that will return any information you ask for; if you have a lot of requests, well, you just need more nodes.
 
 To be clear, that’s how Linea works too–it’s just that Ethereum is decentralized and open; anyone can run a node. Linea is still a testnet, and its nodes are only being run by teams at Consensys. Therefore, in order to provide for the massive interest that the network has generated, a lot of nodes have to be run. This allows dapps to ask for information about the state of the network without impeding the actual execution of transactions by overloading the client.
 
-### What does it do?
+## What does it do?
 
 Receives and responds to requests from users and dapps according to the Ethereum JSON-RPC API standard. This includes providing information to MetaMask users about their accounts on Linea.
 
-### How does it do it?
+## How does it do it?
 
 By leveraging the expertise and resources of Infura, Consensys, and the Ethereum ecosystem as a whole 😀 Infura is running a number of nodes to provide this service, in two main capacities:
 
-#### Client-facing RPC-API nodes
+### Client-facing RPC-API nodes
 
 - These nodes do the “traditional” work of EVM nodes: on the one hand, they are receiving updated network state information from the sequencer and state manager, and providing information about that state to users and dapps when they request it. On the other, they are receiving incoming transactions.
 - All that traffic means that Infura is running them behind a load balancer, and bringing their expertise in scaling blockchain networks across the operation. Those transactions submitted by users are therefore balanced across the nodes, and are thereby routed into the memory pool, for subsequent ingestion and processing by the Coordinator and sequencer in linea-besu.
 
-#### Archive Nodes
+### Archive nodes
 
 - There are more and more dapps and research activities being performed not just on current transaction data, but historical data as well–whether from a day ago, last month, or three years ago (though not that long on Linea, yet!).
 - This type of data request can be quite resource-intensive, and could put the live network nodes at risk of having their performance impacted, and thus threaten the overall health of the network. For this reason, Infura also has deployed archive nodes in a scalable architecture; these kinds of transactions aren’t being run _all_ the time, after all–but when they are, more nodes are spun up as needed to keep up with demand.

--- a/docs/technology/prover/index.mdx
+++ b/docs/technology/prover/index.mdx
@@ -1,19 +1,17 @@
 ---
-title: Trace Expansion and Proving
+title: Trace expansion and proving
 sidebar_position: 5
 image: /img/socialCards/trace-expansion-and-proving.jpg
 ---
 
-## Trace Expansion and Proving
-
-### What is it?
+## What is it?
 
 The module responsible for generating the final set of data for a zero-knowledge proof, and producing that proof.
 
-### What does it do?
+## What does it do?
 
 It receives several sets of information from the Coordinator and linea-besu, and produces a succinct, non-interactive argument of knowledge, or **zkSNARK**.
 
-### How does it do it?
+## How does it do it?
 
 There are multiple operations involved; the first part of this module is Corset. Corset takes in conflated trace data from the Coordinator, and prepares it for the second part, gnark. gnark takes in that prepared, or "expanded", trace data, and uses it to produce a proof of the type that can be submitted to Ethereum.

--- a/docs/technology/prover/proving.mdx
+++ b/docs/technology/prover/proving.mdx
@@ -4,16 +4,16 @@ sidebar_position: 2
 image: /img/socialCards/proving-circuit-execution-and-runtime.jpg
 ---
 
-### gnark zk-snarks
+## gnark zk-snarks
 
-#### What is it?
+### What is it?
 
 In Linea, gnark is the final part of the prover. It is also standalone software which can be used in other projects to create cryptographic circuits.
 
-#### What does it do?
+### What does it do?
 
 Similarly to Corset, gnark has two functions: it prepares a set of “circuits”, another way of referring to a constraint system, of the kind that will create a zk-SNARK proof that can be verified in an L1 Ethereum environment. It also, in fact, _makes_ those proofs.
 
-#### How does it do it?
+### How does it do it?
 
 gnark’s codebase is divided into two separate APIs: a [frontend](https://pkg.go.dev/github.com/consensys/gnark/frontend) and a [backend](https://pkg.go.dev/github.com/consensys/gnark/backend). The methods in gnark’s frontend API allow developers to do the first part, creating cryptographic circuits. In other words, gnark translates Corset’s precompiled Go constraint system into a final set of “circuits”, or constraints, which will ultimately produce the SNARK proof that is submitted to the L1 network. The methods in the backend API are used at runtime to consume data through the proving system created previously in the frontend, producing as a result a proof. That is, gnark accepts the “expanded” trace data for each block or set of blocks from Corset, and processes it through its prepared circuits. At this point, we have what we’ve been out here amongst the stars searching for: a fresh set of transactions, executed in an EVM environment, provably real and correct, ready to dispatch to the L1. So, what does the prover do with it? Send it back to the Coordinator, that’s what.

--- a/docs/technology/prover/trace-expansion.mdx
+++ b/docs/technology/prover/trace-expansion.mdx
@@ -4,17 +4,17 @@ sidebar_position: 1
 image: /img/socialCards/proving-circuit-building.jpg
 ---
 
-### Corset
+## Corset
 
-#### What is it?
+### What is it?
 
 Corset is the first of two parts of the component of Linea’s architecture generally referred to as “the prover”.
 
-#### What does it do?
+### What does it do?
 
 Corset takes the traces, expands them, and prepares them for the prover.
 
-#### How does it do it?
+### How does it do it?
 
 Corset performs its duties through two different paths:
 

--- a/docs/technology/repos.mdx
+++ b/docs/technology/repos.mdx
@@ -10,15 +10,13 @@ Linea is open source, meaning you can inspect the code yourself.
 Each repository that hosts the Linea software is listed below, together with a description of its 
 purpose.
 
-## Linea repositories
-
-### [`linea-monorepo`](https://github.com/Consensys/linea-monorepo)
+## [`linea-monorepo`](https://github.com/Consensys/linea-monorepo)
 
 The principal Linea repository. This mainly includes the smart contracts covering Linea's core 
 functions, the prover in charge of generating ZK proofs, the coordinator responsible for multiple 
 orchestrations, and the postman for executing bridge messages. 
 
-### [`linea-specification`](https://github.com/Consensys/linea-specification)
+## [`linea-specification`](https://github.com/Consensys/linea-specification)
 
 Specification of the constraint system underlying Linea's zkEVM.
 
@@ -27,7 +25,7 @@ Linea's constraint system aims to capture the logic of valid EVM executions.
 
 The constraints specified here are implemented in the `linea-constraints` repo.
 
-### [`linea-constraints`](https://github.com/Consensys/linea-constraints)
+## [`linea-constraints`](https://github.com/Consensys/linea-constraints)
 
 Implementation of the constraint system specified in the `linea-specification` repo.
 
@@ -37,7 +35,7 @@ of the EVM execution). The production of such traces is the job of the `linea-tr
 
 Constraints and traces are two of the inputs to the prover.
 
-### [`linea-tracer`](https://github.com/Consensys/linea-tracer)
+## [`linea-tracer`](https://github.com/Consensys/linea-tracer)
 
 Tracing refers to the process of extracting data from the execution of an EVM client in order to 
 construct large matrices known as execution traces. Execution traces are subject to the constraint 
@@ -45,22 +43,22 @@ system specified in the `linea-specification` repo and implemented in the `linea
 
 The repository contains the elements of Linea responsible for this process.
 
-### [`linea-besu`](https://github.com/Consensys/linea-besu)
+## [`linea-besu`](https://github.com/Consensys/linea-besu)
 
 The Linea implementation of Besu, an Ethereum client, extended with plugins.
 
 As Linea is EVM-equivalent, it is compatible with standard Ethereum clients without plugins; for 
 example, you can also [run a Linea node using Erigon, Nethermind, or Geth](../get-started/how-to/run-a-node/index.mdx). 
 
-### [`linea-sequencer`](https://github.com/Consensys/linea-sequencer)
+## [`linea-sequencer`](https://github.com/Consensys/linea-sequencer)
 
 The implementation of the sequencer, the component of Linea responsible for ordering and building 
 blocks, as well as executing them. 
 
-### [`gnark`](https://github.com/Consensys/gnark)
+## [`gnark`](https://github.com/Consensys/gnark)
 
 Linea's zk-SNARK with a high-level API to design circuits and efficient cryptographic primitives,
 
-### [`shomei`](https://github.com/Consensys/shomei)
+## [`shomei`](https://github.com/Consensys/shomei)
 
 A plugin that extends Besu functionality by maintaining and updating Linea's state. 

--- a/docs/technology/sequencer/conflation.mdx
+++ b/docs/technology/sequencer/conflation.mdx
@@ -6,21 +6,19 @@ image: /img/socialCards/conflation.jpg
 
 import ConflationGraphic from '/img/get_started/concepts/sequencer/conflation/Linea_block_conflation.svg';
 
-## Conflation
-
 <div className="img-large">
     <ConflationGraphic />
 </div>
 
-### What is it?
+## What is it?
 
 Conflation is the process of combining two or more blocks’ worth of transactions into one data set. It can then be used to produce a ‘before and after’ map of the network state (a Merkle tree, in technical terms) as well as a zero-knowledge proof, which is published to Ethereum.
 
-### What does it do?
+## What does it do?
 
 Conflation is not normally seen in mainnet Ethereum environments, where transaction data must be published in discrete blocks, one by one in order, before the next block can be published. In a zkEVM environment, the ‘source of truth’ from Ethereum’s perspective is the data submitted to it: the ZK proof, the list of transactions proved by it, and the Merkle tree. That means that it’s not a question of “how many transactions fit in a block”, but “how many transactions fit in a proof”. By conflating multiple blocks into one, Linea's proving system becomes much more efficient.
 
-### How does it do it?
+## How does it do it?
 
 Conflation occurs within the execution client, but through a process of communication with the Coordinator:
 

--- a/docs/technology/sequencer/index.mdx
+++ b/docs/technology/sequencer/index.mdx
@@ -4,13 +4,11 @@ sidebar_position: 3
 image: /img/socialCards/sequencer.jpg
 ---
 
-## The sequencer
-
-### What is it?
+## What is it?
 
 The sequencer is the heart of Linea's execution client, responsible for **ordering, building, and executing blocks** in a way that allows the subsequent zero-knowledge proof to be made.
 
-### What does it do?
+## What does it do?
 
 The sequencer does a number of things: 
 
@@ -19,8 +17,15 @@ The sequencer does a number of things:
 - Executes those blocks 
 - Prepares certain data relating to the _traces_ of that execution for the zero-knowledge prover.
 
-### How does it do it?
+## How does it do it?
 
-Currently, Linea's execution client is zkGeth, a version of geth that has been modified to work with zk-proving technology. However, Linea is building **linea-besu**: leveraging the full power of the Consensys stack by using the same Besu client software that is used to execute blocks on Ethereum coupled with a plugin system. You can [run your own Linea Besu node](../../get-started/how-to/run-a-node/linea-besu.mdx). 
+Linea's execution client is [Linea Besu](https://github.com/Consensys/linea-besu), an 
+implementation of the Besu execution client extended with additional functionality to support
+Linea and its requirements as a zero-knowledge rollup. You can [run your own Linea Besu node](../../get-started/how-to/run-a-node/linea-besu.mdx). 
 
-Linea's sequencer takes transactions from the Linea memory pool, and builds them into blocks, just like Besu does on mainnet Ethereum. However, on Linea, it also does a bit of extra work, and communication, with the coordinator, to ensure that blocks are made in such a way that they can be proven by the zero-knowledge prover, and that they are as compact as possible-doubly important in a situation where all data has to be written in tiny, costly pieces on Ethereum Mainnet. This is done specifically by subsystems within the Sequencer: the traces generator and conflator.
+Linea's sequencer takes transactions from the Linea memory pool, and builds them into blocks. However, 
+on Linea, it also does a bit of extra work, and communication, with the coordinator, to ensure that 
+blocks are made in such a way that they can be proven by the zero-knowledge prover, and that they 
+are as compact as possible-doubly important in a situation where all data has to be written in 
+tiny, costly pieces on Ethereum Mainnet. This is done specifically by subsystems within the 
+sequencer: the traces generator and conflator.

--- a/docs/technology/sequencer/traces-generator.mdx
+++ b/docs/technology/sequencer/traces-generator.mdx
@@ -4,17 +4,15 @@ sidebar_position: 1
 image: /img/socialCards/traces-generation.jpg
 ---
 
-### Traces Generator
-
-#### What is it?
+## What is it?
 
 The part of Linea’s sequencer responsible for generating the data used by the prover to create ZK proofs, and for making them as compact as possible.
 
-#### What does it do?
+## What does it do?
 
 The traces generator executes blocks that have been built by the sequencer, and preserves data relating to the traces of each transaction.
 
-#### How does it do it?
+## How does it do it?
 
 Once the sequencer has built its blocks, they are executed; and in the process, the EVM produces data known as _traces_. These traces specify the state of the network, and the state of the accounts involved in the transaction, at each granular step of each transaction’s execution. This is the Infinite Improbability Drive at the heart of Linea and its zero-knowledge technology: these traces are the very data that the prover will use to produce a proof. That proof allows Ethereum to know that everything that occurs on Linea truly did occur–without actually knowing any of it.
 

--- a/docs/technology/transaction-lifecycle.mdx
+++ b/docs/technology/transaction-lifecycle.mdx
@@ -6,7 +6,7 @@ description: >-
 image: /img/socialCards/transaction-lifecycle.jpg
 ---
 
-:::note[A note on finality]
+:::note[Finality]
 
 Finality has two definitions on Linea:
 - Soft finality: The transaction is confirmed on Linea. This takes two seconds, i.e Linea's block 


### PR DESCRIPTION
Primarily: a fix to the sequencer index page that corrects zkGeth to Linea Besu. 

Also lots of other minor improvements to formatting and style. 