### PR TITLE
Update linea-besu locations

### DIFF
--- a/docs/get-started/how-to/run-a-node/linea-besu.mdx
+++ b/docs/get-started/how-to/run-a-node/linea-besu.mdx
@@ -35,7 +35,7 @@ with the blockchain, rather than just following it. Use Linea Besu if:
 
 ### Step 1. Download the Linea Besu package
 
-[Download the latest version](https://github.com/Consensys/linea-besu-package/releases) of the
+[Download the latest version](https://github.com/Consensys/linea-monorepo/releases) of the
 Linea Besu package from the releases page.
 
 :::note
@@ -120,7 +120,7 @@ running.
 
 ### Step 1. Download the relevant `docker-compose.yaml` file
 
-Access the [`/docker` directory](https://github.com/Consensys/linea-besu-package/tree/main/docker) 
+Access the [`/docker` directory](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu-package/docker) 
 in the Linea Besu repository. There are several `.yaml` files here corresponding to Besu profiles. 
 Each profile enables you to run a node with different Linea Besu plugin configurations depending on
 your use case.


### PR DESCRIPTION
Linea Besu has been moved to the Linea monorepo — adjusting the run a node page accordingly. 