### PR TITLE
URL fix

### DIFF
--- a/docs/get-started/build/network-info.mdx
+++ b/docs/get-started/build/network-info.mdx
@@ -19,7 +19,7 @@ import TabItem from "@theme/TabItem";
       </tr>
       <tr>
           <td align="left"><b>RPC URL</b></td>
-          <td align="left">https://rpc.linea.build or via <a href="https://support.linea.build/hc/en-us/articles/15752713253147">Infura</a> (recommended)</td>
+          <td align="left">https://rpc.linea.build or via <a href="https://docs.metamask.io/services/get-started/endpoints#linea">Infura</a> (recommended)</td>
       </tr>
       <tr>
           <td align="left"><b>Chain ID</b></td>
@@ -43,7 +43,7 @@ import TabItem from "@theme/TabItem";
       </tr>
       <tr>
           <td align="left"><b>RPC URL</b></td>
-          <td align="left">https://rpc.sepolia.linea.build or via <a href="https://support.linea.build/hc/en-us/articles/15752713253147">Infura</a> (recommended)</td>
+          <td align="left">https://rpc.sepolia.linea.build or via <a href="https://docs.metamask.io/services/get-started/endpoints#linea">Infura</a> (recommended)</td>
       </tr>
       <tr>
           <td align="left"><b>Chain ID</b></td>


### PR DESCRIPTION
Fixing a broken URL for Infura endpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Infura links in network info docs for Mainnet and Linea Sepolia to the new docs.metamask.io URL.
> 
> - **Docs**:
>   - Update Infura links in `docs/get-started/build/network-info.mdx`:
>     - Mainnet: `RPC URL` now points to `docs.metamask.io/services/get-started/endpoints#linea`.
>     - Linea Sepolia: `RPC URL` now points to `docs.metamask.io/services/get-started/endpoints#linea`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44c8e2e87f361764e21810aa1fa73bf20b612144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->