### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/docs/get-started/how-to/get-testnet-eth.mdx
+++ b/docs/get-started/how-to/get-testnet-eth.mdx
@@ -22,6 +22,7 @@ See our [support guide to getting a Linea Names domain](https://support.linea.bu
 ## Other faucets
 
 - [HackQuest](https://hackquest.io/en/faucets/59141) (and check out their [Linea Learning Track](https://hackquest.io/en/learning-track/9be129e7-575b-49bd-a64e-1bbe32427ace))
+- [ethfaucet.com](https://ethfaucet.com?utm_source=linea_docs&utm_medium=docs)
 
 Alternatively, use the [Linea native bridge](https://linea.build/hub/bridge/native-bridge) to 
 [bridge testnet ETH between Sepolia and Linea Sepolia](../how-to/bridge.mdx).


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Linea Sepolia ETH for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new faucet option to the Linea testnet ETH guide.
> 
> - Updates `docs/get-started/how-to/get-testnet-eth.mdx` to include `ethfaucet.com` (with UTM params) under "Other faucets"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b99e6c613c18598d1eee1e2d5a458d20032afd7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->