### PR TITLE
Add new LSC transaction entry

### DIFF
--- a/docs/security-council-record.mdx
+++ b/docs/security-council-record.mdx
@@ -24,12 +24,12 @@ you can take to verify this information.
 
 - **Nonce 64**
   - Action: Add verifiers for [Cancun and Prague hard forks](./release-notes.mdx#beta-v40) and 
-  remove Shanghai verifier.
+  remove Paris verifier.
   - Verification: Events confirming the verifier changes were emitted and are viewable in the 
   transaction logs:
     - Cancun: `VerifierAddressChanged` records the new verifier `0x8421D1e3fb9A737A85dC7FF531c39f324FB2aC5d`, at index 1.
     - Prague: `VerifierAddressChanged` records the new verifier `0xA12E79C375FB0aaddfDA597BBe7b4e9A92e9b3De`, at index 0.
-    - Paris: `VerifierAddressChanged` set the verifier for index 3 at `0x0`.
+    - Paris: `VerifierAddressChanged` unset the verifier at index 3.
 
 ### October 21, 2025
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an Oct 27, 2025 entry to the security council record for L1 nonce 64, documenting Cancun/Prague verifier additions and Paris verifier removal with verification details.
> 
> - **Docs**:
>   - **Security council record** (`docs/security-council-record.mdx`):
>     - Add new entry for **October 27, 2025** → **L1 nonce `64`**:
>       - Action: add verifiers for Cancun and Prague; remove Paris verifier.
>       - Verification: `VerifierAddressChanged` events confirming new Cancun (`0x8421D1e3fb9A737A85dC7FF531c39f324FB2aC5d`, index 1), new Prague (`0xA12E79C375FB0aaddfDA597BBe7b4e9A92e9b3De`, index 0), and unset Paris (index 3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fcc350447a561e8532acbd8e69850fd5eee033c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->