### PR TITLE
 Add JAW.id to account abstraction tools

### DIFF
--- a/docs/network/build/tools/account-abstraction/jaw.mdx
+++ b/docs/network/build/tools/account-abstraction/jaw.mdx
@@ -1,0 +1,43 @@
+---
+title: JAW.id
+
+---
+
+## Identity-first smart accounts
+
+[JAW.id](https://jaw.id) is a TypeScript SDK for building identity-first smart accounts on EVM
+chains. It provides passkey-authenticated, programmable, and extensible accounts through delegated
+permissions, replacing seed phrases and passwords with biometric authentication.
+
+JAW.id is compatible with Linea, enabling developers to onboard users into smart accounts with a
+seamless, web2-adjacent experience.
+
+### Key features
+
+- [**Passkey authentication**](https://docs.jaw.id/concepts/passkeys): Users authenticate with
+  Face ID, fingerprint, or device PIN via WebAuthn. Passkeys sync across devices through iCloud or
+  Google accounts, providing phishing-resistant security without seed phrases.
+- [**Gas sponsoring**](https://docs.jaw.id/configuration/paymasters): Sponsor gas fees for your
+  users through configurable paymasters, eliminating the need for users to hold ETH.
+- [**Batch operations**](https://docs.jaw.id/api-reference/wallet_sendCalls): Execute multiple
+  onchain actions atomically in a single transaction.
+- [**Programmable permissions**](https://docs.jaw.id/concepts/permissions): Grant controlled,
+  scoped access to third parties through a delegated permission layer.
+
+### Integration
+
+JAW.id offers multiple integration paths:
+
+- [**Wagmi connector**](https://docs.jaw.id/wagmi) (`@jaw.id/wagmi`): Drop-in connector for React
+  applications, with custom hooks for connection management and transactions.
+- [**EIP-1193 provider**](https://docs.jaw.id/api-reference): For non-React or framework-agnostic
+  use cases.
+- [**Server-side accounts**](https://docs.jaw.id/account): Use `Account.fromLocalAccount` to wrap
+  any viem `LocalAccount` (from Turnkey, a private key, or another KMS) into a JAW smart account
+  for server-side workflows.
+
+### Getting started
+
+To start building with JAW.id on Linea, get your API key at the
+[JAW.id Dashboard](https://dashboard.jaw.id) and visit the
+[JAW.id documentation](https://docs.jaw.id).

--- a/docs/network/build/tools/account-abstraction/jaw.mdx
+++ b/docs/network/build/tools/account-abstraction/jaw.mdx
@@ -18,7 +18,8 @@ seamless, web2-adjacent experience.
   Face ID, fingerprint, or device PIN via WebAuthn. Passkeys sync across devices through iCloud or
   Google accounts, providing phishing-resistant security without seed phrases.
 - [**Gas sponsoring**](https://docs.jaw.id/configuration/paymasters): Sponsor gas fees for your
-  users through configurable paymasters, eliminating the need for users to hold ETH.
+  users or let them pay in stablecoins through configurable paymasters, eliminating the need to
+  hold ETH.
 - [**Batch operations**](https://docs.jaw.id/api-reference/wallet_sendCalls): Execute multiple
   onchain actions atomically in a single transaction.
 - [**Programmable permissions**](https://docs.jaw.id/concepts/permissions): Grant controlled,
@@ -32,9 +33,7 @@ JAW.id offers multiple integration paths:
   applications, with custom hooks for connection management and transactions.
 - [**EIP-1193 provider**](https://docs.jaw.id/api-reference): For non-React or framework-agnostic
   use cases.
-- [**Server-side accounts**](https://docs.jaw.id/account): Use `Account.fromLocalAccount` to wrap
-  any viem `LocalAccount` (from Turnkey, a private key, or another KMS) into a JAW smart account
-  for server-side workflows.
+- [**Headless accounts**](https://docs.jaw.id/account): For headless or server-side implementations, integrate JAW smart accounts using the low-level `Account` class.
 
 ### Getting started
 

--- a/docs/network/build/tools/account-abstraction/jaw.mdx
+++ b/docs/network/build/tools/account-abstraction/jaw.mdx
@@ -15,8 +15,7 @@ seamless, web2-adjacent experience.
 ### Key features
 
 - [**Passkey authentication**](https://docs.jaw.id/concepts/passkeys): Users authenticate with
-  Face ID, fingerprint, or device PIN via WebAuthn. Passkeys sync across devices through iCloud or
-  Google accounts, providing phishing-resistant security without seed phrases.
+  Face ID, fingerprint, or device PIN via WebAuthn. Phishing-resistant, synced across devices via iCloud/Google (works as transport layer).
 - [**Gas sponsoring**](https://docs.jaw.id/configuration/paymasters): Sponsor gas fees for your
   users or let them pay in stablecoins through configurable paymasters, eliminating the need to
   hold ETH.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding a new vendor/tool page; no runtime code paths are affected.
> 
> **Overview**
> Adds a new account abstraction tool doc page for `JAW.id`, describing its passkey-based smart accounts, key features (gas sponsoring, batching, delegated permissions), and integration/getting-started links for Linea builders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 722bc33752693cbf63f65be23eb6bd5eaf4fda56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->