### PR TITLE
chore: add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,3 @@ updates:
           - "github/*"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Dependabot configuration to manage GitHub Actions updates weekly with grouped minor/patch bumps, PR limits, labels, and cooldown.
> 
> - **Dependabot (GitHub Actions)**:
>   - Configured in `.github/dependabot.yml` to scan from `/` on a weekly schedule (Mondays 03:00).
>   - Limits to 5 open PRs, applies labels `dependencies` and `github-actions`.
>   - Sets commit message prefix to `deps(actions)` with scope included.
>   - Groups minor/patch updates:
>     - `core-actions-minor-patch`: patterns `actions/*`, `github/*`.
>     - `third-party-actions-minor-patch`: all others, excluding the above.
>   - Adds a 7-day cooldown between updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0fb5bd033fa7f89c8ae1c81b1410efd52d295eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->