### PR TITLE
adds infra builder docs link & light touch cleanup

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -1,11 +1,8 @@
-> [!NOTE]
-> While we welcome meaningful contributions to the documentation, please note that contributions
-> will not affect your eligibility for a potential Linea token generation event (TGE) in any way.
-
 # Linea documentation
 
 ## Quick links
-- [Documentation website](https://docs.linea.build/)
+- [Documentation for builders](https://docs.linea.build/) 
+- [Documentation for Linea infrastructure runners](https://github.com/Consensys/linea-monorepo/tree/main/docs)
 - [Community forum](https://community.linea.build/)
 - [Discord](https://discord.gg/linea)
 - [X](https://x.com/LineaBuild)
@@ -23,7 +20,7 @@ itself is published at [`docs.linea.build`](https://docs.linea.build/).
 
 ## Contribute
 
-See something missing? Error in our documentation? Create an issue [here](https://github.com/Consensys/doc.linea/issues).
+See something missing? Error in our documentation? [Create an issue](https://github.com/Consensys/doc.linea/issues).
 
 Alternatively, help us improve our documentation! [Fork our repo](https://github.com/Consensys/doc.linea/fork),
 create a pull request, and tag us for review.
@@ -32,10 +29,10 @@ Alternatively, get in touch via the [community forum](https://community.linea.bu
 [Linea Discord](https://discord.gg/linea) if you have an issue or question.
 
 Please follow these steps if you wish to contribute:
-1. Please make an issue describing the change you wish to make _before_ you start working on it, and
+1. Make an issue describing the change you wish to make _before_ you start working on it, and
 [link to it in your pull request](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-This is particularly important if you are an ecosystem contributor — submitting your details in an 
-issue first will make it much easier for our docs team to process your contributions.
+> This is particularly important if you are an ecosystem contributor — submitting your details in an 
+> issue first will make it much easier for our docs team to process your contributions.
 2. [Fork our repo](https://github.com/Consensys/doc.linea/fork) so that you're able to work on it. 
 3. Make your changes, paying attention to our [contribution guidelines](#contribution-guidelines).
 4. Review your changes locally. See our [guide](#running-locally) on previewing your 
@@ -50,7 +47,7 @@ consider creating an issue instead.
 
 ### Contribution guidelines
 
-The style of the documentation is based on the [Consensys style guide](https://docs-template.consensys.net/contribute/style-guide),
+This documentation applies the [Consensys style guide](https://docs-template.consensys.net/contribute/style-guide),
 other than for images and other media, for which we have [specific guidelines](#adding-images-to-articles).
 
 #### Orthography


### PR DESCRIPTION
Adds link for infra builders to mono repo.
This is starting point for fixing all the readmes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds infra runners docs link and refines README wording/formatting in quick links and contribute sections.
> 
> - **README.mdx**:
>   - **Quick links**: Add `Documentation for Linea infrastructure runners` and rename main docs link to `Documentation for builders`.
>   - **Contribute**: Improve phrasing and link text; convert ecosystem note to a blockquote; clarify step 1 instructions.
>   - **Contribution guidelines**: Minor wording tweak referencing the Consensys style guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8948f908234752619a6f808f9eb92f37ba4ae46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->