### PR TITLE
Update nonce 66 entry in security council record with hyperlink

### DIFF
--- a/docs/security-council-record.mdx
+++ b/docs/security-council-record.mdx
@@ -18,13 +18,13 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
-### December 03, 2025 (Planned)
+### December 03, 2025
 
 #### L1
 
-- **Nonce 66**
+- **[Nonce 66](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0xe2cfd57b3483fb4d469d71c82e5c179d9e84f81920893ce8c1b4e2ec31bab745)**
   - Action: Add verifier for Osaka hard forks and remove unused Prague verifiers.
-  
+
   - Verification: Events confirming the verifier changes were emitted and are viewable in the 
   transaction logs:
     - Osaka: `VerifierAddressChanged` records the new verifier `0x8f8EC9608223C0b8D13238950c03F5D42ceeBb9b`, at index 4.


### PR DESCRIPTION
Update nonce 66 entry in LSC record with hyperlink

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Finalizes the Dec 03, 2025 entry and adds a hyperlink to the L1 nonce 66 Safe transaction.
> 
> - **Docs (`docs/security-council-record.mdx`)**:
>   - **December 03, 2025 (L1)**:
>     - Remove "(Planned)" to finalize the date heading.
>     - Convert `Nonce 66` to a hyperlink pointing to the Safe transaction details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d95045505df5c50f39e00d3d8b72f213932e66d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->