### PR TITLE
Update Openfort quickstart guide link to the latest documentation

### DIFF
--- a/docs/get-started/tooling/social-login/openfort.mdx
+++ b/docs/get-started/tooling/social-login/openfort.mdx
@@ -8,5 +8,5 @@ the development of games and gamified experiences across its suite of API endpoi
 
 Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/security#smart-contract-accounts) from within the app context and sign blockchain transactions.
 
-Use the [auth quickstart guide](https://www.openfort.xyz/docs/guides/getting-started) to allow 
+Use the [auth quickstart guide](https://www.openfort.io/docs/products/kit/react/quickstart) to allow 
 social login for onboarding users.


### PR DESCRIPTION
Replaced the outdated and non-working link to the Openfort authentication quickstart guide with the current, working URL (https://www.openfort.io/docs/products/kit/react/quickstart) in the documentation. This ensures users are directed to the latest onboarding instructions for social login integration.