### PR TITLE
[Chore] - add missing operation

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -25,8 +25,10 @@ you can take to verify this information.
 - **[Nonce 69](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x4bd7cb5cab64c9d64778f35bfe1cddbdceec5a57849f99b9ba54d86d580776fb)**
   - Actions: 
     - Add verifier at index 1 supporting EIP-7702 Type-4 transactions.
-  - Verification: Events confirming the verifier changes were emitted and are viewable in the 
-  transaction logs: `VerifierAddressChanged` records the new verifier `0x66355689a9f067eeb9dc9d899e4192676988279c`, at index 1.
+    - Unset verifier at index 4.
+  - Verification: Events confirming the verifier changes were emitted and are viewable in the transaction logs:
+    - Set verifier: `VerifierAddressChanged` records the new verifier `0x66355689a9f067eeb9dc9d899e4192676988279c`, at index 1.
+    - Unset: `VerifierAddressChanged` unset the verifier at index 4.
 
 ### March 23, 2026
 #### L1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main risk is misinformation if the recorded onchain action/event wording is incorrect.
> 
> **Overview**
> Updates the `Linea Security Council transaction record` entry for **March 24, 2026 (Nonce 69)** to include the missing operation to **unset the verifier at index 4**, and adjusts the verification section to explicitly document both the set and unset `VerifierAddressChanged` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c963e05ed3df61dc54f1fc068b78e0ee50b443c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->