### PR TITLE
docs: add detail on transaction validity conditions

### DIFF
--- a/docs/network/overview/known-finality-state.mdx
+++ b/docs/network/overview/known-finality-state.mdx
@@ -102,11 +102,27 @@ The sequencer orders transactions, taking into account the
 [priority fee paid](../how-to/gas-fees.mdx#understand-the-gas-price-calculation). Valid
 transactions are placed into blocks in the correct sequence and executed.
 
-::::note[Validity]
+::::note[Transaction validity conditions]
 
 While the Linea chain may be followed using any Ethereum-compatible client, transaction validity
 conditions are specific to Linea, and differ slightly from those of other networks, including
 Ethereum.
+
+Linea enforces the following validity conditions before a transaction can be included in a block:
+
+- **Standard EVM checks**: Valid signature, correct nonce, sufficient balance to cover
+  `value + (gasLimit × gasPrice)`, and gas limit within block gas limits.
+- **Profitability threshold**: Each transaction must meet a minimum profitability threshold for
+  the sequencer. This means the fee paid by the transaction must be sufficient to cover the
+  cost of processing and proving the transaction. Transactions that do not meet this threshold
+  are rejected from the mempool.
+- **EIP-1559 gas pricing**: Linea uses the same EIP-1559 fee mechanism as Ethereum, with a
+  base fee that adjusts based on block utilization. See
+  [predictable pricing](./predictable-pricing.mdx) for details on how the base fee stabilizes
+  on Linea.
+
+For more information on how Linea differs from Ethereum, see
+[Ethereum differences](./ethereum-differences.mdx).
 
 ::::
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -205,7 +205,7 @@ for [private networks](../../stack/how-it-works/deployment-models.mdx#private-va
 These architectural components support transactions from submission to finalization. 
 
 1. Submission: transactions enter the mempool via the RPC entrypoint of a [full node](#full-nodes).
-2. Block building: the [sequencer](./sequencer/index.mdx) orders and executes transactions into blocks.
+2. Block building: the [sequencer](./sequencer/index.mdx) validates, orders, and executes transactions into blocks. Linea enforces specific [transaction validity conditions](../../network/overview/known-finality-state.mdx#step-2-block-building), including a profitability threshold, that differ from Ethereum.
 3. State tracking: the [state manager](./state-manager.mdx) updates the state representation;
    the [tracer](./sequencer/traces-generator.mdx) generates traces.
 4. Conflation: the [coordinator](./coordinator.mdx) groups blocks into batches.


### PR DESCRIPTION
## Summary

Expands the transaction validity note in the transaction lifecycle section to detail Linea-specific transaction validity conditions.

### Changes

- **`docs/network/overview/known-finality-state.mdx`**: Expanded the `::::note[Validity]` section with specific details on:
  - Standard EVM checks (signature, nonce, balance)
  - Profitability threshold enforcement by the sequencer
  - EIP-1559 gas pricing specifics on Linea
  - Cross-references to predictable pricing and Ethereum differences pages
- **`docs/protocol/architecture/index.mdx`**: Added a cross-reference from the architecture transaction lifecycle overview to the detailed validity conditions

Closes #1322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies transaction inclusion rules and adds a cross-reference in the transaction lifecycle description.
> 
> **Overview**
> Adds explicit Linea-specific *transaction validity conditions* to the fast-finality docs, expanding the sequencer validity note to list standard EVM checks, a sequencer profitability threshold, and EIP-1559/base-fee behavior with links to related pages.
> 
> Updates the architecture transaction lifecycle to state the sequencer validates transactions and to deep-link readers to the new validity-conditions section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 500bebf3c9a6b277ecd5e70874c41623108d2513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->