### PR TITLE
Remove dead faucet pages

### DIFF
--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -21,15 +21,7 @@ See our [support guide to getting a Linea Names domain](https://support.linea.bu
 
 ## Other faucets
 
-- [Infura](https://infura.io/faucet/linea)
-- [GetBlock](https://getblock.io/faucet/linea-sepolia/)
 - [HackQuest](https://hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
 
-Alternatively, [use the Linea native bridge to bridge testnet ETH between Sepolia and Linea Sepolia](../how-to/bridge.mdx).
-
-## Get testnet ERC-20 tokens
-
-Testnet ERC-20 tokens may be useful for development purposes.
-
-One method is to use the [OKX faucet](https://okx.com/xlayer/faucet/sepoliafaucet), which 
-enables you to select from a handful of different testnet ERC-20 tokens.
+Alternatively, use the [Linea native bridge](https://linea.build/hub/bridge/native-bridge) to 
+[bridge testnet ETH between Sepolia and Linea Sepolia](../how-to/bridge.mdx).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the ERC-20 faucet section and updates the native bridge link in the Linea testnet ETH guide.
> 
> - **Docs** (`docs/get-started/how-to/get-testnet-eth.mdx`):
>   - Remove the "Get testnet ERC-20 tokens" section (including the OKX faucet reference).
>   - Update bridge guidance to link to the Linea native bridge (`https://linea.build/hub/bridge/native-bridge`) and clarify bridging between Sepolia and Linea Sepolia.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51e14a7be4db16eb645d0e273f50caa9c68d2dd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->