### PR TITLE
Fix broken link to BONSAI data storage format documentation

### DIFF
--- a/docs/get-started/how-to/state-recovery.mdx
+++ b/docs/get-started/how-to/state-recovery.mdx
@@ -49,7 +49,7 @@ mode:
     ```toml
     sync-mode="FULL"
     ```
-- [`BONSAI`](https://besu.hyperledger.org/public-networks/reference/cli/options#data-storage-format) 
+- [`BONSAI`](https://besu.hyperledger.org/public-networks/concepts/data-storage-formats) 
 data storage:
     ```toml
     data-storage-format="BONSAI"


### PR DESCRIPTION
Updated the broken link to BONSAI data storage format CLI options to point to the working concepts page that explains the same feature.