### PR TITLE
Register tokens in Dev Hub

### DIFF
--- a/docs/get-started/build/contracts.mdx
+++ b/docs/get-started/build/contracts.mdx
@@ -125,7 +125,7 @@ To see **the most up-to-date list of tokens on Linea**, see
 [the token explorer here](https://consensys.github.io/linea-token-list/), which is derived from the
 official lists in [this repo](https://github.com/Consensys/linea-token-list/blob/main/json/linea-mainnet-token-shortlist.json). 
 
-To **get your own token included**, register your token in the [Linea Developer Hub](https://developer.linea.build/).
+To **get your own token included**, register your token in the [Linea Developer Hub](https://developer.linea.build/) "Configure" tab.
 
 To see **which third-party bridges are available**, consult our [Ecosystem Portal's list](https://linea.build/hub/apps/category/bridge).
 

--- a/docs/get-started/how-to/migrate-dapp.mdx
+++ b/docs/get-started/how-to/migrate-dapp.mdx
@@ -48,7 +48,7 @@ token on Linea as you would on any other EVM-compatible chain.
 
 ### Register your token
 
-With your token deployed, register your token in the [Linea Developer Hub](https://developer.linea.build/).
+With your token deployed, register your token in the [Linea Developer Hub](https://developer.linea.build/) "Configure" tab.
 
 ### Submit metadata to Lineascan
 


### PR DESCRIPTION
Users should register their tokens in the Linea Developer Hub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Direct users to register tokens via the Linea Developer Hub "Configure" tab instead of submitting PRs to the token list repo.
> 
> - **Docs**:
>   - Update token registration guidance to the Linea Developer Hub "Configure" tab.
>     - `docs/get-started/build/contracts.mdx`: Replace link/instructions for getting tokens included with Developer Hub registration.
>     - `docs/get-started/how-to/migrate-dapp.mdx`: Rename section to `Register your token` and replace token-list PR steps with Developer Hub registration; keep Lineascan metadata guidance unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468d5e9f900b6e8aed390f32bcbb385b62ff24c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->