### PR TITLE
Updating security council record

### DIFF
--- a/docs/security-council-record.mdx
+++ b/docs/security-council-record.mdx
@@ -18,7 +18,19 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
-### November 17, 2025 (Planned)
+### December 03, 2025 (Planned)
+
+#### L1
+
+- **Nonce 66**
+  - Action: Add verifier for Osaka hard forks and remove unused Prague verifiers.
+  
+  - Verification: Events confirming the verifier changes were emitted and are viewable in the 
+  transaction logs:
+    - Osaka: `VerifierAddressChanged` records the new verifier `0x8f8EC9608223C0b8D13238950c03F5D42ceeBb9b`, at index 4.
+    - Prague: `VerifierAddressChanged` unset the verifier at index 0.
+
+### November 17, 2025
 
 #### L1
 


### PR DESCRIPTION
Updating security council record with December 3rd planned changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a December 03, 2025 (Planned) entry with L1 Nonce 66 detailing Osaka verifier addition and Prague verifier removal.
> 
> - **Docs**:
>   - **`docs/security-council-record.mdx`**:
>     - Add new planned entry for **December 03, 2025**.
>       - L1 **Nonce 66**: add Osaka verifier `0x8f8EC960...Bb9b` (index 4); remove Prague verifier (unset index 0).
>     - Update planned date heading from November 17, 2025 to December 03, 2025; retain November 17, 2025 as a separate finalized section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 598b9da76c9805fa645ac3fd045719140d74d853. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->