### PR TITLE
Fix nightly link checker.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,36 +10,20 @@ permissions:
   contents: read
 
 jobs:
-  linkCheckMdx:
-    name: Run link check on .mdx files
+  linkCheck:
+    name: Run link check
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: LinkCheck mdx files
+      - name: LinkCheck
         uses: ConsenSys/github-actions/docs-link-check@main
         with:
-          FILE_EXTENSION: mdx
-          MODIFIED_FILES_ONLY: no
-
-  linkCheckMd:
-    needs: linkCheckMdx
-    name: Run link check on .md files
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: LinkCheck md files
-        uses: ConsenSys/github-actions/docs-link-check@main
-        with:
-          FILE_EXTENSION: md
-          MODIFIED_FILES_ONLY: no
+          CONFIG_FILE: .linkspector.yml
 
   slackNotification:
-    needs: [linkCheckMdx, linkCheckMd]
+    needs: linkCheck
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     permissions: {}   # zero scopes

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -11,7 +11,6 @@ ignorePatterns:
   - pattern: '^https://x\.com(?:[/?].*)?$'
   - pattern: '^https://support\.metamask\.io(?:[/?].*)?$'
   - pattern: '^https://(?:www\.)?infura\.io/faucet/linea(?:[/?].*)?$'
-  - pattern: '^https://(?:www\.)?infura\.io(?:[/?].*)?$'
   - pattern: '^https://rpc\.sepolia\.linea\.build(?:[/?].*)?$'
   - pattern: '^https://help\.coinbase\.com(?:[/?].*)?$'
   - pattern: '^https://bridge\.linea\.build(?:[/?].*)?$'


### PR DESCRIPTION
The nightly job used config settings from the now deprecated linkchecker package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces separate md/mdx nightly link checks with a single job using .linkspector.yml and updates Slack dependency.
> 
> - **CI**:
>   - **Nightly workflow**: Replace separate `linkCheckMdx`/`linkCheckMd` with single `linkCheck` job using `ConsenSys/github-actions/docs-link-check@main` and `CONFIG_FILE: .linkspector.yml`; rename step; update `slackNotification` to depend on `linkCheck`.
> - **Config**:
>   - **New `.linkspector.yml`**: Defines scan dirs, excluded dirs, ignore patterns, and allowed status codes for link checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c90643b7024397509ec368712d616761ee6084d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->