### PR TITLE
Amend Beta v4 date

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -25,7 +25,7 @@ import TabItem from "@theme/TabItem";
 ## Beta v4
 
 **Linea Mainnet:**
-- Paris: 21 October, 2025, [block 24787631](https://lineascan.build/block/countdown/24787631)
+- Paris: 22 October, 2025, [block 24787631](https://lineascan.build/block/countdown/24787631)
 - Shanghai: 10am UTC, 23 October, 2025 
 - Cancun: TBC
 - Prague: TBC


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts Beta v4 Linea Mainnet Paris date from Oct 21 to Oct 22, 2025 (block unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da23fa4eaed37096aa7b0903fd0bfb9641eca530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->