### PR TITLE
docs: fix typo bridge.mdx

### DIFF
--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -70,7 +70,7 @@ and is required for any transfers:
 - From Linea to Ethereum (L2 -> L1)
 - Involving USDC.
 
-Automatic claiming is seleceted by default for all transfers where it is possible, and manual
+Automatic claiming is selected by default for all transfers where it is possible, and manual
 claiming is automatically applied when necessary. [See below for more information](#claiming).
 
 :::


### PR DESCRIPTION
`seleceted` - `selected` --fixed