### PR TITLE
[Chore] - Add extra detail for council review

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -41,7 +41,7 @@ you can take to verify this information.
         - `YIELD_PROVIDER_STAKING_ROLE` (0x220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db347258)
       - `(Un)pauseTypeRoleSet` for index 9 (`NATIVE_YIELD_STAKING`)
         - To pause the type `PAUSE_NATIVE_YIELD_STAKING_ROLE` is required.
-        - To unpause the type `UNPAUSE_NATIVE_YIELD_STAKING_ROLE` is required.
+        - To remove the pause the type `UNPAUSE_NATIVE_YIELD_STAKING_ROLE` is required.
       - `YieldManagerChanged` Yield manager set at address `0xeb63cabdd78537b9b72a2afb573f7caa91bd8d94`
       - `LineaRollupVersionChanged` "6.0" to "7.0" (hex encoded)
       - `Initialized` - reinitialized to 7


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates to the security council transaction record; no runtime or onchain logic is changed.
> 
> **Overview**
> Adds extra verification detail to the `Nonce 67` entry in `docs/changelog/security-council-record.mdx`, including a link to Yield Boost audit reports, the audited deployment/implementation addresses, explicit role IDs granted to the security council and automation service, and clarified `(Un)pauseTypeRoleSet` requirements for `NATIVE_YIELD_STAKING`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64f98c2bddeab6f4b6ada187a8410ce5f4848a0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->