### PR TITLE
Update Beta v4 migration guide for Cancun and Prague

### DIFF
--- a/docs/security-council-record.mdx
+++ b/docs/security-council-record.mdx
@@ -18,6 +18,19 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
+### October 27, 2025
+
+#### L1
+
+- **Nonce 64**
+  - Action: Add verifiers for [Cancun and Prague hard forks](./release-notes.mdx#beta-v40) and 
+  remove Paris verifier.
+  - Verification: Events confirming the verifier changes were emitted and are viewable in the 
+  transaction logs:
+    - Cancun: `VerifierAddressChanged` records the new verifier `0x8421D1e3fb9A737A85dC7FF531c39f324FB2aC5d`, at index 1.
+    - Prague: `VerifierAddressChanged` records the new verifier `0xA12E79C375FB0aaddfDA597BBe7b4e9A92e9b3De`, at index 0.
+    - Paris: `VerifierAddressChanged` unset the verifier at index 3.
+
 ### October 21, 2025
 
 #### L1


### PR DESCRIPTION
Removes instructions that were relevant before Paris; replaces with ones that are relevant ahead of Cancun/Prague.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the Beta v4.0 migration guide for Cancun/Prague with new genesis/compose steps, Geth v1.16+ guidance, updated Besu image, and streamlined verification logs while removing pre-Paris instructions.
> 
> - **Docs — `docs/get-started/how-to/run-a-node/beta-v4-migration.mdx`**:
>   - Rename and normalize references to Beta v4.0; update headings (e.g., “After Beta v4.0”).
>   - Add Cancun/Prague upgrade flow:
>     - New genesis file links for Maru, Besu, and Geth.
>     - Update `docker-compose.yml` with `linea-besu-package` image `rc17`.
>     - Reinitialize node (compose down/up) and verify via logs.
>     - Add Geth warning to use v1.16.x+.
>     - Include sample verification log outputs for Maru, Besu, and Geth (fork timestamps).
>   - Update EL compatibility section (incl. new Linea-specific Besu image tag).
>   - Remove/replace legacy, pre-Paris/Shanghai upgrade paths and extensive sections (simultaneous start, JWT, private key mgmt, troubleshooting) in favor of a concise Cancun/Prague-focused guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a9160c7296db5313da9962120640e82d9350c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->