### PR TITLE
Update details in `eth_sendBundle` page

### DIFF
--- a/docs/api/reference/eth-sendbundle.mdx
+++ b/docs/api/reference/eth-sendbundle.mdx
@@ -8,9 +8,8 @@ image: /img/socialCards/ethsendbundle.jpg
 
 :::note
 
-Access to this endpoint is permissioned via Infura, and is not relevant for node operators as it's 
-available on sequencers only. To add this endpoint to your Infura account, please open a ticket via 
-the "Contact" button on our [support page](https://support.linea.build/).
+Access to this endpoint is permissioned via Infura. Currently, only Infura nodes are able to forward 
+the requests to the sequencer.
 
 :::
 


### PR DESCRIPTION
Amendeding the callout to be clearer about how this method requires access to the sequencer, which only Infura does.