### PR TITLE
Fixed links resulting in 404s.

### DIFF
--- a/docs/get-started/how-to/deploy-smart-contract/foundry.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/foundry.mdx
@@ -47,13 +47,11 @@ cd linea-tutorial
 
 ## Deploy a smart contract
 
-To deploy a smart contract we highly recommend using an Infura endpoint, as the public endpoint may 
-experience rate limiting and is not meant for production use.
+:::caution Public endpoints are rate limited and not meant for production systems
 
+We recommend using a node provider such as Infura.
 [Sign up for an Infura account](https://docs.metamask.io/developer-tools/dashboard/) to generate
 an API key. In the dashboard, enable the Linea endpoints you want to use with that key.
-
-:::caution
 
 These instructions use API keys and private keys inline. We highly recommend hiding them
 [in `.env` files](#deploy-a-smart-contract-using-a-env-file)

--- a/docs/get-started/how-to/deploy-smart-contract/hardhat.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/hardhat.mdx
@@ -70,11 +70,9 @@ value in the script.
 You can use the public endpoints or node provider (such as Infura) to deploy your contract to the Linea mainnet or
 testnets.
 
-:::important
+:::caution Public endpoints are rate limited and not meant for production systems
 
-The public endpoints are rate limited and not meant for production systems. We recommend using a
-node provider such as Infura.
-
+We recommend using a node provider such as Infura.
 [Sign up for an Infura account](https://docs.metamask.io/developer-tools/dashboard/) to generate
 an API key. In the dashboard, enable the Linea endpoints you want to use with that key.
 

--- a/docs/get-started/how-to/deploy-smart-contract/remix.mdx
+++ b/docs/get-started/how-to/deploy-smart-contract/remix.mdx
@@ -40,11 +40,9 @@ Navigate to the **Solidity compiler** tab on the left navigation and click **Com
 You can deploy a smart contract using the injected provider, meaning Remix can auto-detect the network you're
 on and your account information. To do this, navigate to the **Deploy & run transactions** tab.
 
-:::caution
+:::caution Public endpoints are rate limited and not meant for production systems
 
-The public endpoints are rate limited and not meant for production systems. We recommend using a node
-provider such as Infura instead.
-
+We recommend using a node provider such as Infura.
 [Sign up for an Infura account](https://docs.metamask.io/developer-tools/dashboard/) to generate
 an API key. In the dashboard, enable the Linea endpoints you want to use with that key.
 


### PR DESCRIPTION
The existing Infura hyperlinks are redirecting to a location that doesn't exist. Fixed the links to go directly to the MetaMask docs.

Additionally, the use of admonitions were inconsistently applied to the sentence. Applied the `caution` type to all of them.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Infura signup links to MetaMask dashboard and clarify provider guidance across Foundry, Hardhat, and Remix deployment docs.
> 
> - **Docs**:
>   - **Infura signup/link updates**:
>     - Replace old Infura links with `https://docs.metamask.io/developer-tools/dashboard/` and clarify enabling Linea endpoints across:
>       - `docs/get-started/how-to/deploy-smart-contract/foundry.mdx`
>       - `docs/get-started/how-to/deploy-smart-contract/hardhat.mdx`
>       - `docs/get-started/how-to/deploy-smart-contract/remix.mdx`
>   - **Copy tweaks**:
>     - Emphasize using a node provider (Infura) over public endpoints; minor punctuation/wording fixes (e.g., testnets line, caution/important sections).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dde88053938d563223a4623a854834f2b6840f88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->