### PR TITLE
vale-raw-output

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,6 +16,5 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Vale
-        uses: Consensys/github-actions/docs-spelling-check@main
-        with:
-          FILEPATHS: "docs"
+        uses: Consensys/github-actions/docs-spelling-check@reviewdog-vale
+

--- a/docs/protocol/architecture/coordinator.mdx
+++ b/docs/protocol/architecture/coordinator.mdx
@@ -6,7 +6,7 @@ image: /img/socialCards/coordinator.jpg
 
 ## What is it?
 
-The coordinator is Linea’s coordination module across a number of functions. It is also the channel through which information on the state of Ethereum comes into Linea, and through which information on the state of Linea returns to Ethereum.
+The coordinator  is Linea’s coordination module across a number of functions. It is also the channel through which information on the state of Ethereum comes into Linea, and through which information on the state of Linea returns to Ethereum.
 
 ## What does it do?
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI configuration change plus a small documentation edit; low impact and no production code paths are affected.
> 
> **Overview**
> Switches the spelling CI job to run `Consensys/github-actions/docs-spelling-check@reviewdog-vale` instead of `@main`, and drops the explicit `FILEPATHS: "docs"` configuration.
> 
> Applies a minor edit in `docs/protocol/architecture/coordinator.mdx` (text change in the “What is it?” section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e7d4b28a069fa424b2f21a082342fccdabef76f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->