### PR TITLE
Remove chainlens explorer

### DIFF
--- a/docs/network/build/block-explorers.mdx
+++ b/docs/network/build/block-explorers.mdx
@@ -47,11 +47,6 @@ As users take actions on the network, there are changes to those accounts and to
           <td>https://oklink.com/linea</td>
           <td>`https://oklink.com/docs/en/#welcome-to-oklink-api`</td>
         </tr>
-        <tr>
-          <td>Chainlens</td>
-          <td>https://linea.chainlens.com/</td>
-          <td>`https://linea.chainlens.com/api`</td>
-        </tr>
         {/* It would appear that, as of August 14, 2025, Socialscan has deprecated the Linea explorer.
         However, manta.socialscan.io for example still exists; leaving this here for now in case the Linea instance is fixed. */}
         {/* <tr>


### PR DESCRIPTION
Appears to be down

Not sure if it is a temporary issue or not, decided to create PR just in case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the deprecated `Chainlens` entry from the Linea block explorers docs.
> 
> - Deletes the `Chainlens` row (site and API) from `docs/network/build/block-explorers.mdx`'s explorers table
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33313fa4916521810ee4efd386006df7e680636b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->