### PR TITLE
[Chore] - Add nonce 65 LSC Transaction

### DIFF
--- a/docs/security-council-record.mdx
+++ b/docs/security-council-record.mdx
@@ -23,7 +23,7 @@ you can take to verify this information.
 #### L1
 
 - **[Nonce 65](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x6a188b2fd845580a6be7fca4acbc878e730f853163265e5e1f4fb73b07a3ec82)**
-  - Action: Add verifier for Limitless prover and
+  - Action: Add verifier for beta-v4.3 Limitless prover and
   remove unused Cancun and Shanghai verifiers.
   
   - Verification: Events confirming the verifier changes were emitted and are viewable in the 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a planned L1 nonce 65 entry to `docs/security-council-record.mdx` documenting Limitless prover verifier addition and removal of Cancun/Shanghai verifiers with verification details.
> 
> - **Docs**:
>   - Update `docs/security-council-record.mdx` with a new section: *November 17, 2025 (Planned)*.
>     - **L1 — `Nonce 65`**:
>       - Add verifier for beta-v4.3 Limitless prover (`0x814d80782aa8c508ababe9c6956d8f1f90e5177a`, index 3).
>       - Remove unused Cancun (unset index 1) and Shanghai (unset index 4) verifiers.
>       - Include verification steps via `VerifierAddressChanged` events in transaction logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26619ac71be2f6f2f6f538b6b502fa2af224f2d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->