### PR TITLE
Update engine-api-endpoint with jwt-secret-path

### DIFF
--- a/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
@@ -248,7 +248,8 @@ For production environments, you should enable JWT authentication:
 ### Generate JWT secret
 
 ```bash
-openssl rand -hex 32 > ~/linea-node/jwt/jwtsecret
+mkdir -p ./jwt
+openssl rand -hex 32 > ./jwt/jwtsecret
 ```
 
 ### Update Besu config


### PR DESCRIPTION
Added jwt-secret-path to engine-api-endpoint configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks JWT as optional and switches JWT setup to use ./jwt/jwtsecret with corresponding Besu/Maru config and Docker volume updates.
> 
> - **Docs — Run a node (Beta v4 migration)**:
>   - Mark JWT Authentication as optional.
>   - Standardize JWT secret location and naming:
>     - Generate secret into `./jwt/jwtsecret` (ensure `./jwt` exists).
>     - Update Besu `engine-jwt-file` to `/jwt/jwtsecret`.
>     - Update Maru `payload-validator.engine-api-endpoint.jwt-secret-path` to `/jwt/jwtsecret`.
>     - Change Docker volumes to mount the whole `./jwt` directory at `/jwt:ro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112a301588749c68d43b0eaf50ad8a0757cacf05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->