### PR TITLE
[Chore] - add verifier actions for LSC

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -55,7 +55,7 @@ you can take to verify this information.
         - `0x04728BF704a716C26F9EF4085013b760AC885631` Linea Rollup will use the audited implementation address.
     - Linea Rollup: 
       - `RoleGranted` 4 roles granted to the security council `0x892bb7EeD71efB060ab90140e7825d8127991DD3`.
-        - `SET_YIELD_MANAGER_ROLE` (0x76ef52a5344b10ed112c1dg48c7c06f51e919518ea6fb005f9b25b359b955e3be)
+        - `SET_YIELD_MANAGER_ROLE` (0x76ef52a5344b10ed112c1d48c7c06f51e919518ea6fb005f9b25b359b955e3be)
         - `YIELD_PROVIDER_STAKING_ROLE` (0x220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db347258)
         - `PAUSE_NATIVE_YIELD_STAKING_ROLE`(0xcc10d6eec3c757d645e27b3f3001a3ba52f692da0bce25fabf58c6ecaf376450)
         - `UNPAUSE_NATIVE_YIELD_STAKING_ROLE` (0x4b4665d8754e6ea0608430ef3e91c1b45c72aafe8800e289cd35f38d85361858)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the on-chain transaction record; risk is limited to potential inaccuracies in the recorded nonce/action details.
> 
> **Overview**
> Adds a new entry to `docs/changelog/security-council-record.mdx` for the **March 23, 2026 (L1) Linea Security Council** transaction (`Nonce 68`), documenting verifier configuration updates (set a new EIP-7702 type-4 verifier at index 0 and unset the old verifier at index 3) with a link and event-based verification notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc1833112671a8400211d331380edc2a75ff032a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->