### PR TITLE
Remove outdated Alchemy Subgraphs tutorials link

### DIFF
--- a/docs/get-started/tooling/data-indexers/alchemy.mdx
+++ b/docs/get-started/tooling/data-indexers/alchemy.mdx
@@ -35,7 +35,6 @@ through a GraphQL API.
 
 - [Subgraphs quickstart](https://docs.alchemy.com/reference/subgraphs-quickstart)
 - [Deploying a Subgraph](https://docs.alchemy.com/reference/deploying-a-subgraph)
-- [Subgraphs tutorials](https://docs.alchemy.com/docs/learn-subgraphs)
 
 ## Help
 


### PR DESCRIPTION
Deleted the outdated "Subgraphs tutorials" link (https://docs.alchemy.com/docs/learn-subgraphs) from the Alchemy Subgraphs documentation section, as the URL is no longer valid. This helps keep the documentation accurate and free of broken links. No other content was changed.