### PR TITLE
Fix Beta v4.0 Shanghai timestamp

### DIFF
--- a/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
@@ -88,7 +88,7 @@ Geth clients have a slightly more complex compatability situation:
 
 As a result, for a zero-downtime upgrade path, you must upgrade in a specific order:
 1. Start with v1.13.15 (compatible with London hard fork, i.e. pre-Beta v4)
-2. Upgrade to v1.16.x _after_ Linea has updated to Shanghai ([10am CET, 23 October, 2025](../../../release-notes.mdx#beta-v4)) and _before_
+2. Upgrade to v1.16.x _after_ Linea has updated to Shanghai ([10am UTC, 23 October, 2025](../../../release-notes.mdx#beta-v4)) and _before_
   Linea upgrades to Cancun (time TBC)
 
 :::


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects the Geth upgrade instruction timestamp from 10am CET to 10am UTC in `docs/get-started/how-to/run-a-node/beta-v4-migration.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846b0ce62b77bd2803d05c7f047f6978d7e73045. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->