### PR TITLE
Removing Fusaka banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,14 +103,14 @@ const config = {
   themeConfig:
     /* @type {import('@docusaurus/preset-classic').ThemeConfig} */
     {
-      announcementBar: {
-        id: "announcement_bar_2025_12_fusaka",
-        content:
-          '📣 <strong>Running a Linea node?</strong> The Fusaka upgrade is coming to Linea Mainnet on December 3, 2025. Learn how to upgrade <a href="/get-started/how-to/run-a-node/beta-v4-migration/#fusaka-upgrade-guide">here</a>',
-        backgroundColor: "#61dfff",
-        textColor: "#121212",
-        isCloseable: false,
-      },
+      // announcementBar: {
+      //   id: "announcement_bar_2025_12_fusaka",
+      //   content:
+      //     '📣 <strong>Running a Linea node?</strong> The Fusaka upgrade is coming to Linea Mainnet on December 3, 2025. Learn how to upgrade <a href="/get-started/how-to/run-a-node/beta-v4-migration/#fusaka-upgßrade-guide">here</a>',
+      //   backgroundColor: "#61dfff",
+      //   textColor: "#121212",
+      //   isCloseable: false,
+      // },
       colorMode: {
         defaultMode: "dark",
         disableSwitch: false,


### PR DESCRIPTION
Removing Fusaka upgrade banner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the Fusaka upgrade announcement bar in `docusaurus.config.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932138941fb186d472cf15a0c8fd83ab402c64c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->