### PR TITLE
Add final Beta v4.0 mainnet hard fork timings

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -33,8 +33,8 @@ We maintain a record and brief explanation of Linea Security Council transaction
 **Linea Mainnet:**
 - Paris: 22 October, 2025, [block 24787631](https://lineascan.build/block/countdown/24787631)
 - Shanghai: 10am UTC, 23 October, 2025 
-- Cancun: TBC
-- Prague: TBC
+- Cancun: 10am UTC, 28 October, 2025
+- Prague: 10:10am UTC, 28 October, 2025
 
 **Linea Sepolia:**
 - Paris: 24 September, 2025


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set final Cancun (10am UTC, 28 Oct 2025) and Prague (10:10am UTC, 28 Oct 2025) timings for Linea Mainnet Beta v4.0 in release notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aceda68ac2b204775731e8ca38d980e05968041f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->