### PR TITLE
doc.linea - Fix/action explicit permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,7 +12,7 @@ jobs:
     name: Link Checking
     runs-on: ubuntu-latest
     permissions:
-        contents: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: LinkCheck

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,6 +11,8 @@ jobs:
   linkCheck:
     name: Link Checking
     runs-on: ubuntu-latest
+    permissions:
+        contents: read
     steps:
       - uses: actions/checkout@v4
       - name: LinkCheck

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,8 @@
       needs: [linkCheckMdx, linkCheckMd]
       if: ${{ failure() }}
       runs-on: ubuntu-latest
+      permissions:
+        contents: read
       steps:
         - name: Slack Notification
           uses: ConsenSys/github-actions/slack-notify@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@
     schedule:
       - cron: "0 0 * * *"
     workflow_dispatch: {}
+
+  permissions:
+    contents: read
   
   jobs:
     linkCheckMdx:
@@ -39,8 +42,7 @@
       needs: [linkCheckMdx, linkCheckMd]
       if: ${{ failure() }}
       runs-on: ubuntu-latest
-      permissions:
-        contents: none
+      permissions: {}   # zero scopes
       steps:
         - name: Slack Notification
           uses: ConsenSys/github-actions/slack-notify@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,7 @@
       if: ${{ failure() }}
       runs-on: ubuntu-latest
       permissions:
-        contents: read
+        contents: none
       steps:
         - name: Slack Notification
           uses: ConsenSys/github-actions/slack-notify@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,54 +1,54 @@
 ---
-  name: Nightly check
-  
-  on:
-    schedule:
-      - cron: "0 0 * * *"
-    workflow_dispatch: {}
+name: Nightly check
 
-  permissions:
-    contents: read
-  
-  jobs:
-    linkCheckMdx:
-      name: Run link check on .mdx files
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-      steps:
-        - uses: actions/checkout@v4
-        - name: LinkCheck mdx files
-          uses: ConsenSys/github-actions/docs-link-check@main
-          with:
-              FILE_EXTENSION: mdx
-              MODIFIED_FILES_ONLY: no
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
 
-    linkCheckMd:
-      needs: linkCheckMdx
-      name: Run link check on .md files
-      if: always()
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-      steps:
-        - uses: actions/checkout@v4
-        - name: LinkCheck md files
-          uses: ConsenSys/github-actions/docs-link-check@main
-          with:
-            FILE_EXTENSION: md
+permissions:
+  contents: read
+
+jobs:
+  linkCheckMdx:
+    name: Run link check on .mdx files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: LinkCheck mdx files
+        uses: ConsenSys/github-actions/docs-link-check@main
+        with:
+            FILE_EXTENSION: mdx
             MODIFIED_FILES_ONLY: no
 
-    slackNotification:
-      needs: [linkCheckMdx, linkCheckMd]
-      if: ${{ failure() }}
-      runs-on: ubuntu-latest
-      permissions: {}   # zero scopes
-      steps:
-        - name: Slack Notification
-          uses: ConsenSys/github-actions/slack-notify@main
-          with:
-            SLACK_CHANNEL: doc-ci-alerts
-            SLACK_COLOR: danger
-            SLACK_TITLE: Linea docs nightly build - Failure
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-            MSG_MINIMAL: true
+  linkCheckMd:
+    needs: linkCheckMdx
+    name: Run link check on .md files
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: LinkCheck md files
+        uses: ConsenSys/github-actions/docs-link-check@main
+        with:
+          FILE_EXTENSION: md
+          MODIFIED_FILES_ONLY: no
+
+  slackNotification:
+    needs: [linkCheckMdx, linkCheckMd]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions: {}   # zero scopes
+    steps:
+      - name: Slack Notification
+        uses: ConsenSys/github-actions/slack-notify@main
+        with:
+          SLACK_CHANNEL: doc-ci-alerts
+          SLACK_COLOR: danger
+          SLACK_TITLE: Linea docs nightly build - Failure
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          MSG_MINIMAL: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,8 +20,8 @@ jobs:
       - name: LinkCheck mdx files
         uses: ConsenSys/github-actions/docs-link-check@main
         with:
-            FILE_EXTENSION: mdx
-            MODIFIED_FILES_ONLY: no
+          FILE_EXTENSION: mdx
+          MODIFIED_FILES_ONLY: no
 
   linkCheckMd:
     needs: linkCheckMdx

--- a/.github/workflows/update-node-size.yml
+++ b/.github/workflows/update-node-size.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-data:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
 
@@ -63,6 +65,8 @@ jobs:
     needs: [update-data]
     if: ${{ failure() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
       - name: Slack Notification
         uses: Consensys/github-actions/slack-notify@main


### PR DESCRIPTION
Adding explicit permissions to the workflows as recommended by CodeQL and reported in the issue #1258 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add explicit least-privilege permissions across workflows (read for link checks, write for data update, none for Slack notifications).
> 
> - **CI workflows**: add explicit permissions (least privilege)
>   - `.github/workflows/links.yml`
>     - `linkCheck` job: add `permissions: { contents: read }`.
>   - `.github/workflows/nightly.yml`
>     - Top-level: add `permissions: { contents: read }`.
>     - `linkCheckMdx`/`linkCheckMd`: ensure `permissions: { contents: read }`.
>     - `slackNotification`: set `permissions: {}` (zero scopes).
>   - `.github/workflows/update-node-size.yml`
>     - `update-data`: add `permissions: { contents: write }`.
>     - `slackNotification`: set `permissions: { contents: none }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d44e7dafccdd4d8b18e0178660465cc4835ee8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->