### PR TITLE
replaces cta with form

### DIFF
--- a/docs/stack/features/index.mdx
+++ b/docs/stack/features/index.mdx
@@ -30,7 +30,7 @@ The stack is designed to support enterprises with an extensible and configurable
 
 :::tip
 
-Reach out to [support.linea.build](https://support.linea.build/) for assistance in designing your
+[Reach out](https://forms.gle/eip4XrYhPFDuLtDQ8) for assistance in designing your
 enterprise deployment. From transaction ordering, to data availability, to block times, Linea's rich
 extensible architecture supports concise ledger configurations to match your enterprise needs.
 

--- a/docs/stack/features/validium.mdx
+++ b/docs/stack/features/validium.mdx
@@ -12,7 +12,7 @@ disclosure.
 
 :::important
 
-Reach out to [support.linea.build](https://support.linea.build/) to enquire about rollup-as-a-service, wherein all or part of the operations are supported by Linea and her partners.
+[Reach out](https://forms.gle/eip4XrYhPFDuLtDQ8) to enquire about rollup-as-a-service, wherein all or part of the operations are supported by Linea and her partners.
 
 :::
 

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -75,5 +75,5 @@ deep protocol expertise.
 
 ## Next steps
 
-Ready to build? Reach out to [support.linea.build](https://support.linea.build/) to enquire about our rollup-as-a-service
+Ready to build? [Reach out](https://forms.gle/eip4XrYhPFDuLtDQ8) to enquire about our rollup-as-a-service
 or to access our dedicated design team who will configure the stack to your business needs.


### PR DESCRIPTION
Fixes #1342 as test of the current link resulted in a "not us"

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates outbound CTA links; main risk is an incorrect/broken URL impacting user contact flow.
> 
> **Overview**
> Updates Linea stack docs CTAs to **replace `support.linea.build` links with a single Google Form** (`https://forms.gle/eip4XrYhPFDuLtDQ8`) across the Features, Validium/Privacy, and Stack Overview pages.
> 
> No product behavior changes—only documentation link/wording adjustments for how readers contact the team about enterprise deployments and rollup-as-a-service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f030de5931b4b39da69281156f3f2565c1d654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->