### PR TITLE
How to write and deploy assertions

### DIFF
--- a/docs/network/how-to/write-and-deploy-assertions.mdx
+++ b/docs/network/how-to/write-and-deploy-assertions.mdx
@@ -4,8 +4,8 @@ description: A guide to developing Credible Layer assertions
 sidebar_position: 4
 ---
 
-The Credible Layer is security infrastructure that lets you define security rules for your smart
-contracts and enforces them at the network level. When a transaction violates your rules, it's
+The Credible Layer is security infrastructure built by [Phylax Systems](https://phylax.systems) that lets you define security rules for your smart
+contracts and enforce them at the network level. When a transaction violates your rules, it's
 dropped *before* it can execute—preventing exploits rather than detecting them after the damage is
 done.
 
@@ -239,7 +239,7 @@ The ownership transfer should timeout, confirming the assertion blocked it.
 - [Cheatcodes Reference](https://docs.phylax.systems/credible/cheatcodes-reference) — All available
   assertion cheatcodes
 
-## Community & support
+## Phylax community & support
 
 - [Telegram](https://t.me/phylax_credible_layer)
 - [X/Twitter](https://x.com/phylaxsystems)


### PR DESCRIPTION
- Add documentation for writing and deploying Credible Layer assertions on Linea
- Covers architecture overview, quick start guide, and deployment workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new how-to doc for developing and deploying Credible Layer assertions.
> 
> - New `docs/network/how-to/write-and-deploy-assertions.mdx` with architecture overview, assertion capabilities, and use cases
> - Quickstart covers installing `pcl`, cloning the starter, and an example `OwnableAssertion` with `triggers`, `ph.forkPreTx()`, and `ph.forkPostTx()`
> - Step-by-step: test (`pcl test`), deploy contract (Foundry), authenticate, store/submit via `pcl`, deploy via dapp, and verify blocking behavior
> - Includes links to deeper docs and community resources
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ce314d1d277a30eb351fd70112da3e3f6343cf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->