### PR TITLE
Amend JSON-RPC API information

### DIFF
--- a/docs/get-started/build/ethereum-differences.mdx
+++ b/docs/get-started/build/ethereum-differences.mdx
@@ -182,8 +182,3 @@ and include:
 - `linea_getProof`
 - `linea_getTransactionExclusionStatusV1`
 - `eth_sendRawTransaction`
-
-Additionally, the following methods are not supported:
-
-- `eth_newFilter`
-- `eth_newBlockFilter`.


### PR DESCRIPTION
Removes some text that states some methods (`eth_newFilter`, `eth_newBlockFilter`) were unavailable. They are available now. 