### PR TITLE
Alchemy link update

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -12,7 +12,7 @@ image: /img/socialCards/node-providers.jpg
     <th>WebSocket</th>
   </tr>
   <tr>
-    <td><a href="https://alchemy.com/">Alchemy</a></td>
+    <td><a href="https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=linea">Alchemy</a></td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
   </tr>


### PR DESCRIPTION
Updating a link to Alchemy per their request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single external URL; impact is limited to where the link directs users.
> 
> **Overview**
> Updates the `Alchemy` entry in the `Node providers` docs to point to `dashboard.alchemy.com` with Linea referral UTM parameters instead of the generic `alchemy.com` homepage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 930e8010b6858b9a6cfae2312ec15aef6c92ef3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->