### PR TITLE
update fusaka guide, sepolia besu verion

### DIFF
--- a/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/get-started/how-to/run-a-node/beta-v4-migration.mdx
@@ -25,16 +25,14 @@ Confirmation: We will announce the mainnet upgrade go/no-go decision on Monday e
 This upgrade requires updating BOTH your Execution Layer (EL) and Consensus Layer (Maru) clients:
 
 #### Sepolia Testnet:
-- Besu: consensys/linea-besu-package:beta-v4.4-rc7-20251202165721-14b8f4c
-- Maru: consensys/maru:95cab28
-- Geth: >= 1.16.5 + [updated genesis](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/geth/geth-genesis.json)
-- Other EL clients: Check for Fusaka-compatible versions
+- **Besu & Maru versions**: See the latest versions in the [Sepolia docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/docker-compose.yml)
+- **Geth**: See version and configuration in the [Sepolia Geth docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/docker-compose.yml)
+- **Other EL clients**: Check for Fusaka-compatible versions
 
 #### Mainnet:
-- Besu: **consensys/linea-besu-package:beta-v4.4-rc7-20251202165721-14b8f4c** 
-- Maru: **consensys/maru:9737a45** 
-- Geth: >= 1.16.5 + [updated genesis](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/geth/geth-genesis.json)
-- Other EL clients: Check for Fusaka-compatible versions
+- **Besu & Maru versions**: See the latest versions in the [Mainnet docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/docker-compose.yml)
+- **Geth**: See version and configuration in the [Mainnet Geth docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/docker-compose.yml)
+- **Other EL clients**: Check for Fusaka-compatible versions
 
 ### Verify your upgrade
 After upgrading, validate that your node is running the correct fork by checking the forkId:
@@ -145,13 +143,18 @@ Replace your-node-name with a unique identifier for your node (e.g., mycompany-n
 
 ##### Docker Compose example:
 
+For the latest Docker Compose configurations with current versions, see:
+- **Sepolia**: [docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/docker-compose.yml)
+- **Mainnet**: [docker-compose.yml](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/docker-compose.yml)
+
+To add Ethstats monitoring, add this flag to your Besu service:
 ```yaml
 besu-node:
-  image: consensys/linea-besu-package:beta-v4.4-rc7-20251202165721-14b8f4c
+  # ... other configuration from the docker-compose.yml above
   command:
     - --config-file=/var/lib/besu/linea-besu.config.toml
-    - --ethstats=your-node-name:YOUR_ETHSTATS_KEY@ethstats.sepolia.linea.build # sepolia
-    - --ethstats=your-node-name:YOUR_ETHSTATS_KEY@ethstats.linea.build # mainnet
+    - --ethstats=your-node-name:YOUR_ETHSTATS_KEY@ethstats.sepolia.linea.build # for sepolia
+    - --ethstats=your-node-name:YOUR_ETHSTATS_KEY@ethstats.linea.build # for mainnet
 ```
 
 ##### More details here: 


### PR DESCRIPTION
bumb besu version for sepolia, that fixes PRECOMPILE_BLS_C1_MEMBERSHIP_CALLS error:
RC7 (beta-v4.4-rc7-20251202165721-14b8f4c) has:
PRECOMPILE_BLS_C1_MEMBERSHIP_CALLS = 8 (the renamed key)
PRECOMPILE_P256_VERIFY_EFFECTIVE_CALLS = 128 (the new v4.4 key)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Docs now reference docker-compose for latest client versions/configs and refine Ethstats instructions/example.
> 
> - **Docs — Fusaka upgrade guide (`docs/get-started/how-to/run-a-node/beta-v4-migration.mdx`)**
>   - Replace hardcoded EL/CL version listings for Sepolia and Mainnet with pointers to the latest `docker-compose.yml` files.
>   - Clarify Geth references by linking to the corresponding Geth `docker-compose.yml` configs for each network.
>   - Ethstats section: add links to latest Docker Compose configs; simplify the example by referencing external compose config and clarifying `--ethstats` flags for Sepolia/Mainnet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb97376d7b1cba1f04654e3df9de760492a41445. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->