### PR TITLE
Add Chainstack to private RPC providers

### DIFF
--- a/docs/get-started/tooling/node-providers/index.mdx
+++ b/docs/get-started/tooling/node-providers/index.mdx
@@ -32,6 +32,11 @@ image: /img/socialCards/node-providers.jpg
     <td>:white_check_mark:</td>
   </tr>
   <tr>
+    <td><a href="https://chainstack.com/">Chainstack</a></td>
+    <td>:white_check_mark:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+  <tr>
     <td><a href="https://drpc.org/">DRPC</a></td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
@@ -75,10 +80,12 @@ image: /img/socialCards/node-providers.jpg
 
 ## Run your own node
 
-- [Set it up yourself](../../how-to/run-a-node/index.mdx)
-- [One-click deploy with EasyNode](https://app.easy-node.xyz/)
-- [One-click deploy with Mintair](https://mintair.xyz/)
-- [One-click deploy with RapidNode](https://rapidnode.xyz)
+View our [node running guides](../../how-to/run-a-node/index.mdx) to find out how to run a node locally. 
+
+You can also run nodes with the follower providers:
+- [EasyNode](https://app.easy-node.xyz/)
+- [Mintair](https://mintair.xyz/)
+- [RapidNode](https://rapidnode.xyz)
 
 ## Use RPC proxy and caching
 

--- a/docs/get-started/tooling/node-providers/index.mdx
+++ b/docs/get-started/tooling/node-providers/index.mdx
@@ -82,7 +82,7 @@ image: /img/socialCards/node-providers.jpg
 
 View our [node running guides](../../how-to/run-a-node/index.mdx) to find out how to run a node locally. 
 
-You can also run nodes with the follower providers:
+You can also run nodes with the following providers:
 - [EasyNode](https://app.easy-node.xyz/)
 - [Mintair](https://mintair.xyz/)
 - [RapidNode](https://rapidnode.xyz)


### PR DESCRIPTION
[Chainstack now supports Linea](https://chainstack.com/build-better-with-linea/). Updated the page accordingly. 