### PR TITLE
Amend Geth version in Beta v4 node migration guide

### DIFF
--- a/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
@@ -72,7 +72,9 @@ with Prague will work.
 Supported EL clients include:
 
 - Besu: [25.8.0](https://github.com/hyperledger/besu/releases/tag/25.8.0) or higher
-- Geth: Latest release (downtime required)
+- Geth: 
+  - Pre-Shanghai: v1.13.15
+  - Post-Shanghai: v1.16.x  
 - Erigon: Latest release
 - Nethermind: Latest release
 - Linea-specific: A new `linea-besu-package` release is available via Docker: `consensys/linea-besu-package:beta-v4.0-rc11-20251004063519-a5c4c31`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces vague Geth guidance with explicit supported versions (v1.13.15 pre-Shanghai, v1.16.x post-Shanghai) in the Beta v4 migration guide.
> 
> - **Docs**:
>   - Update EL client compatibility in `docs/get-started/how-to/run-a-node/beta-v4-migration.mdx`:
>     - Replace generic Geth recommendation with explicit versions:
>       - Pre-Shanghai: `v1.13.15`
>       - Post-Shanghai: `v1.16.x`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec8e39558212b91b36da71dbf78bdacdbd70e9c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->