### PR TITLE
fix: Update Umbrella Network documentation link

### DIFF
--- a/docs/get-started/tooling/oracles/umbrella.mdx
+++ b/docs/get-started/tooling/oracles/umbrella.mdx
@@ -62,7 +62,8 @@ crucial. Access the data you need, precisely when you need it.
 
 ## Technical documentation
 
-[Visit our technical documentation](https://umbrella-network.readme.io/reference).
+- [Technical documentation](https://umbrella-network.github.io/technical-documentation/umbrella-network/docs/getting-started-1.html)
+- [Reference documentation](https://umbrella-network.readme.io/reference
 
 ## Follow Umbrella Network
 

--- a/docs/get-started/tooling/oracles/umbrella.mdx
+++ b/docs/get-started/tooling/oracles/umbrella.mdx
@@ -62,7 +62,7 @@ crucial. Access the data you need, precisely when you need it.
 
 ## Technical documentation
 
-[Visit our technical documentation](https://umbrella-network.readme.io/docs).
+[Visit our technical documentation](https://umbrella-network.readme.io/reference).
 
 ## Follow Umbrella Network
 


### PR DESCRIPTION
Update the broken documentation link from https://umbrella-network.readme.io/docs to the working https://umbrella-network.readme.io/reference in the Umbrella Network oracle integration documentation