### PR TITLE
[Chore] - Add link to nonce 67

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -21,7 +21,7 @@ you can take to verify this information.
 
 ### February 26, 2026
 #### L1
-- **`Nonce 67` - Link TBD**
+- **[Nonce 67](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0xa1c97a648c46f47e3c9e377c7a372294d9fa4eacb464e7e32932ac1c91cd819c)**
   - Actions: 
     - Remove Zodiac Roles Modifier Module
     - Upgrade LineaRollup to V7.0 with Yield Boost functionality not enabled.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a single hyperlink; no runtime or security-impacting code paths are affected.
> 
> **Overview**
> Updates the Linea Security Council transaction record to replace the placeholder for February 26, 2026 (L1) **Nonce 67** with the finalized Safe transaction link, enabling direct verification of the recorded actions/events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 240699b960bbb81026b3c443161fcc562fb51c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->