### PR TITLE
Adjust node size system to remove full Geth node

### DIFF
--- a/docs/get-started/how-to/run-a-node/geth.mdx
+++ b/docs/get-started/how-to/run-a-node/geth.mdx
@@ -53,10 +53,8 @@ Download the genesis file for the relevant network.
 
 ### Step 3. Define disk space volume (optional) \{#disk-space-geth}
 
-Define a volume size appropriate to your expected usage. Geth nodes use:
-
-- Full node: <NodeSize network="mainnet" cluster="linea-prod-eks" pvc="data-linea-geth-full-snapshot-0" />
-- Archive node: <NodeSize network="mainnet" cluster="linea-prod-eks" pvc="data-linea-geth-archive-v2-0" />
+Define a volume size appropriate to your expected usage. A Geth archive node uses:
+<NodeSize network="mainnet" cluster="linea-prod-eks" pvc="data-linea-geth-archive-v2-0" />
 
 <LastUpdated />
 

--- a/linea-node-size/config.json
+++ b/linea-node-size/config.json
@@ -12,11 +12,6 @@
     {
       "network": "mainnet",
       "cluster": "linea-prod-eks",
-      "pvc": "data-linea-geth-full-snapshot-0"
-    },
-    {
-      "network": "mainnet",
-      "cluster": "linea-prod-eks",
       "pvc": "data-linea-geth-archive-v2-0"
     }
   ]


### PR DESCRIPTION
Removes the Geth full node from the system that fetches data from internal observability platform. There is no data available any more for full Geth nodes. 