### PR TITLE
Fix links in `run-a-node` guides

### DIFF
--- a/docs/get-started/how-to/run-a-node/besu.mdx
+++ b/docs/get-started/how-to/run-a-node/besu.mdx
@@ -128,7 +128,7 @@ files include the network genesis file, Docker Compose file and Besu configurati
 <Tabs groupId="networks" className="my-tabs">
   <TabItem value="mainnet" label="Mainnet">
   
-  Head to the `[/docs/getting-started/linea-mainnet/](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet/)` 
+  Head to the [`/docs/getting-started/linea-mainnet/`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet)
   directory in the Linea monorepo for all the files you need. Make sure you download the contents of
   both:
   - `/docs/getting-started/linea-mainnet`, which contains the `docker-compose.yml` file that you'll 
@@ -150,7 +150,7 @@ files include the network genesis file, Docker Compose file and Besu configurati
   </TabItem>
   <TabItem value="Linea Sepolia" label="Linea Sepolia">
   
-  Head to the `[/docs/getting-started/linea-sepolia/](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia/)` 
+  Head to the [`/docs/getting-started/linea-sepolia`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia/)
   directory in the Linea monorepo for all the files you need. Make sure you download the contents of
   both:
   - `/docs/getting-started/linea-sepolia`, which contains the `docker-compose.yml` file that you'll 

--- a/docs/get-started/how-to/run-a-node/geth.mdx
+++ b/docs/get-started/how-to/run-a-node/geth.mdx
@@ -174,7 +174,7 @@ Download the configuration files for the relevant network. Ensure that you downl
 <Tabs groupId="networks" className="my-tabs">
   <TabItem value="mainnet" label="Mainnet">
   
-  Head to the `[/docs/getting-started/linea-mainnet/](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet/)` 
+  Head to the `[`/docs/getting-started/linea-mainnet`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet/) 
   directory in the Linea monorepo for all the files you need. Make sure you download the contents of
   both:
   - `/docs/getting-started/linea-mainnet`, which contains the `docker-compose.yml` file that you'll 
@@ -194,7 +194,7 @@ Download the configuration files for the relevant network. Ensure that you downl
   </TabItem>
   <TabItem value="Linea Sepolia" label="Linea Sepolia">
   
-  Head to the `[/docs/getting-started/linea-sepolia/](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia/)` 
+  Head to the [`/docs/getting-started/linea-sepolia`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia/) 
   directory in the Linea monorepo for all the files you need. Make sure you download the contents of
   both:
   - `/docs/getting-started/linea-sepolia`, which contains the `docker-compose.yml` file that you'll 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix Markdown link formatting for Linea Mainnet/Sepolia paths in Besu and Geth run-a-node guides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb1bde30b36d860b92e6711b692e6d8e98a3cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->