### PR TITLE
Adjust Linea Besu Docker instructions

### DIFF
--- a/docs/get-started/how-to/run-a-node/linea-besu.mdx
+++ b/docs/get-started/how-to/run-a-node/linea-besu.mdx
@@ -165,18 +165,7 @@ You can use [this page](https://whatismyip.com/) to find your public IP address.
 
 :::
 
-### Step 3. Configure your L1 RPC endpoint
-
-If you're using an `advanced` profile, insert your preferred L1 RPC endpoint in the 
-`docker-compose.yaml` file:
-
-```yaml
---plugin-linea-l1-rpc-endpoint=YOUR_L1_RPC_ENDPOINT
-```
-
-If you only intend to run a `basic` profile, go straight to the next step.
-
-### Step 4. Start the Linea Besu node
+### Step 3. Start the Linea Besu node
 
 <Tabs groupId="networks" className="my-tabs">
   <TabItem value="mainnet" label="Mainnet">
@@ -194,7 +183,8 @@ If you only intend to run a `basic` profile, go straight to the next step.
     docker run -e BESU_PROFILE=advanced-mainnet consensys/linea-besu-package:latest
     ```
 
-    Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1. 
+    Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1, and replace the image
+    name with a more recent version from the releases page.
   </TabItem>
   <TabItem value="Linea Sepolia" label="Linea Sepolia">
       In a terminal, navigate to your `.yaml` file's directory. Then start the node by running 
@@ -211,6 +201,7 @@ If you only intend to run a `basic` profile, go straight to the next step.
       docker run -e BESU_PROFILE=advanced-sepolia consensys/linea-besu-package:beta-v4.0-rc11-20251004063519-a5c4c31
       ```
 
-      Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1. 
+      Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1, and replace the image
+      name with a more recent version from the releases page.
     </TabItem>
 </Tabs>


### PR DESCRIPTION
Fixes #1245 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the L1 RPC config step and adds guidance to use the latest image in docker run examples; renumbers Docker steps.
> 
> - **Docs (Linea Besu Docker)**:
>   - Remove `Step 3. Configure your L1 RPC endpoint` section from Docker setup.
>   - Renumber subsequent step to `Step 3. Start the Linea Besu node`.
>   - In both Mainnet and Linea Sepolia `docker run` examples:
>     - Keep `BESU_PROFILE` note and add instruction to replace the image with a newer release (`consensys/linea-besu-package:<version>`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16225e955beb5d1a94699b717d64f894dc20cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->