### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build
         uses: Consensys/github-actions/docs-build@main

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Case check action
         uses: Consensys/docs-gha/docs-case-check@main

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         file-extensions: [".md", ".mdx"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: LinkCheck
         uses: Consensys/github-actions/docs-link-check@main
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Lint code
         uses: ConsenSys/github-actions/docs-lint-all@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@
       permissions:
         contents: read
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: LinkCheck mdx files
           uses: ConsenSys/github-actions/docs-link-check@main
           with:
@@ -28,7 +28,7 @@
       permissions:
         contents: read
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: LinkCheck md files
           uses: ConsenSys/github-actions/docs-link-check@main
           with:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Vale
         uses: Consensys/github-actions/docs-spelling-check@main

--- a/.github/workflows/update-node-size.yml
+++ b/.github/workflows/update-node-size.yml
@@ -9,7 +9,7 @@ jobs:
   update-data:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Use Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0