### PR TITLE
Adjust Beta v4 dates

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -24,14 +24,13 @@ import TabItem from "@theme/TabItem";
 
 ## Beta v4
 
-**Linea Mainnet: October 2025** (TBC)
+**Linea Mainnet: mid-October 2025** (TBC)
 
 **Linea Sepolia:**
 - Paris: 24 September, 2025
 - Shanghai: 29 September, 2025
 - Cancun: 30 September, 2025
-
-The Prague upgrade will occur on Linea Sepolia in early October (TBC).
+- Prague: 7 October, 2025
 
 - Implement Pectra hardfork on Linea (including all EVM upgrades since London), achieving full 
   EVM-equivalence. The upgrade will occur in stages, progressing through hard forks.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts Beta v4 dates: Linea Mainnet to mid-October 2025 and adds Prague on Sepolia for 7 October 2025.
> 
> - **Docs** (`docs/release-notes.mdx`):
>   - **Beta v4**:
>     - Update `Linea Mainnet` date to `mid-October 2025` (TBC).
>     - Add `Prague: 7 October, 2025` under `Linea Sepolia`; remove prior early-October TBC note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8f01e55747ce10633fc094075d584567dd9d02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->