### PR TITLE
adds missing redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -428,7 +428,8 @@
             "/get-started/quickstart/connect",
             "/technology/network-data",
             "/technology/network-data.mdx",
-            "/network/build/network-info"
+            "/network/build/network-info",
+            "/network/build/network-info.mdx"
         ]
     },
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds two missing redirects to route legacy `network-info` URLs to the `connect` page.
> 
> - Updates `redirects.json` `to: /network/build/connect` mapping by adding `from` entries for `/network/build/network-info` and `/network/build/network-info.mdx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b58afeb92a442266d064f6b5e1ada609f8d6e16b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->