### PR TITLE
Release notes update

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -19,6 +19,14 @@ We maintain a record and brief explanation of Linea Security Council transaction
 
 :::
 
+## Beta v4.4
+
+**Linea Mainnet: 3 December 2025**
+
+**Linea Sepolia: 1 December 2025**
+
+- Upgraded Linea to Fusaka (Ethereum's latest EVM upgrade), detailed in the [upgrade guide](./get-started/how-to/run-a-node/beta-v4-migration.mdx).
+
 ## Beta v4.3
 
 **Linea Mainnet: 17 November 2025**


### PR DESCRIPTION
Updating release notes to include Beta v4.2 and v4.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `docs/release-notes.mdx` with Beta v4.2–v4.4 details and corrects date formatting for v4.1.
> 
> - **Docs: `docs/release-notes.mdx`**
>   - **New release entries**:
>     - `Beta v4.4` (Mainnet: 3 Dec 2025, Sepolia: 1 Dec 2025): upgrade to Fusaka; link to upgrade guide.
>     - `Beta v4.3` (Mainnet: 17 Nov 2025, Sepolia: 10 Nov 2025): limitless prover; throughput to 100 Mgas/s.
>     - `Beta v4.2` (Mainnet: 5 Nov 2025, Sepolia: 31 Oct 2025): burn mechanism updated to include LINEA; link to guide.
>   - **Edits**: normalize date formatting (remove commas) in `Beta v4.1` headings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd0d5dae2bf1ec7545f2b6226a660c0b0e271717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->