### PR TITLE
add onBrokenAnchors to config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,6 +22,7 @@ const config = {
   url: "https://docs.linea.build",
   baseUrl: "/",
   onBrokenLinks: "throw",
+  onBrokenAnchors: "throw",
   favicon: "img/favicons/favicon-96x96.png",
   trailingSlash: false,
 


### PR DESCRIPTION
add onBrokenAnchors to config
- Context: https://docusaurus.io/docs/api/docusaurus-config#onBrokenAnchors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config change, but it can cause CI/builds to fail if the docs contain invalid or missing anchor links.
> 
> **Overview**
> Tightens Docusaurus link validation by setting `onBrokenAnchors: "throw"` in `docusaurus.config.js`, causing builds to error on broken in-page anchor references (similar to existing `onBrokenLinks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 085517cee278f4d40ee2323d207f3728717cb81e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->