### PR TITLE
[Chore] - Add nonce 67 for LSC L1

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -21,7 +21,7 @@ you can take to verify this information.
 
 ### February 26, 2026
 #### L1
-- **[Nonce 67](TBD)**
+- **`Nonce 67` - Link TBD**
   - Actions: 
     - Remove Zodiac Roles Modifier Module
     - Upgrade LineaRollup to V7.0 with Yield Boost functionality not enabled.


### PR DESCRIPTION
Adds nonce 67 for L1 Linea Security Council transaction - link to be added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that records a new transaction nonce and verification notes; no runtime or contract code is modified.
> 
> **Overview**
> Adds a new entry to `docs/changelog/security-council-record.mdx` documenting Linea Security Council **L1 nonce 67** (Feb 26, 2026), including intended actions (removing the Zodiac Roles Modifier module and upgrading `LineaRollup` to v7.0 with yield boost disabled) and the on-chain event log cues to verify them. The Safe transaction link is left as **TBD**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d6f6bf1138e97e7c9d8cb2cba37688cc371e3cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->