### PR TITLE
Remove broken links from block explorers table

### DIFF
--- a/docs/api/reference/linea-estimategas.mdx
+++ b/docs/api/reference/linea-estimategas.mdx
@@ -179,7 +179,7 @@ Where:
 
 The result of the request returns hexadecimal equivalent integers of gas prices in wei. Convert the hexadecimal value into
 decimals to get the wei value. You can use any hexadecimal to decimal converter such as
-[RapidTables](https://www.rapidtables.com/convert/number/hex-to-decimal.html).
+[RapidTables](https://rapidtables.com/convert/number/hex-to-decimal.html).
 
 :::
 

--- a/docs/api/token-api/overview.mdx
+++ b/docs/api/token-api/overview.mdx
@@ -35,10 +35,10 @@ Data is collected and updated from multiple sources:
 
 ### Primary sources
 - Onchain data (smart contract states)
-- [CoinGecko](https://www.coingecko.com/en/api)
+- [CoinGecko](https://coingecko.com/en/api)
 - MetaMask Token & Price API
 - [Dune Analytics](https://dune.com/)
-- [Nile](https://www.nile.build/)
+- [Nile](https://nile.build/)
 - [Moralis](https://moralis.com/)
 
 Please see the [Linea terms of use](https://linea.build/terms-of-service) about third party

--- a/docs/get-started/build/block-explorers.mdx
+++ b/docs/get-started/build/block-explorers.mdx
@@ -43,8 +43,8 @@ As users take actions on the network, there are changes to those accounts and to
         </tr>
         <tr>
           <td>OKLink</td>
-          <td>https://www.oklink.com/linea</td>
-          <td>`https://www.oklink.com/docs/en/#welcome-to-oklink-api`</td>
+          <td>https://oklink.com/linea</td>
+          <td>`https://oklink.com/docs/en/#welcome-to-oklink-api`</td>
         </tr>
         <tr>
           <td>Chainlens</td>

--- a/docs/get-started/build/block-explorers.mdx
+++ b/docs/get-started/build/block-explorers.mdx
@@ -34,12 +34,9 @@ As users take actions on the network, there are changes to those accounts and to
           <td>https://lineaplorer.build/</td>
           <td>`https://lineaplorer.build/api`</td>
         </tr>
-        <tr>
-          <td>L2Scan</td>
-          <td>https://linea.l2scan.co</td>
-          <td>`https://linea.l2scan.co/api/contract`</td>
-        </tr>
-        <tr>
+        {/* It would appear that L2Scan, as of Aug 14, 2025, only supports the Merlin and B2 networks.
+        Removing this entry.*/}
+        <tr> 
           <td>Blockscout</td>
           <td>https://explorer.linea.build</td>
           <td>`https://explorer.linea.build/api`</td>
@@ -54,11 +51,13 @@ As users take actions on the network, there are changes to those accounts and to
           <td>https://linea.chainlens.com/</td>
           <td>`https://linea.chainlens.com/api`</td>
         </tr>
-        <tr>
+        {/* It would appear that, as of August 14, 2025, Socialscan has deprecated the Linea explorer.
+        However, manta.socialscan.io for example still exists; leaving this here for now in case the Linea instance is fixed. */}
+        {/* <tr>
           <td>Socialscan</td>
           <td>https://linea.socialscan.io/</td>
           <td>`https://api.socialscan.io/linea`</td>
-        </tr>
+        </tr> */}
         <tr>
           <td>Linea for Humans</td>
           <td>https://linea.forhumans.app/</td>
@@ -74,11 +73,8 @@ As users take actions on the network, there are changes to those accounts and to
           <td>https://platform.arkhamintelligence.com/</td>
           <td>n/a</td>
         </tr>
-        <tr>
-          <td>NFTScan</td>
-          <td>https://linea.nftscan.com/</td>
-          <td>n/a</td>
-        </tr>
+        {/* As of August 14, 2025, it would appear NFTScan no longer supports Linea.
+        Removing their entry. */}
       </tbody>
     </table>
   </TabItem>

--- a/docs/get-started/build/ethereum-differences.mdx
+++ b/docs/get-started/build/ethereum-differences.mdx
@@ -101,8 +101,8 @@ major milestones, forks, and updates to the blockchain.
 _Consult the Ethereum Foundation's [Opcode Reference](https://ethereum.org/en/developers/docs/evm/opcodes/) 
 for more._
 
-[Evmdiff](https://www.evmdiff.com) is also a useful resource for comparing Linea with Ethereum, and 
-[evm.codes](https://www.evm.codes/) is useful for information about specific opcodes on Ethereum.
+[Evmdiff](https://evmdiff.com) is also a useful resource for comparing Linea with Ethereum, and 
+[evm.codes](https://evm.codes/) is useful for information about specific opcodes on Ethereum.
 
 ## Precompiles
 

--- a/docs/get-started/build/quickstart/app.mdx
+++ b/docs/get-started/build/quickstart/app.mdx
@@ -29,7 +29,7 @@ A wallet that can connect to Linea Sepolia. We recommend [MetaMask](https://meta
 There are many frameworks out there for building web apps. We're going to focus on [Next.js](https://nextjs.org/),
 a React framework.
 
-Conveniently, [Dynamic](https://www.dynamic.xyz/) have created the `create-dynamic-app` which 
+Conveniently, [Dynamic](https://dynamic.xyz/) have created the `create-dynamic-app` which 
 quickly creates a web3-enabled Next.js app which already has important packages like [Wagmi](../../tooling/libraries/wagmi.mdx) 
 and [Viem](../../tooling/libraries/viem.mdx) (which Wagmi depends on) installed.
 
@@ -86,7 +86,7 @@ the advantage of allowing you to enable other sign-in methods and embedded walle
 minor changes on the Dynamic dashboard. This isn't something we're going cover here, but it's 
 worth considering for your own app. 
 
-To set up the widget, you'll need to sign up for a free [Dynamic](https://www.dynamic.xyz/get-started) 
+To set up the widget, you'll need to sign up for a free [Dynamic](https://dynamic.xyz/get-started) 
 account, which enables you to access your own Dynamic dashboard. You can sign in with your wallet, 
 so you don't have to worry about handing over personal information.
 

--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -162,7 +162,7 @@ accessible via the icon next to settings in the top-right of the widget.
 ### Bridge USDC
 
 USDC is handled differently by the native bridge. Since Linea has [native USDC](https://linea.build/blog/lineas-seamless-upgrade-to-native-usdc-a-game-changer-for-onchain-payments), 
-the bridge uses the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol) 
+the bridge uses the [Cross-Chain Transfer Protocol](https://circle.com/cross-chain-transfer-protocol) 
 (CCTP) rather than the [canonical token bridge](../../technology/canonical-token-bridge.mdx) 
 that underpins other native bridge transfers.
 
@@ -344,7 +344,7 @@ For ETH or ERC-20 tokens:
 - L2 &rarr; L1: 2-16 hours
 - L1 &rarr; L2: ~20 minutes
 
-USDC transfers are considerably faster, as they use the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol).
+USDC transfers are considerably faster, as they use the [Cross-Chain Transfer Protocol](https://circle.com/cross-chain-transfer-protocol).
 See the [USDC section](#bridge-usdc) for further information.
 
 ## Centralized exchange (CEX)

--- a/docs/get-started/how-to/deploy-smart-contract/atlas.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/atlas.mdx
@@ -15,14 +15,14 @@ Atlas is a browser-based IDE with an integrated AI assistant that allows you to 
 You can write tests for your contract (Foundry is built-in), and ask the AI to help you write your
 contracts, deployment scripts, and more.
 
-View [the tutorial](https://www.youtube.com/embed/mnyYizj3l_8?si=eVXHsWWZxlg9EU4D), which shows how to build a
+View [the tutorial](https://youtube.com/embed/mnyYizj3l_8?si=eVXHsWWZxlg9EU4D), which shows how to build a
 DEX from scratch on Linea. You can also [open and run the tutorial](https://app.atlaszk.com/projects?template=https://github.com/sameesiddiqui/LilDex&open=LilDex.sol) in one click.
 
 <div class="center-container">
     <div class="video-container">
       <iframe
         class="video-iframe"
-        src="https://www.youtube.com/embed/mnyYizj3l_8?si=eVXHsWWZxlg9EU4D"
+        src="https://youtube.com/embed/mnyYizj3l_8?si=eVXHsWWZxlg9EU4D"
         title="How to build a DEX (like uniswap) in 1 smart contract"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen></iframe>

--- a/docs/get-started/how-to/deploy-smart-contract/cookbook.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/cookbook.mdx
@@ -6,7 +6,7 @@ image: /img/socialCards/cookbookdev.jpg
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
-[Cookbook.dev](https://www.cookbook.dev/?utm=lineadocs) is an open-source smart contract registry where
+[Cookbook.dev](https://cookbook.dev/?utm=lineadocs) is an open-source smart contract registry where
 developers can find solidity primitives, libraries, and smart contracts for protocols. It provides an easy and
 fast way to develop smart contracts by integrating with a variety of blockchain-native developer tools.
 
@@ -15,7 +15,7 @@ Cookbook's no-code deploy and using Cookbook with Remix, Hardhat and Foundry.
 
 ## Search Cookbook's smart contract registry
 
-Navigate to [cookbook.dev/chains/Linea](https://www.cookbook.dev/chains/Linea?utm=lineadocs) and explore **Protocols** on Linea, or search for specific smart contracts in the search bar.
+Navigate to [cookbook.dev/chains/Linea](https://cookbook.dev/chains/Linea?utm=lineadocs) and explore **Protocols** on Linea, or search for specific smart contracts in the search bar.
 
 <div class="center-container">
   <div class="img-large">
@@ -56,7 +56,7 @@ Import verified smart contract code into Cookbook to fork, learn about, or build
 
 ## Deploy a smart contract without coding
 
-Choose **No-Code Deploy** on select (usually simpler) smart contracts on [Cookbook](https://www.cookbook.dev/contracts/simple-token?utm=lineadocs).
+Choose **No-Code Deploy** on select (usually simpler) smart contracts on [Cookbook](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
 
 <div class="center-container">
   <div class="img-large">
@@ -134,9 +134,9 @@ contracts in the Remix IDE.
 
 ## Deploy your smart contract with Hardhat
 
-After finding the smart contract or protocol you want to work with in [Cookbook](https://www.cookbook.dev/?utm=lineadocs),
+After finding the smart contract or protocol you want to work with in [Cookbook](https://cookbook.dev/?utm=lineadocs),
 select the **Download Source** option and select **Hardhat** to download the contract boilerplate. For
-this example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://www.cookbook.dev/contracts/simple-token?utm=lineadocs).
+this example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
 
 
 ### Compile the smart contract
@@ -240,9 +240,9 @@ on the [Linea Mainnet block explorer](https://lineascan.build/).
 
 ## Deploy your smart contract with Foundry
 
-After finding the smart contract or protocol you want to work with in [Cookbook](https://www.cookbook.dev/chains/Linea?utm=lineadocs),
+After finding the smart contract or protocol you want to work with in [Cookbook](https://cookbook.dev/chains/Linea?utm=lineadocs),
 select the **Download Source** option and select **Foundry** to download the contract boilerplate. For this
-example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://www.cookbook.dev/contracts/simple-token?utm=lineadocs).
+example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
 
 **Prerequisites**:
 

--- a/docs/get-started/how-to/deploy-smart-contract/foundry.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/foundry.mdx
@@ -12,7 +12,7 @@ In this quickstart, we'll create a basic [Foundry](https://book.getfoundry.sh/) 
     <div class="video-container">
       <iframe
         class="video-iframe"
-        src="https://www.youtube.com/embed/nvRvlel3iTQ?si=no67QFjDpeyyfwsG"
+        src="https://youtube.com/embed/nvRvlel3iTQ?si=no67QFjDpeyyfwsG"
         title="How to deploy a smart contract on Linea with Foundry"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen></iframe>

--- a/docs/get-started/how-to/deploy-smart-contract/hardhat.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/hardhat.mdx
@@ -14,7 +14,7 @@ walkthrough:
     <div class="video-container">
       <iframe
         class="video-iframe"
-        src="https://www.youtube.com/embed/aECCf2P9pgw?si=fV5n0nySuUITbLm8"
+        src="https://youtube.com/embed/aECCf2P9pgw?si=fV5n0nySuUITbLm8"
         title="How to deploy a smart contract on Linea with Hardhat"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen></iframe>

--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -21,9 +21,9 @@ See our [support guide to getting a Linea Names domain](https://support.linea.bu
 
 ## Other faucets
 
-- [Infura](https://www.infura.io/faucet/linea)
+- [Infura](https://infura.io/faucet/linea)
 - [GetBlock](https://getblock.io/faucet/linea-sepolia/)
-- [HackQuest](https://www.hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://www.hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
+- [HackQuest](https://hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
 
 Alternatively, [use the Linea native bridge to bridge testnet ETH between Sepolia and Linea Sepolia](../how-to/bridge.mdx).
 
@@ -31,5 +31,5 @@ Alternatively, [use the Linea native bridge to bridge testnet ETH between Sepoli
 
 Testnet ERC-20 tokens may be useful for development purposes.
 
-One method is to use the [OKX faucet](https://www.okx.com/xlayer/faucet/sepoliafaucet), which 
+One method is to use the [OKX faucet](https://okx.com/xlayer/faucet/sepoliafaucet), which 
 enables you to select from a handful of different testnet ERC-20 tokens.

--- a/docs/get-started/how-to/poh-api.mdx
+++ b/docs/get-started/how-to/poh-api.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 Proof of Humanity was originally created to verify community members taking part in the Linea Voyage. 
 It aggregates many attestation providers, giving users many options (onchain transaction history, 
-biometrics, zero-knowledge KYC, etc.) to demonstrate their personhood, using the [Verax Attestation Registry](https://www.ver.ax/) 
+biometrics, zero-knowledge KYC, etc.) to demonstrate their personhood, using the [Verax Attestation Registry](https://ver.ax/) 
 under the hood.
 
 Even though PoH was originally created for our own needs, the API is publicly available to the 

--- a/docs/get-started/how-to/run-a-node/besu.mdx
+++ b/docs/get-started/how-to/run-a-node/besu.mdx
@@ -115,7 +115,7 @@ The Besu Docker image doesn't run on Windows.
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
 running.
 
 ### Step 1. Download configuration files
@@ -154,7 +154,7 @@ In the `docker-compose.yaml` file, update the `--p2p-host` command to include yo
 
 :::tip
 
-You can use [this page](https://www.whatismyip.com/) to find your public IP address.
+You can use [this page](https://whatismyip.com/) to find your public IP address.
 
 :::
 

--- a/docs/get-started/how-to/run-a-node/erigon.mdx
+++ b/docs/get-started/how-to/run-a-node/erigon.mdx
@@ -150,7 +150,7 @@ The Erigon node will attempt to find peers to begin synchronizing and to downloa
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
 running.
 
 ### Step 1. Download configuration files

--- a/docs/get-started/how-to/run-a-node/geth.mdx
+++ b/docs/get-started/how-to/run-a-node/geth.mdx
@@ -164,7 +164,7 @@ otherwise, you might not be connected to the Linea network.
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
 running.
 
 ### Step 1. Download configuration files

--- a/docs/get-started/how-to/run-a-node/linea-besu.mdx
+++ b/docs/get-started/how-to/run-a-node/linea-besu.mdx
@@ -115,7 +115,7 @@ The node will attempt to find peers to begin synchronizing and to download the w
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
 running.
 
 ### Step 1. Download the relevant `docker-compose.yaml` file
@@ -150,7 +150,7 @@ In the `.yaml` file you downloaded, adjust the `--p2p-host` command with your pu
 
 :::tip
 
-You can use [this page](https://www.whatismyip.com/) to find your public IP address.
+You can use [this page](https://whatismyip.com/) to find your public IP address.
 
 :::
 

--- a/docs/get-started/how-to/run-a-node/nethermind.mdx
+++ b/docs/get-started/how-to/run-a-node/nethermind.mdx
@@ -70,7 +70,7 @@ state.
 
 ### Prerequisites
 
-Download and install [Docker](https://www.docker.com/products/docker-desktop/) and ensure it is 
+Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
 running throughout.
 
 ### Step 1. Download Docker image

--- a/docs/get-started/tooling/account-abstraction/biconomy.mdx
+++ b/docs/get-started/tooling/account-abstraction/biconomy.mdx
@@ -9,4 +9,4 @@ solution to reduce friction in your dapp: it eases onboarding for new users and 
 transaction complexities that your users face on a daily basis. This is enabled by using Smart 
 Contract Wallets (SCW) built on top of our multi-chain Relayer Infrastructure.
 
-Find out more about Biconomy [here](https://www.biconomy.io/).
+Find out more about Biconomy [here](https://biconomy.io/).

--- a/docs/get-started/tooling/account-abstraction/oklink.mdx
+++ b/docs/get-started/tooling/account-abstraction/oklink.mdx
@@ -3,7 +3,7 @@ title: OKLink
 image: /img/socialCards/oklink.jpg
 ---
 
-[OKLink](https://www.oklink.com/) is a one-stop blockchain data platform covering a wide range of 
+[OKLink](https://oklink.com/) is a one-stop blockchain data platform covering a wide range of 
 onchain metrics. 
 
 OKLink provides onchain information, prioritizing accessibility by simplifying insights for easy 
@@ -12,10 +12,10 @@ and other onchain data covering 40+ chains.
 
 ## Account abstraction services available through OKLink
 
-1. [View UserOps details](https://www.oklink.com/linea/tx/uop/0x6c8f68613afffeb70ea31f145dc416d18540a32a0e00e04df4c94018d666fde2): 
+1. [View UserOps details](https://oklink.com/linea/tx/uop/0x6c8f68613afffeb70ea31f145dc416d18540a32a0e00e04df4c94018d666fde2): 
 including the AA address initiating the transaction, paymaster information, and details about using 
 ERC-20 tokens for transaction fees.
-2. [View the transaction list for ERC-4337](https://www.oklink.com/linea/address/0x7fb5aa2a66bd08c61956bd29df4da48cc63d66d9/aa): 
+2. [View the transaction list for ERC-4337](https://oklink.com/linea/address/0x7fb5aa2a66bd08c61956bd29df4da48cc63d66d9/aa): 
 can view all ERC-4337 transactions related to the address.
-3. [View the details page of the Entry Point](https://www.oklink.com/linea/address/0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789/contract): 
+3. [View the details page of the Entry Point](https://oklink.com/linea/address/0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789/contract): 
 supports viewing transactions, contract details, and performing contract read and write operations.

--- a/docs/get-started/tooling/account-abstraction/openfort.mdx
+++ b/docs/get-started/tooling/account-abstraction/openfort.mdx
@@ -12,5 +12,5 @@ development without worrying about private key management, the account model or 
 
 Openfort is powered by [ERC-6551](https://eips.ethereum.org/EIPS/eip-6551) and [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337).
 
-[Visit the docs](https://www.openfort.xyz/docs) to get started with Openfort by deploying a smart 
+[Visit the docs](https://openfort.xyz/docs) to get started with Openfort by deploying a smart 
 account on Linea and creating your first transaction.

--- a/docs/get-started/tooling/ai/spheron.mdx
+++ b/docs/get-started/tooling/ai/spheron.mdx
@@ -3,7 +3,7 @@ title: Spheron network
 image: /img/socialCards/spheron-network.jpg
 ---
 
-[Spheron Network](https://www.spheron.network/) is a decentralized compute provider and marketplace 
+[Spheron Network](https://spheron.network/) is a decentralized compute provider and marketplace 
 that offers scalable and secure infrastructure solutions. It aims to create a decentralized GPU 
 exchange for global AI workloads, enabling projects from DeFi to AI to access compute solutions at 
 lower costs compared to traditional providers. Spheron focuses on simplicity, usability, and support

--- a/docs/get-started/tooling/analytics/arkham.mdx
+++ b/docs/get-started/tooling/analytics/arkham.mdx
@@ -12,6 +12,6 @@ Access Arkham [here](https://platform.arkhamintelligence.com/).
 References:
 
 - [Platform guide](https://arkhamintelligence.notion.site/Arkham-eb1213a42ae24fe39643bd737f4ae78e)
-- [Whitepaper](https://www.arkhamintelligence.com/whitepaper)
+- [Whitepaper](https://arkhamintelligence.com/whitepaper)
 - [Codex](https://codex.arkhamintelligence.com/)
-- [Demos](https://www.youtube.com/@arkhamintel)
+- [Demos](https://youtube.com/@arkhamintel)

--- a/docs/get-started/tooling/analytics/cookie3.mdx
+++ b/docs/get-started/tooling/analytics/cookie3.mdx
@@ -3,7 +3,7 @@ title: Cookie3
 image: /img/socialCards/cookie3.jpg
 ---
 
-[Cookie3](https://www.cookie3.co/) is like Google Analytics, but for web3. It allows you to 
+[Cookie3](https://cookie3.co/) is like Google Analytics, but for web3. It allows you to 
 analyze every visitor and wallet on your website, including campaigns and customer journey 
 exploration features.
 
@@ -36,5 +36,5 @@ events, product launches, and giveaways.
 
 ## Additional resources
 
-1. [One-minute YouTube explainer](https://www.youtube.com/@Cookie3_com)
+1. [One-minute YouTube explainer](https://youtube.com/@Cookie3_com)
 2. [Documentation](https://docs.cookie3.co/)

--- a/docs/get-started/tooling/analytics/dune.mdx
+++ b/docs/get-started/tooling/analytics/dune.mdx
@@ -31,7 +31,7 @@ Here are some resources to help you learn more about Dune Analytics:
 tutorials on using Dune Analytics.
 - [API Docs](https://docs.dune.com/api): The API documentation provides detailed information on how 
 to access blockchain data programmatically using Dune's API.
-- [YouTube](https://www.youtube.com/@dunecom) : The Dune YouTube channel features video tutorials 
+- [YouTube](https://youtube.com/@dunecom) : The Dune YouTube channel features video tutorials 
 and demos of the platform.
 - [Blog](https://dune.com/blog): The Dune blog features articles, case studies, and updates about 
 the platform.

--- a/docs/get-started/tooling/attestations/primus.mdx
+++ b/docs/get-started/tooling/attestations/primus.mdx
@@ -3,7 +3,7 @@ title: Primus
 image: /img/socialCards/primus.jpg
 ---
 
-[Primus](https://www.primuslabs.xyz/) is a cryptography-based attestation protocol to bring all 
+[Primus](https://primuslabs.xyz/) is a cryptography-based attestation protocol to bring all 
 internet data into smart contracts. Primus relies heavily on cryptography to minimize trust, 
 and enables end users to prove the correctness of their personal web data in a privacy-preserving 
 manner.
@@ -61,6 +61,6 @@ Learn more and start using PADO!
 
 - [X](https://x.com/primus_labs)
 - [Discord](https://discord.com/invite/pdrNxRrApX)
-- [Website](https://www.primuslabs.xyz/)
+- [Website](https://primuslabs.xyz/)
 - [Medium](https://medium.com/@primuslabs)
 - [Github](https://github.com/primus-labs)

--- a/docs/get-started/tooling/contracts-templates/cookbook.mdx
+++ b/docs/get-started/tooling/contracts-templates/cookbook.mdx
@@ -3,12 +3,12 @@ title: Cookbook.dev
 image: /img/socialCards/cookbookdev.jpg
 ---
 
-[Cookbook.dev](https://www.cookbook.dev/?utm=lineadocs) is an open-source smart contract registry 
+[Cookbook.dev](https://cookbook.dev/?utm=lineadocs) is an open-source smart contract registry 
 where developers can find Solidity primitives, libraries, and smart contracts for protocols.
 
 ## Search the smart contract registry
 
-Navigate to [cookbook.dev/chains/Linea](https://www.cookbook.dev/chains/Linea?utm=lineadocs) and 
+Navigate to [cookbook.dev/chains/Linea](https://cookbook.dev/chains/Linea?utm=lineadocs) and 
 explore protocols on Linea, or search for specific smart contracts in the search bar.
 
 <div class="center-container">

--- a/docs/get-started/tooling/cross-chain/arcana.mdx
+++ b/docs/get-started/tooling/cross-chain/arcana.mdx
@@ -30,7 +30,7 @@ Unified balance allows users to spend the consolidated multi-chain balance of su
 
 ## Linea integration
 
-To enable chain abstraction on Linea, web3 apps must install and integrate with the [Arcana Chain Abstraction SDK](https://www.npmjs.com/package/@arcana/ca-sdk). See the [quick start guide](https://docs.arcana.network/quick-start/ca-quick-start/) and the CA [API](https://ca-sdk-ref-guide.netlify.app/) for details. Check out web3 app [integration examples](https://docs.arcana.network/ca/examples/). 
+To enable chain abstraction on Linea, web3 apps must install and integrate with the [Arcana Chain Abstraction SDK](https://npmjs.com/package/@arcana/ca-sdk). See the [quick start guide](https://docs.arcana.network/quick-start/ca-quick-start/) and the CA [API](https://ca-sdk-ref-guide.netlify.app/) for details. Check out web3 app [integration examples](https://docs.arcana.network/ca/examples/). 
 
 ## CA SDK demonstration
 

--- a/docs/get-started/tooling/cross-chain/axelar.mdx
+++ b/docs/get-started/tooling/cross-chain/axelar.mdx
@@ -82,7 +82,7 @@ source chain, via the Axelar network, to the destination chain.
 ## Linea-Axelar example
 
 For a full end-to-end example of a Linea-Axelar integration, check out our 
-[video walkthrough](https://www.youtube.com/watch?v=-KgJZmq8Umc&t=1s) of the 
+[video walkthrough](https://youtube.com/watch?v=-KgJZmq8Umc&t=1s) of the 
 process. The complementary code can be found [here](https://github.com/Olanetsoft/linea-interchain-workshop-with-axelar).
 
 ## Axelar use cases
@@ -98,7 +98,7 @@ interchain applications that can be built on top of Axelar:
    centralized exchanges or multiple different exchanges to swap tokens across 
    chains.
 
-2. Interchain lending (e.g. [Prime Protocol](https://www.primeprotocol.xyz/))
+2. Interchain lending (e.g. [Prime Protocol](https://primeprotocol.xyz/))
 
    - A chain-agnostic prime brokerage that allows users to deposit assets from 
    any connected chain and use their aggregate value as collateral for loans on 

--- a/docs/get-started/tooling/cross-chain/shortcuts.mdx
+++ b/docs/get-started/tooling/cross-chain/shortcuts.mdx
@@ -70,12 +70,12 @@ the transaction involves an Onthis Shortcut, and provides a breakdown of:
 - A description of what will happen once you send funds to the Shortcut. 
 
 Install the Snap by heading either to the [Snaps Directory](https://snaps.metamask.io/snap/npm/onthis-snap/) 
-or the [dedicated Onthis page](https://www.onthis.xyz/snap), and then hitting 
+or the [dedicated Onthis page](https://onthis.xyz/snap), and then hitting 
 'Add to MetaMask'.
 
 ## Fees
 
-Shortcuts are provided by [onthis.xyz](https://www.onthis.xyz/) and are built on 
+Shortcuts are provided by [onthis.xyz](https://onthis.xyz/) and are built on 
 top of [Across](https://across.to/). Both services charge users a fee on the 
 origin network. This fee covers the bridging costs and automation costs and is 
 shared between the two providers. The fee is calculated as a percentage of the 
@@ -161,7 +161,7 @@ ENS name.
 
 Shortcuts can be upgraded by the creator. An attacker can upgrade the contract 
 and change its behavior. Linea addresses this risk by requiring trusted creators 
-(like the [onthis.xyz](https://www.onthis.xyz/) team) to hold the owner keys in 
+(like the [onthis.xyz](https://onthis.xyz/) team) to hold the owner keys in 
 a secure multisig or asking the creators to hand over the ownership of the 
 contracts to the Linea multisig.
 

--- a/docs/get-started/tooling/data-indexers/arkham.mdx
+++ b/docs/get-started/tooling/data-indexers/arkham.mdx
@@ -13,6 +13,6 @@ Access Arkham [here](https://platform.arkhamintelligence.com/).
 Resources:
 
 - [Platform guide](https://arkhamintelligence.notion.site/Arkham-eb1213a42ae24fe39643bd737f4ae78e)
-- [Whitepaper](https://www.arkhamintelligence.com/whitepaper)
+- [Whitepaper](https://arkhamintelligence.com/whitepaper)
 - [Codex](https://codex.arkhamintelligence.com/)
-- [Demos](https://www.youtube.com/@arkhamintel)
+- [Demos](https://youtube.com/@arkhamintel)

--- a/docs/get-started/tooling/data-indexers/covalent.mdx
+++ b/docs/get-started/tooling/data-indexers/covalent.mdx
@@ -117,7 +117,7 @@ There are four primary developer tools for using the APIs:
 3.  [GoldRush UI Kit](https://github.com/covalenthq/goldrush-kit/?utm_source=linea&utm_medium=partner-docs) -
     React components for your dApp frontend.
 
-        [![GoldRush Component Example](https://www.datocms-assets.com/86369/1711147954-goldrush_wallet_ui_example.png)](https://goldrush-wallet-portfolio-ui.vercel.app/dashboard/balance/0xfc43f5f9dd45258b3aff31bdbe6561d97e8b71de/transfers/eth-mainnet/0xf8c3527cc04340b208c854e985240c02f7b7793f)
+        [![GoldRush Component Example](https://datocms-assets.com/86369/1711147954-goldrush_wallet_ui_example.png)](https://goldrush-wallet-portfolio-ui.vercel.app/dashboard/balance/0xfc43f5f9dd45258b3aff31bdbe6561d97e8b71de/transfers/eth-mainnet/0xf8c3527cc04340b208c854e985240c02f7b7793f)
 
 4.  [GoldRush Decoder](https://github.com/covalenthq/goldrush-decoder/?utm_source=linea&utm_medium=partner-docs) -
     decode any raw event logs into human-readable structured data.

--- a/docs/get-started/tooling/data-indexers/dune.mdx
+++ b/docs/get-started/tooling/data-indexers/dune.mdx
@@ -43,7 +43,7 @@ Here are some resources to help you learn more about Dune Analytics:
   information on how to access blockchain data programmatically using Dune's
   API.
 
-- [YouTube](https://www.youtube.com/@dunecom) : The Dune YouTube channel
+- [YouTube](https://youtube.com/@dunecom) : The Dune YouTube channel
   features video tutorials and demos of the platform.
 
 - [Blog](https://dune.com/blog): The Dune blog features articles, case studies,

--- a/docs/get-started/tooling/data-indexers/moralis.mdx
+++ b/docs/get-started/tooling/data-indexers/moralis.mdx
@@ -94,4 +94,4 @@ Moralis real-time data APIs can be used to build:
 
 - [Sign up for a free account](https://moralis.io/?utm_source=linea-docs&utm_medium=partner-docs)
 - Visit the [Moralis documentation](https://docs.moralis.io/?utm_source=linea-docs&utm_medium=partner-docs)
-- Check out our [tutorials on Youtube](https://www.youtube.com/@MoralisWeb3).
+- Check out our [tutorials on Youtube](https://youtube.com/@MoralisWeb3).

--- a/docs/get-started/tooling/data-indexers/scopescan.mdx
+++ b/docs/get-started/tooling/data-indexers/scopescan.mdx
@@ -138,6 +138,6 @@ Scopescan allows the Linea community to do the following:
 
 ## Reference links:
 
-- [Scopescan](https://www.scopescan.ai/home?network=linea)
+- [Scopescan](https://scopescan.ai/home?network=linea)
 - [Scopescan docs](https://docs.scopescan.ai)
-- [Scopescan on 0xScope](https://www.0xscope.com/scopeScan)
+- [Scopescan on 0xScope](https://0xscope.com/scopeScan)

--- a/docs/get-started/tooling/gas/blocknative.mdx
+++ b/docs/get-started/tooling/gas/blocknative.mdx
@@ -5,7 +5,7 @@ image: /img/socialCards/blocknative.jpg
 
 Blocknative offers APIs to help developers and users estimate fees on Linea. The estimates are based 
 on real-time Linea data and ML modeling to accurately and consistently estimate Linea transaction 
-fees. Linea fee estimation is also available in the Blocknative [browser extension](https://www.blocknative.com/gas-extension).
+fees. Linea fee estimation is also available in the Blocknative [browser extension](https://blocknative.com/gas-extension).
 
 ## Use the Blocknative Gas API
 

--- a/docs/get-started/tooling/libraries/ape.mdx
+++ b/docs/get-started/tooling/libraries/ape.mdx
@@ -8,7 +8,7 @@ and interact with smart contracts, all in one command line session. With a
 modular plugin system, Ape supports multiple contract languages and chains,
 including Linea.
 
-Ape is built by [ApeWorX LTD](https://www.apeworx.io/).
+Ape is built by [ApeWorX LTD](https://apeworx.io/).
 
 The Linea team developed the [plugin to add Linea support to Ape](https://github.com/Consensys/ape-linea).
 

--- a/docs/get-started/tooling/libraries/web3j.mdx
+++ b/docs/get-started/tooling/libraries/web3j.mdx
@@ -4,7 +4,7 @@ description: A web3 Java library that supports Linea-specific RPC methods.
 image: /img/socialCards/web3j.jpg
 ---
 
-[Web3j](https://www.web3labs.com/web3j-sdk) is a lightweight, modular, and open-source Java library 
+[Web3j](https://web3labs.com/web3j-sdk) is a lightweight, modular, and open-source Java library 
 designed for EVM blockchains. Since Linea is EVM-equivalent, it is completely compatible with 
 Web3j. 
 
@@ -14,5 +14,5 @@ Web3j supports Linea-specific RPC methods:
 - [`linea_getProof`](../../../api/reference/linea-getproof.mdx) can be called using `lineaGetProof()`
 - [`linea_getTransactionExclusionStatusV1`](../../../api/reference/linea-gettransactionexclusionstatusv1.mdx) can be called using `lineaGetTransactionExclusionStatusV1()`.
 
-To get started, visit the [documentation](https://docs.web3j.io/latest/quickstart/), or [read more](https://www.lfdecentralizedtrust.org/blog/full-linea-rpc-apis-support-in-web3j) 
+To get started, visit the [documentation](https://docs.web3j.io/latest/quickstart/), or [read more](https://lfdecentralizedtrust.org/blog/full-linea-rpc-apis-support-in-web3j) 
 about using the Linea-specific RPC methods.

--- a/docs/get-started/tooling/node-providers/index.mdx
+++ b/docs/get-started/tooling/node-providers/index.mdx
@@ -12,12 +12,12 @@ image: /img/socialCards/node-providers.jpg
     <th>WebSocket</th>
   </tr>
   <tr>
-    <td><a href="https://www.alchemy.com/">Alchemy</a></td>
+    <td><a href="https://alchemy.com/">Alchemy</a></td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
   </tr>
   <tr>
-    <td><a href="https://www.ankr.com/rpc/">ANKR</a></td>
+    <td><a href="https://ankr.com/rpc/">ANKR</a></td>
     <td>:x:</td>
     <td>:white_check_mark:</td>
   </tr>
@@ -52,7 +52,7 @@ image: /img/socialCards/node-providers.jpg
     <td>:x:</td>
   </tr>
   <tr>
-    <td><a href="https://www.infura.io/">Infura</a></td>
+    <td><a href="https://infura.io/">Infura</a></td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
   </tr>
@@ -67,7 +67,7 @@ image: /img/socialCards/node-providers.jpg
     <td>:x:</td>
   </tr>
   <tr>
-    <td><a href="https://www.quicknode.com">QuickNode</a></td>
+    <td><a href="https://quicknode.com">QuickNode</a></td>
     <td>:x:</td>
     <td>:white_check_mark:</td>
   </tr>

--- a/docs/get-started/tooling/oracles/api3.mdx
+++ b/docs/get-started/tooling/oracles/api3.mdx
@@ -178,4 +178,4 @@ Here are some additional developer resources:
 - [OEV docs](https://docs.api3.org/oev-searchers/)
 - [Github](https://github.com/api3dao/)
 - [Medium](https://medium.com/api3)
-- [YouTube](https://www.youtube.com/API3DAO)
+- [YouTube](https://youtube.com/API3DAO)

--- a/docs/get-started/tooling/oracles/dia.mdx
+++ b/docs/get-started/tooling/oracles/dia.mdx
@@ -5,7 +5,7 @@ image: /img/socialCards/dia.jpg
 
 ## Request a custom oracle
 
-[DIA](https://www.diadata.org/) offers customizable oracles tailored to each
+[DIA](https://diadata.org/) offers customizable oracles tailored to each
 dapp's needs. Each oracle can be customized in several ways, including data
 sources, data cleansing filters, pricing and computational methodologies, update
 mechanisms and more. This ensures that the data and oracle remain robust and
@@ -101,4 +101,4 @@ to see all API endpoints.
 - [Discord](https://go.diadata.org/discord-menu)
 - [Website](https://diadata.org/)
 - [Docs](https://docs.diadata.org/)
-- [Explore data](https://www.diadata.org/app/)
+- [Explore data](https://diadata.org/app/)

--- a/docs/get-started/tooling/oracles/pyth.mdx
+++ b/docs/get-started/tooling/oracles/pyth.mdx
@@ -46,7 +46,7 @@ atomically updates the price and then interacts with an application powered by
 Pyth, the price that the application will read will be equal to the price the
 user submitted.
 
-[Read an in-depth explanation from one of our contributors, Jayant](https://www.youtube.com/watch?v=qdwrs23Qc9g), and [read more about on-demand updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand).
+[Read an in-depth explanation from one of our contributors, Jayant](https://youtube.com/watch?v=qdwrs23Qc9g), and [read more about on-demand updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand).
 
 ## Use price feeds
 

--- a/docs/get-started/tooling/oracles/umbrella.mdx
+++ b/docs/get-started/tooling/oracles/umbrella.mdx
@@ -12,7 +12,7 @@ aggregating large volumes of data at scale. Secured by a network of
 decentralized community validators, Umbrella can provide any data that you need 
 when you need it.
 
-Umbrella can create any custom price feed for your project. [Contact us](https://www.umb.network/contact#form).
+Umbrella can create any custom price feed for your project. [Contact us](https://umb.network/contact#form).
 
 ## Solutions
 
@@ -41,7 +41,7 @@ These are the price feeds available on Linea Mainnet and their configuration:
 > You can expect some delays on the update of the price feeds on chain as 
 validators on the Umbrella Network complete their upgrades.
 
-If you need another price feed, [contact us](https://www.umb.network/contact#form).
+If you need another price feed, [contact us](https://umb.network/contact#form).
 
 Check our technical documentation at the bottom of this page to get the 
 Umbrella's Registry contract address on Linea.
@@ -67,4 +67,4 @@ crucial. Access the data you need, precisely when you need it.
 
 ## Follow Umbrella Network
 
-[Discord](https://discord.com/invite/AHHSM7Bks2) | [Twitter](https://x.com/UmbNetwork) | [Announcements](https://t.me/umbnetannouncement) | [Website](https://www.umb.network/) | [Governance](https://umb.network/community)
+[Discord](https://discord.com/invite/AHHSM7Bks2) | [Twitter](https://x.com/UmbNetwork) | [Announcements](https://t.me/umbnetannouncement) | [Website](https://umb.network/) | [Governance](https://umb.network/community)

--- a/docs/get-started/tooling/permanent-data/irys/irys-querying.mdx
+++ b/docs/get-started/tooling/permanent-data/irys/irys-querying.mdx
@@ -15,7 +15,7 @@ for transactions by:
 ## GraphQL clients
 
 You can query using an HTTP library like `fetch` or `axios`, or use specialized 
-clients like [Apollo Client](https://www.apollographql.com/) or [urql](https://formidable.com/open-source/urql/).
+clients like [Apollo Client](https://apollographql.com/) or [urql](https://formidable.com/open-source/urql/).
 
 ## Endpoint
 
@@ -155,7 +155,7 @@ query getByTimestamp {
 :::info
 Irys timestamps are accurate to the millisecond, so you need to provide a 
 timestamp in millisecond format when querying. You can convert from 
-human-readable time to UNIX timestamp using websites like [Epoch101](https://www.epoch101.com/), 
+human-readable time to UNIX timestamp using websites like [Epoch101](https://epoch101.com/), 
 be sure to convert in **millisecond** format, not **second**.
 :::
 

--- a/docs/get-started/tooling/security/spherex.mdx
+++ b/docs/get-started/tooling/security/spherex.mdx
@@ -3,7 +3,7 @@ title: SphereX
 image: /img/socialCards/spherex.jpg
 ---
 
-[SphereX](https://www.spherex.xyz/) eliminates unexpected manipulations and malicious attacks, 
+[SphereX](https://spherex.xyz/) eliminates unexpected manipulations and malicious attacks, 
 employing _embedded security_ to neutralize attack surfaces. Stay leaps ahead - remove the element 
 of surprise and ensure the unwavering control in every conceivable situation.
 

--- a/docs/get-started/tooling/social-login/openfort.mdx
+++ b/docs/get-started/tooling/social-login/openfort.mdx
@@ -6,7 +6,7 @@ image: /img/socialCards/openfort.jpg
 [Openfort](https://openfort.xyz) provides account abstraction infrastructure designed to simplify 
 the development of games and gamified experiences across its suite of API endpoints. 
 
-Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/security#smart-contract-accounts) from within the app context and sign blockchain transactions.
+Authenticated users can instantly access the embedded, non-custodial [smart account](https://openfort.xyz/docs/security#smart-contract-accounts) from within the app context and sign blockchain transactions.
 
-Use the [auth quickstart guide](https://www.openfort.io/docs/products/kit/react/quickstart) to allow 
+Use the [auth quickstart guide](https://openfort.io/docs/products/kit/react/quickstart) to allow 
 social login for onboarding users.

--- a/docs/learn/ecosystem-tutorials/irys/irys-dynamic-nfts.mdx
+++ b/docs/learn/ecosystem-tutorials/irys/irys-dynamic-nfts.mdx
@@ -114,7 +114,7 @@ contract SuperMon is ERC721URIStorage {
   </div>
 </div>
 
-1. Fund the Irys Devnet with 0.1 [Linea Sepolia ETH](https://www.infura.io/faucet/linea) to pay
+1. Fund the Irys Devnet with 0.1 [Linea Sepolia ETH](https://infura.io/faucet/linea) to pay
     for your uploads.
 
     :::info

--- a/docs/learn/voting-dapp.mdx
+++ b/docs/learn/voting-dapp.mdx
@@ -49,7 +49,7 @@ that includes both the frontend and backend components needed for our applicatio
 
 ### Initialize the project
 
-Let's create a new project using the [Create Web3 Template CLI](https://www.npmjs.com/package/@consensys/create-web3-template) 
+Let's create a new project using the [Create Web3 Template CLI](https://npmjs.com/package/@consensys/create-web3-template) 
 by Consensys.
 
 This command-line tool simplifies the setup process by providing all the necessary tools and 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -129,7 +129,7 @@ the hub's consistency arguments.
 
 - Improvements to the Linea bridge: 
   - New UI for improved user experience 
-  - Update Linea native bridge to use the [Circle CCTP](https://www.circle.com/cross-chain-transfer-protocol) 
+  - Update Linea native bridge to use the [Circle CCTP](https://circle.com/cross-chain-transfer-protocol) 
   for USDC transfers
   - Add new bridging aggregators for faster transfers and greater chain selection
   - Integrate [Onramper](https://onramper.com/) for seamless fiat onramping to Linea only (live on 

--- a/docs/technology/decentralization.mdx
+++ b/docs/technology/decentralization.mdx
@@ -41,7 +41,7 @@ EVM coverage**.
 
 Open-sourcing Linea's software stack is an essential element of our roadmap, fostering transparency 
 and aligning with web3 values. The Linea software stack is publicly available under the 
-[AGPL-2.0](https://www.apache.org/licenses/LICENSE-2.0) license, which ensures that users have the 
+[AGPL-2.0](https://apache.org/licenses/LICENSE-2.0) license, which ensures that users have the 
 freedom to view, fork, and modify the code. An overview of Linea's repositories is available in 
 our [architecture section](./repos.mdx). 
 

--- a/docs/technology/message-service/reference.mdx
+++ b/docs/technology/message-service/reference.mdx
@@ -163,7 +163,7 @@ need to call one of these methods using the parameters detailed in the [interfac
 
 #### Option 2: Use the Linea SDK
 
-The [Linea SDK](../../api/linea-sdk.mdx) (view the [npm package](https://www.npmjs.com/package/@consensys/linea-sdk?activeTab=readme))
+The [Linea SDK](../../api/linea-sdk.mdx) (view the [npm package](https://npmjs.com/package/@consensys/linea-sdk?activeTab=readme))
 simplifies the execution of messages on the destination layer.
 
 Install the SDK using the package manager of your choice. For example:


### PR DESCRIPTION
As per @julien-marchand, this PR removes several links to block explorers that no longer support Linea:

- NFTScan
- L2Scan

Socialscan is a bit unclear; our canonical URL, `linea.socialscan.io`, is definitely broken / 404. However, there are other instances of this URL pattern resolving, e.g. `manta.socialscan.io`, so if this is simply e.g. a deployment or DNS problem, I've simply commented out that entry, in case we can get it working again.