### PR TITLE
Add Privy app ID placeholder in connect-wallet documentation

### DIFF
--- a/docs/get-started/how-to/connect-wallet.mdx
+++ b/docs/get-started/how-to/connect-wallet.mdx
@@ -345,7 +345,7 @@ import { linea, lineaSepolia } from 'viem/chains'
 export default function App() {
   return (
     <PrivyProvider
-    appId="cm4tv4knx03yv4baen04ozlhv"
+    appId="your-privy-app-id" // add your App ID here
     config={{
       appearance: {
         theme: 'dark',
@@ -397,7 +397,7 @@ import { ConnectButton } from '../components/ConnectButton';
 export default function App() {
   return (
     <PrivyProvider
-    appId="cm4tv4knx03yv4baen04ozlhv"
+    appId="your-privy-app-id" // add your App ID here
     config={{
       appearance: {
         theme: 'dark',


### PR DESCRIPTION
App id can be exposed, but it is unnecessary here: https://docs.privy.io/basics/get-started/dashboard/create-new-app#get-api-credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace hardcoded Privy app ID in documentation code samples with a placeholder value.
> 
> - **Docs (Privy)**:
>   - Replace example `appId` with `"your-privy-app-id"` placeholder in `docs/get-started/how-to/connect-wallet.mdx` Privy `PrivyProvider` code snippets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4472408f68bde1ba11382e34a6b1590644402975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->