### PR TITLE
release notes update

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -27,10 +27,11 @@ We maintain a record and brief explanation of [Linea Security Council transactio
 
 - Switches prover to small fields, enabling faster proof generation. **This change deprecates the ENS resolver contract; you will need to update your configuration to point to the new contract address.** More information [here](../network/how-to/deploy-subdomain.mdx). 
 - Increases throughput to 200 Mgas/s.
+- Introduces EIP-7702, enabling gassless transactions, batch transactions, and session keys. No user action or migration required.
 
 ## Beta v5.0
 
-**Linea Mainnet: 23 February 2026**
+**Linea Mainnet: 30 March 2026**
 
 **Linea Sepolia: 21 December 2025**
 


### PR DESCRIPTION
Updating release ntoes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; updates release-note text without affecting runtime behavior.
> 
> **Overview**
> Updates `release-notes.mdx` for upcoming releases: adds a Beta v6.0 bullet noting EIP-7702 support (gasless/batch/session-key transactions) and revises the Beta v5.0 Linea Mainnet date to **30 March 2026**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2edd0b0e4238bd9ac46f7cf8fbffa4bc080fbdc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->