### PR TITLE
Improved transaction record for L2 nonce 51

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -19,13 +19,14 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
-### March TBD, 2026
+### March 04, 2026
 #### L2
 - **[Nonce 51](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD&id=multisig_0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD_0x16c878b15579d7418f6df9ed006fa6c35294422df86691c273821b48fe7bc627)**
   - Actions: Account rotation.
-    - Grant `L1_L2_MESSAGE_SETTER_ROLE` ( `0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415` ) to the new address ( `0x2b0f9c76970975aec03784efd763623757ef7652` )
-    - Revoke `L1_L2_MESSAGE_SETTER_ROLE` ( `0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415` ) from the existing address ( `0xc1c6b09d1eb6fca0ff3ca11027e5bc4aedb47f67` )
-Verification
+    - Grant `L1_L2_MESSAGE_SETTER_ROLE` (`0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415`) to the new address (`0x2b0f9c76970975aec03784efd763623757ef7652`).
+    - Revoke `L1_L2_MESSAGE_SETTER_ROLE` (`0x4705265620026983c754c5288b65446d794a03174326ec6d7c0b5c7f1fd67415`) from the existing address (`0xc1c6b09d1eb6fca0ff3ca11027e5bc4aedb47f67`).
+
+  - Verification
     - Corresponding `RoleGranted` and `RoleRevoked` events emitted matching the addresses and `L1_L2_MESSAGE_SETTER_ROLE` hash value.
 
 ### February 26, 2026


### PR DESCRIPTION
Improved transaction record for L2 nonce 51.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a changelog record; no runtime, contract, or operational behavior changes.
> 
> **Overview**
> Updates `docs/changelog/security-council-record.mdx` to finalize the March 2026 L2 `Nonce 51` entry by replacing the placeholder date with `March 04, 2026` and tightening the action/verification formatting (punctuation, spacing, and a clearer `Verification` section) for the role grant/revoke details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7a7c732ef6829e8141841540187a917424b6620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->