### PR TITLE
Update USDC bridging information re: CCTP fast transfers

### DIFF
--- a/docs/get-started/how-to/bridge.mdx
+++ b/docs/get-started/how-to/bridge.mdx
@@ -168,10 +168,8 @@ that underpins other native bridge transfers.
 
 USDC transfers currently require [manual claiming](#manual-claiming).
 
-CCTP enables faster transfers. USDC transfers in both directions (L1 &rarr; L2 _and_ L2 &rarr; L1) typically 
-complete within 20 minutes, and generally much faster. See the [CCTP documentation](https://developers.circle.com/stablecoins/cctp-getting-started)
-for a fuller explanation, or check [here](https://developers.circle.com/cctp/required-block-confirmations) 
-for information on timescales.
+While CCTP does allow for "[fast transfers](https://developers.circle.com/stablecoins/cctp-getting-started)", this option is currently not being offered for Linea.
+This is in order to ensure low, transparent pricing to users.
 
 ### Claiming
 
@@ -343,9 +341,6 @@ Key:
 For ETH or ERC-20 tokens:
 - L2 &rarr; L1: 2-16 hours
 - L1 &rarr; L2: ~20 minutes
-
-USDC transfers are considerably faster, as they use the [Cross-Chain Transfer Protocol](https://www.circle.com/cross-chain-transfer-protocol).
-See the [USDC section](#bridge-usdc) for further information.
 
 ## Centralized exchange (CEX)
 


### PR DESCRIPTION
The Support and Linea teams recently determined that, while CCTP-enabled "fast transfers" of USDC _may_ indeed be faster, they have an associated premium cost which is not always transparently disclosed to users.

This friction and lack of transparency led to the decision to disable fast transfers for the time being, to ensure low costs and clear UX. This PR is intended to reflect this change.

There may be other parts of the documentation which need to be updated accordingly, but this is the clearest starting point.