### PR TITLE
Add section on CEX transfers

### DIFF
--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -326,6 +326,23 @@ Key:
   Previously the postman fee was applied to automatic claiming transfers from L1 to L2, but is now 
   free.
 
+## Centralized exchange (CEX)
+
+Head to the [Layerswap documentation](https://docs.layerswap.io/user-docs/layerswap-app/transfer-from-cex) 
+for guides on tranferring from CEXs.
+
+An integration with Layerswap enables you to withdraw funds to Linea from one of several supported 
+CEXs. This enables you to move funds from a CEX _to Linea_ even if the CEX doesn't support Linea.
+
+Generally, this process involves:
+1. Configure your source CEX and transfer amount.
+2. Layerswap generates a unique deposit address.
+3. Go to the CEX and transfer the required funds to the deposit address. 
+4. Layerswap handles the cross-chain transfer to Linea.
+
+The process can differ slightly depending on the CEX. The [Layerswap docs](https://docs.layerswap.io/user-docs/layerswap-app/transfer-from-cex
+contain guides specific to each CEX.
+
 ## Buy
 
 Under the "Buy" tab, you'll find the [Onramper](https://onramper.com/) widget, which enables you

--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -332,9 +332,9 @@ Head to the [Layerswap documentation](https://docs.layerswap.io/user-docs/layers
 for guides on tranferring from CEXs.
 
 An integration with Layerswap enables you to withdraw funds to Linea from one of several supported 
-CEXs. This enables you to move funds from a CEX _to Linea_ even if the CEX doesn't support Linea.
+CEXs. This enables you to move funds from a CEX to Linea even if the CEX doesn't support Linea.
 
-Generally, this process involves:
+Generally, this process involves these steps:
 1. Configure your source CEX and transfer amount.
 2. Layerswap generates a unique deposit address.
 3. Go to the CEX and transfer the required funds to the deposit address. 


### PR DESCRIPTION
The [bridge app](https://bridge.linea.build) now supports transfers from CEXs using Layerswap. Adding a brief section to cover this and link to Layerswap docs as the source of truth.