### PR TITLE
[Chore] - Address rotation docs for L2 Security Council

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -21,7 +21,7 @@ you can take to verify this information.
 
 ### March TBD, 2026
 #### L2
-- **Nonce 51 - Link TBD**
+- **[Nonce 51](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD&id=multisig_0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD_0x16c878b15579d7418f6df9ed006fa6c35294422df86691c273821b48fe7bc627)**
   - Actions: Account rotation.
     - Grant `L1_L2_MESSAGE_SETTER_ROLE` ( `0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415` ) to the new address ( `0x2b0f9c76970975aec03784efd763623757ef7652` )
     - Revoke `L1_L2_MESSAGE_SETTER_ROLE` ( `0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415` ) from the existing address ( `0xc1c6b09d1eb6fca0ff3ca11027e5bc4aedb47f67` )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new transaction record entry; no code or contract behavior is modified.
> 
> **Overview**
> Adds a new **March 2026 (TBD)** entry to `docs/changelog/security-council-record.mdx` documenting L2 Security Council multisig **nonce 51** as an account rotation.
> 
> The entry records granting and revoking `L1_L2_MESSAGE_SETTER_ROLE` between two addresses and includes verification guidance via matching `RoleGranted`/`RoleRevoked` events and a Safe transaction link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a18d71b90e33b66fa242d8cc99f0a3e7eb7697f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->