### PR TITLE
Amend paths for Docker directories

### DIFF
--- a/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
@@ -138,9 +138,9 @@ See below for the steps you'll need to follow to upgrade, and then refer to the 
 
 ### Step 1: Obtain files {#obtain-files-upgrade}
 
-The files you need to run Maru are available in the Linea monorepo at the [`/docker` directory](https://github.com/Consensys/linea-monorepo/tree/main/docker), in either the `linea-mainnet` or `linea-sepolia` directory:
-- [Mainnet](https://github.com/Consensys/linea-monorepo/tree/main/docker/linea-mainnet) 
-- [Sepolia](https://github.com/Consensys/linea-monorepo/tree/main/docker/linea-sepolia)
+The files you need to run Maru are available in the Linea monorepo at the [`/docs/getting-started` directory](https://github.com/Consensys/linea-monorepo/tree/docs/getting-started), in either the `linea-mainnet` or `linea-sepolia` directory:
+- [Mainnet](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet) 
+- [Sepolia](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia)
 
 To get the files, choose one of the following methods:
 1. Clone the Linea monorepo, potentially shallow cloning with e.g. `git clone --depth 5` to save 
@@ -197,9 +197,9 @@ maintenance window.
 
 ### Step 1: Obtain files
 
-The files you need to run Maru are available in the Linea monorepo at the [`/docker` directory](https://github.com/Consensys/linea-monorepo/tree/main/docker), in either the `linea-mainnet` or `linea-sepolia` directory:
-- [Mainnet](https://github.com/Consensys/linea-monorepo/tree/main/docker/linea-mainnet) 
-- [Sepolia](https://github.com/Consensys/linea-monorepo/tree/main/docker/linea-sepolia)
+The files you need to run Maru are available in the Linea monorepo at the [`/docs/getting-started` directory](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started), in either the `linea-mainnet` or `linea-sepolia` directory:
+- [Mainnet](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet) 
+- [Sepolia](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia)
 
 To get the files, choose one of the following methods::
 1. Clone the Linea monorepo, potentially shallow cloning with e.g. `git clone --depth 5` to save 


### PR DESCRIPTION
Corresponds to https://github.com/Consensys/linea-monorepo/pull/1565

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Maru file location links in the Beta v4 migration guide from /docker to /docs/getting-started for both mainnet and sepolia sections.
> 
> - **Docs**:
>   - **Beta v4 migration guide** (`docs/get-started/how-to/run-a-node/beta-v4-migration.mdx`):
>     - Update “Step 1: Obtain files” links from `docker/linea-{mainnet|sepolia}` to `docs/getting-started/linea-{mainnet|sepolia}` in both upgrade and simultaneous start sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a145d6f8fadf4a4af4ef7ee278aebeb13e3c1ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->