### PR TITLE
Fix Typo: Change "informations" to "information" in Comments

### DIFF
--- a/docs/learn/first-dapp.mdx
+++ b/docs/learn/first-dapp.mdx
@@ -267,12 +267,12 @@ const Home: NextPage = () => {
 
   return (
     <div className="bg-background w-full h-screen flex items-center justify-center">
-      {/* Top right corner: Wallet informations */}
+      {/* Top right corner: Wallet information */}
       <div className="absolute top-0 right-0 p-4">
         <ConnectButton />
       </div>
 
-      {/* Bottom left corner: Debug informations */}
+      {/* Bottom left corner: Debug information */}
       <div className="absolute text-xs text-gray-500 bottom-0 left-0 p-4">
         status: {account.status}
         <br />


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the comments of the docs/learn/first-dapp.mdx file. The word "informations" has been replaced with the correct English term "information" in two comment lines. No functional code changes were made; this update is for clarity and proper English usage in documentation comments.
