### PR TITLE
updates repo page

### DIFF
--- a/docs/technology/repos.mdx
+++ b/docs/technology/repos.mdx
@@ -7,14 +7,18 @@ import DocCardList from "@theme/DocCardList";
 
 Linea is open source, meaning you can inspect the code yourself. 
 
-Each repository that hosts the Linea software is listed below, together with a description of its 
-purpose.
+This page describes each repository that hosts the Linea software and its purpose.
 
 ## [`linea-monorepo`](https://github.com/Consensys/linea-monorepo)
 
-The principal Linea repository. This mainly includes the smart contracts covering Linea's core 
-functions, the prover in charge of generating ZK proofs, the coordinator responsible for multiple 
-orchestrations, and the postman for executing bridge messages. 
+The principal Linea repository. This includes the:
+
+- Coordinator: responsible for multiple orchestrations
+- Linea-Besu plugins: to support the sequencer, tracer, and RPC nodes
+- Postman: for executing cross-chain messages
+- Prover: in charge of generating ZK proofs
+- Sequencer: responsible for ordering, building, and executing blocks
+- Smart contracts: covering Linea's core functions
 
 ## [`linea-specification`](https://github.com/Consensys/linea-specification)
 
@@ -30,30 +34,26 @@ The constraints specified here are implemented in the `linea-constraints` repo.
 Implementation of the constraint system specified in the `linea-specification` repo.
 
 Linea's constraint system applies to so-called "traces", which are large matrices of fixed width 
-(i.e. fixed number of columns or "registries") and variable depth (correlating with the complexity 
+(that is, a fixed number of columns or "registries") and variable depth (correlating with the complexity 
 of the EVM execution). The production of such traces is the job of the `linea-tracer` repo.
 
 Constraints and traces are two of the inputs to the prover.
 
 ## [`linea-tracer`](https://github.com/Consensys/linea-tracer)
 
+Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover.
+
 Tracing refers to the process of extracting data from the execution of an EVM client in order to 
 construct large matrices known as execution traces. Execution traces are subject to the constraint 
 system specified in the `linea-specification` repo and implemented in the `linea-constraints` repo.
 
-The repository contains the elements of Linea responsible for this process.
+## [`linea-besu-upstream`](https://github.com/Consensys/linea-besu-upstream)
 
-## [`linea-besu`](https://github.com/Consensys/linea-besu)
+A Besu build configured for Linea.
 
-The Linea implementation of Besu, an Ethereum client, extended with plugins.
+[Besu](https://besu.hyperledger.org/) is an Ethereum client that supports [Linea as a named network](https://besu.hyperledger.org/public-networks/reference/cli/options#network), with optional plugins for additional functionality.
 
-As Linea is EVM-equivalent, it is compatible with standard Ethereum clients without plugins; for 
-example, you can also [run a Linea node using other clients](../get-started/how-to/run-a-node/index.mdx). 
-
-## [`linea-sequencer`](https://github.com/Consensys/linea-sequencer)
-
-The implementation of the sequencer, the component of Linea responsible for ordering and building 
-blocks, as well as executing them. 
+As Linea is EVM-equivalent, it is compatible with [standard Ethereum clients](../get-started/how-to/run-a-node/index.mdx). 
 
 ## [`gnark`](https://github.com/Consensys/gnark)
 
@@ -61,7 +61,7 @@ Linea's zk-SNARK with a high-level API to design circuits and efficient cryptogr
 
 ## [`shomei`](https://github.com/Consensys/shomei)
 
-A plugin that extends Besu functionality by maintaining and updating Linea's state. 
+A plugin that extends Besu's functionality by maintaining and updating Linea's state. 
 
 ## [`maru`](https://github.com/Consensys/maru)
 


### PR DESCRIPTION
Fixes: #1279 The repo readmes were out of date, prs are in to update those and the same updates are being reflected here. Briefly, the monorepo is now housing more of the tech stack.

includes minor proof

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates repository documentation to reflect current architecture and naming.
> 
> - Expands `linea-monorepo` section to list key components: Coordinator, Linea-Besu plugins, Postman, Prover, Sequencer, and smart contracts
> - Replaces `linea-besu` with `linea-besu-upstream`, noting Besu support for Linea and compatibility with standard Ethereum clients
> - Clarifies `linea-tracer` as a Linea-Besu plugin and tightens wording around constraints/traces
> - Minor phrasing/grammar improvements across the page
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b0028e9059c7d6945cb1a5603fcfa85b3cffde8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->