### PR TITLE
Amend Cookbook links

### DIFF
--- a/docs/get-started/how-to/deploy-smart-contract/cookbook.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/cookbook.mdx
@@ -6,7 +6,7 @@ image: /img/socialCards/cookbookdev.jpg
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
-[Cookbook.dev](https://cookbook.dev/?utm=lineadocs) is an open-source smart contract registry where
+[Cookbook.dev](https://contracts.cookbook.dev/) is an open-source smart contract registry where
 developers can find solidity primitives, libraries, and smart contracts for protocols. It provides an easy and
 fast way to develop smart contracts by integrating with a variety of blockchain-native developer tools.
 
@@ -15,7 +15,7 @@ Cookbook's no-code deploy and using Cookbook with Remix, Hardhat and Foundry.
 
 ## Search Cookbook's smart contract registry
 
-Navigate to [cookbook.dev/chains/Linea](https://cookbook.dev/chains/Linea?utm=lineadocs) and explore **Protocols** on Linea, or search for specific smart contracts in the search bar.
+Navigate to [cookbook.dev/chains/Linea](https://contracts.cookbook.dev/chains/Linea) and explore **Protocols** on Linea, or search for specific smart contracts in the search bar.
 
 <div class="center-container">
   <div class="img-large">
@@ -56,7 +56,7 @@ Import verified smart contract code into Cookbook to fork, learn about, or build
 
 ## Deploy a smart contract without coding
 
-Choose **No-Code Deploy** on select (usually simpler) smart contracts on [Cookbook](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
+The **No-Code Deploy** filter enables you to view (usually simpler) smart contracts on [Cookbook](https://contracts.cookbook.dev/search?filter=No-Code+Deploy) that don't require coding to deploy.
 
 <div class="center-container">
   <div class="img-large">
@@ -134,9 +134,9 @@ contracts in the Remix IDE.
 
 ## Deploy your smart contract with Hardhat
 
-After finding the smart contract or protocol you want to work with in [Cookbook](https://cookbook.dev/?utm=lineadocs),
+After finding the smart contract or protocol you want to work with in [Cookbook](https://contracts.cookbook.dev/),
 select the **Download Source** option and select **Hardhat** to download the contract boilerplate. For
-this example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
+this example, we'll use the OpenZeppelin [Simple ERC-20 Token Smart Contract](https://contracts.cookbook.dev/contracts/simple-token).
 
 
 ### Compile the smart contract
@@ -240,9 +240,9 @@ on the [Linea Mainnet block explorer](https://lineascan.build/).
 
 ## Deploy your smart contract with Foundry
 
-After finding the smart contract or protocol you want to work with in [Cookbook](https://cookbook.dev/chains/Linea?utm=lineadocs),
+After finding the smart contract or protocol you want to work with in [Cookbook](https://contracts.cookbook.dev/),
 select the **Download Source** option and select **Foundry** to download the contract boilerplate. For this
-example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://cookbook.dev/contracts/simple-token?utm=lineadocs).
+example, we'll use [Cookbook's Simple ERC-20 Token Smart Contract](https://contracts.cookbook.dev/contracts/simple-token).
 
 **Prerequisites**:
 
@@ -309,7 +309,6 @@ The tests in the `contract.t.sol` file are only examples, please generate your o
 For more information on using Cookbook to find, learn about or build with smart contracts, see
 the following resources:
 
-- [Documentation](https://docs.cookbook.dev/)
 - [Blog](https://medium.com/@cookbookdev)
 - [X (Twitter)](https://x.com/cookbook_dev)
 - [Community](https://discord.gg/cookbook)

--- a/docs/get-started/tooling/contracts-templates/cookbook.mdx
+++ b/docs/get-started/tooling/contracts-templates/cookbook.mdx
@@ -3,12 +3,12 @@ title: Cookbook.dev
 image: /img/socialCards/cookbookdev.jpg
 ---
 
-[Cookbook.dev](https://cookbook.dev/?utm=lineadocs) is an open-source smart contract registry 
+[Cookbook.dev](https://contracts.cookbook.dev/) is an open-source smart contract registry 
 where developers can find Solidity primitives, libraries, and smart contracts for protocols.
 
 ## Search the smart contract registry
 
-Navigate to [cookbook.dev/chains/Linea](https://cookbook.dev/chains/Linea?utm=lineadocs) and 
+Navigate to [contracts.cookbook.dev/chains/Linea](https://contracts.cookbook.dev/chains/Linea) and 
 explore protocols on Linea, or search for specific smart contracts in the search bar.
 
 <div class="center-container">
@@ -96,7 +96,6 @@ about Linea, Solidity, or the smart contract you're working with.
 For more information on using Cookbook to find, learn about or build with smart contracts, check out 
 the following resources:
 
-- [Documentation](https://docs.cookbook.dev)
 - [Blog](https://medium.com/@cookbookdev)
 - [X](https://x.com/cookbook_dev)
 - [Community](https://discord.gg/cookbook)


### PR DESCRIPTION
Prompted by #1174.

Amending some links to the `cookbook.dev` domain to point specifically to the Cookbook smart contract library, as the main pages in the domain are focussed on the Cookbook AI tooling. 

Removed links to the documentation, as this seems to no longer relate to the smart contract library.