### PR TITLE
Minor fixes to bridging page

### DIFF
--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -164,13 +164,14 @@ accessible via the icon next to settings in the top-right of the widget.
 USDC is handled differently by the native bridge. Since Linea has [native USDC](https://linea.build/blog/lineas-seamless-upgrade-to-native-usdc-a-game-changer-for-onchain-payments), 
 the bridge uses the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol) 
 (CCTP) rather than the [canonical token bridge](../../technology/canonical-token-bridge.mdx) 
-elements that underpin other native bridge transfers.
+that underpins other native bridge transfers.
 
 USDC transfers currently require [manual claiming](#manual-claiming).
 
 CCTP enables faster transfers. USDC transfers in both directions (L1 &rarr; L2 _and_ L2 &rarr; L1) typically 
 complete within 20 minutes, and generally much faster. See the [CCTP documentation](https://developers.circle.com/stablecoins/cctp-getting-started)
-for a fuller explanation.
+for a fuller explanation, or check [here](https://developers.circle.com/cctp/required-block-confirmations) 
+for information on timescales.
 
 ### Claiming
 
@@ -343,11 +344,8 @@ For ETH or ERC-20 tokens:
 - L2 &rarr; L1: 2-16 hours
 - L1 &rarr; L2: ~20 minutes
 
-For USDC:
-- If the app has integrated the Circle [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol), 
-  enabling a faster-than-finality transfer: **~8-20 seconds** for EVM chains
-- Without CCTP (standard transfer, i.e. requires hard finality): **~13-19 minutes** for Ethereum and 
-  L2 chains  
+USDC transfers are considerably faster, as they use the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol).
+See the [USDC section](#bridge-usdc) for further information.
 
 ## Centralized exchange (CEX)
 
@@ -363,7 +361,7 @@ Generally, this process involves these steps:
 3. Go to the CEX and transfer the required funds to the deposit address. 
 4. Layerswap handles the cross-chain transfer to Linea.
 
-The process can differ slightly depending on the CEX. The [Layerswap docs](https://docs.layerswap.io/user-docs/layerswap-app/transfer-from-cex
+The process can differ slightly depending on the CEX. The [Layerswap docs](https://docs.layerswap.io/user-docs/layerswap-app/transfer-from-cex)
 contain guides specific to each CEX.
 
 ## Buy


### PR DESCRIPTION
Remove references to specific timings with USDC, as these are variable and hard to pin down (albeit faster than other assets regardless). Also fixes a broken embedded link. 