### PR TITLE
rmvs 2025

### DIFF
--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -7,7 +7,7 @@ image: /img/socialCards/overview.jpg
 Linea is a secure, low-cost, and Ethereum-equivalent layer 2 blockchain built to bring the world 
 onchain without compromising on security and decentralization. 
 
-Linea has been incubated within Consensys and will decentralize in 2025. 
+Linea has been incubated within Consensys and is working towards decentralization. 
 
 Our mission is to empower developers to build the next generation of decentralized applications and 
 onboard the next billion users to web3. 

--- a/docs/technology/architecture.mdx
+++ b/docs/technology/architecture.mdx
@@ -4,7 +4,7 @@ description: An overview of how Linea works
 image: /img/socialCards/architecture.jpg
 ---
 
-Linea aims to be a fully decentralized, permissionless network. To support this goal, the Linea architecture is made up of three main elements:
+Linea is designed to be a fully decentralized, permissionless network. The Linea architecture is made up of three main elements:
 
 - Sequencer
 - Prover
@@ -12,8 +12,8 @@ Linea aims to be a fully decentralized, permissionless network. To support this 
 
 ## Current state
 
-Linea is in mainnet status, and the team is fervently working towards full decentralization. 
-The following is a good representation of the main components of Linea, and how they interact:
+Linea Mainnet is in beta status, and the team is working towards full decentralization. 
+The following represents the main components of Linea, and how they interact:
 
 <div className="responsive-graphic">
   <picture>


### PR DESCRIPTION
removes ref to 2025, needs discussion on solution:

1. Ideally link to public roadmap
2. I could use most recent roadmap discussion on community forum (but that will age quickly)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to reflect current decentralization status and mainnet phase.
> 
> - In `get-started/index.mdx`, removes the time-bound "decentralize in 2025" phrasing and states Linea is "working towards decentralization"
> - In `technology/architecture.mdx`, rewords intro for clarity and updates "Current state" to "Linea Mainnet is in beta"; minor phrasing tweaks to component diagram description
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a09c506a5cd347053389e5272bf70c4cafda88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->