### PR TITLE
Replace Mirror links with Paragraph

### DIFF
--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -159,7 +159,7 @@ accessible via the icon next to settings in the top-right of the widget.
 
 ### Bridge USDC
 
-USDC is handled differently by the native bridge. Since Linea has [native USDC](https://linea.mirror.xyz/VX4CIab0JP17_WLKHuf9v8bIKBHP6gLNv2etUv9UFK0), 
+USDC is handled differently by the native bridge. Since Linea has [native USDC](https://linea.build/blog/lineas-seamless-upgrade-to-native-usdc-a-game-changer-for-onchain-payments), 
 the bridge uses the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol) 
 (CCTP) rather than the [canonical token bridge](../../technology/canonical-token-bridge.mdx) 
 elements that underpin other native bridge transfers.

--- a/docs/get-started/tooling/attestations/verax.mdx
+++ b/docs/get-started/tooling/attestations/verax.mdx
@@ -17,7 +17,7 @@ protocol, dapp, or user that wants to use those attestations can easily use and 
 from the different sources that are available in that distribution channel. Examples of some of the 
 integrations currently being built include Clique, GitCoin, Primus Labs and Reclaim Protocol.
 
-To learn more about why we need Verax read this [blog post](https://linea.mirror.xyz/LlLx7IytwRYWQbLlxHr6zoUZjqNQdQ5P95zo3Dcilb0).
+To learn more about why we need Verax, read this [blog post](https://linea.build/blog/introducing-verax-an-on-chain-attestation-registry).
 
 ## Use cases
 
@@ -44,7 +44,7 @@ relevant to them, without the need for a centralized curator.
 ## Proof of Humanity (PoH)
 
 PoH systems ensure that participants in web3 are real humans and not bots. For example, in the 
-[Linea DeFi Voyage](https://linea.mirror.xyz/Y7Co9H1-oV0O51nKYW0eFPZSs2xn--YJ2wRJzEecN6o) these 
+[Linea DeFi Voyage](https://linea.build/blog/welcome-to-the-linea-voyage-defi), these 
 systems were run by our partners such as Gitcoin, Clique, and Aspecta, leveraging the Verax registry. 
 End-users don't directly interact with Verax at any point.
 

--- a/docs/technology/transaction-lifecycle.mdx
+++ b/docs/technology/transaction-lifecycle.mdx
@@ -85,7 +85,7 @@ a two-stage method for developing the proofs that eventually get passed to L1, f
 an **inner proof** and then an **outer proof**.
 
 The inner proof uses a combination of tools, including Arcane and Vortex, to recursively reduce
-the proof size. For a more in-depth look at Linea's inner proof system, see [this article](https://linea.mirror.xyz/B3b1lUK8--UKZ_Qehk7SfOyvdcGbcuoyvNsSukHgOY8).
+the proof size. For a more in-depth look at Linea's inner proof system, see [this article](https://linea.build/blog/the-linea-prover-for-a-very-smart-high-schooler).
 
 Next, the outer proof is generated using the Consensys-maintained library [`gnark`](https://docs.gnark.consensys.net/),
 compressing the proof size even further. The resulting proof is what's known as a zk-SNARK:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,6 +181,10 @@ const config = {
                 href: "https://linea.build/",
               },
               {
+                label: "Blog",
+                href: "https://linea.build/blog",
+              }
+              {
                 label: "Status",
                 href: "https://linea.statuspage.io/",
               },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -183,7 +183,7 @@ const config = {
               {
                 label: "Blog",
                 href: "https://linea.build/blog",
-              }
+              },
               {
                 label: "Status",
                 href: "https://linea.statuspage.io/",


### PR DESCRIPTION
The Linea blog has migrated to Paragraph, hosted at https://linea.build/blog. This PR replaces Mirror links with the articles' new locations. 

Also adds a blog link to the footer.