### PR TITLE
docs: add Get Featured page to Launch an app section

### DIFF
--- a/docs/network/build/launch-an-app/get-featured.mdx
+++ b/docs/network/build/launch-an-app/get-featured.mdx
@@ -1,0 +1,133 @@
+---
+title: Get featured
+sidebar_position: 5
+description: >-
+  Nominate your app for featured placement on the Linea Hub and amplification on
+  X through the Developer Hub.
+---
+
+# Get featured on the Linea Hub
+
+Getting [listed on the Linea Hub](./hub.mdx) is a great first step, but featuring and amplification
+are what drive real visibility. Use the **Get Featured** tab in the
+[Developer Hub](https://developer.linea.build/get-featured) to nominate your app for homepage
+placement and co-promotion on X.
+
+## Why nominate your app?
+
+The Linea editorial team reviews every nomination and considers it for featuring opportunities. A
+successful nomination can unlock:
+
+- **Featured placement** on the Linea Hub homepage.
+- **Amplification on X** — coordinated posts, retweets, and co-marketing with the Linea account.
+- **Newsletter highlights** and ecosystem roundups.
+- **Campaign promotion** — spotlight your live events, launches, or incentive programs directly on
+  the Hub.
+
+Featuring is earned, not guaranteed. Apps that are live, generating onchain activity, and delivering
+a polished user experience have the strongest nominations.
+
+## Before you nominate
+
+Your app must be [submitted for review](./hub.mdx) in the Developer Hub before you can create a
+nomination. The Token and Events sections also become available only after your app submission.
+
+Make sure your [app listing](./hub.mdx) is complete and polished — reviewers will look at it
+alongside your nomination.
+
+## How to submit a nomination
+
+1. Sign in to the [Developer Hub](https://developer.linea.build/) and select the app you want to
+   nominate.
+1. Open the **Get Featured** tab in the navigation.
+1. Select **New Nomination** in the sidebar.
+1. Fill in the nomination form (see below).
+1. Click **Submit Nomination**.
+
+Once submitted, the editorial team will evaluate your nomination and reach out if they need more
+information.
+
+## Nomination form
+
+### Name
+
+Give your nomination a clear, descriptive title — for example, _"Acme DEX v2 Launch"_ or
+_"Summer Trading Competition"_. This helps the editorial team understand your request at a glance.
+
+### Type
+
+Select the category that best describes your nomination:
+
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>When to use</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>App Launch</strong></td>
+      <td>You are launching or pre-launching a new app on Linea.</td>
+    </tr>
+    <tr>
+      <td><strong>App Enhancements</strong></td>
+      <td>You are shipping new features, functionality, or significant updates to an existing app.</td>
+    </tr>
+    <tr>
+      <td><strong>New Event</strong></td>
+      <td>You are running a new event, campaign, or time-limited experience in your app.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Description
+
+Explain what you are launching or updating and why it matters. Include context on the user impact,
+any incentives, and what makes this noteworthy for the Linea community. Be specific — the more
+detail you provide, the easier it is for the editorial team to craft compelling promotional content.
+
+### Publish date
+
+Select the date (or date range) when you plan to go live. The editorial team needs lead time to
+coordinate promotion, so **submit your nomination at least two weeks in advance**. The minimum
+accepted lead time is two business days.
+
+### Amplification on X (optional)
+
+If you want the Linea team to amplify your launch on X, toggle this option and provide:
+
+- **Tweet or draft preview link** — a URL to your draft tweet (for example, a Typefully or
+  Twitter draft link) so the team can review messaging and coordinate timing.
+- **Notes** — any additional context, such as preferred posting times, hashtags, or accounts to
+  tag.
+
+## Managing nominations
+
+### View past nominations
+
+Switch to **Past Nominations** in the sidebar to view all nominations you have submitted for the
+selected app.
+
+### Edit a nomination
+
+Click any past nomination to update its details. Changes are saved when you click
+**Update Nomination**.
+
+### Delete a nomination
+
+While editing, click **Delete** and confirm by typing `DELETE` in the dialog. Deleted nominations
+cannot be recovered.
+
+## Tips for a strong nomination
+
+- **Lead time matters.** The earlier you submit, the more time the editorial team has to plan
+  coverage. Two weeks minimum is recommended.
+- **Be specific.** Vague descriptions like "big update coming" are hard to promote. Describe the
+  feature, the user benefit, and the expected impact.
+- **Provide assets.** If you are requesting amplification on X, include a ready-to-review draft
+  tweet. This accelerates the coordination process.
+- **Keep your listing current.** Make sure your app page on the Hub reflects the latest version of
+  your product before nominating for a feature.
+- **Show traction.** Apps with strong onchain activity and user engagement are more likely to be
+  featured.

--- a/sidebars.js
+++ b/sidebars.js
@@ -60,6 +60,7 @@ const sidebars = {
             "network/build/launch-an-app/hub",
             "network/build/launch-an-app/hub-reviews",
             "network/build/launch-an-app/events",
+            "network/build/launch-an-app/get-featured",
             "network/build/launch-an-app/dapp-support",
           ],
         },


### PR DESCRIPTION
## Summary

- Adds a new **Get Featured** documentation page under *Build on Linea > Launch an app*, documenting the Developer Hub nomination workflow for builders seeking featured placement, X amplification, and co-marketing.
- Registers the page in `sidebars.js` between "Publish an event" and "Get support".

## Context

The [Linea Developer Hub](https://developer.linea.build/) now includes a **Get Featured** tab where teams can submit nominations to request homepage featuring, coordinated X amplification, and campaign promotion. This page documents:

- What the nomination feature is and why to use it
- Prerequisites (app must be submitted for review first)
- Step-by-step submission instructions
- Form field guidance (name, type, description, publish date, X amplification)
- Managing past nominations (view, edit, delete)
- Tips for strong nominations

## Format

- `.mdx` file with YAML front matter, matching existing page conventions
- HTML `<table>` syntax per contribution guidelines
- Relative `.mdx` links matching sibling pages (`hub.mdx`, `events.mdx`)
- No manual `image` field (auto-generated on build)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new page and a sidebar entry, with no code or runtime behavior impact beyond site navigation/content.
> 
> **Overview**
> Adds a new `Launch an app` doc page, `get-featured.mdx`, describing how builders nominate apps via the Developer Hub for Linea Hub homepage featuring and optional X amplification (including prerequisites, form field guidance, and managing/editing/deleting nominations).
> 
> Updates `sidebars.js` to surface the new **Get featured** page in the `Build on Linea > Launch an app` navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17d87261b26b40ce4409b5e6c3a81af902b616d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->