### PR TITLE
[Chore] - new verifier at nonce 71

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -22,9 +22,15 @@ you can take to verify this information.
 ### March 31, 2026
 #### L1
 
+- **[Nonce 71](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Add replacement verifier at index 1 supporting Small Fields and Dynamic Chain Configuration.
+  - Verification:
+    - Set verifier: `VerifierAddressChanged` records the new verifier `0x0D0f070386edC441A63fB8FAe8FB937Bbd88c5Cb`, at index 1.
+
 - **[Nonce 70](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
-    - Add verifier at index 1 supporting Small Fields, Pause Cooldown and Dynamic Chain Configuration.
+    - Add verifier at index 1 supporting Small Fields and Dynamic Chain Configuration.
     - Upgrade the LineaRollup to support Pause Cooldown and Dynamic Chain Configuration.
     - Upgrade the TokenBridge to support Pause Cooldown.
     - Grant the `SECURITY_COUNCIL_ROLE` to the TokenBridge as part of the Pause Cooldown.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that adds a new transaction record and tweaks wording for the prior nonce entry; no runtime code changes.
> 
> **Overview**
> Adds a new **March 31, 2026 / L1** entry for `Nonce 71` in `docs/changelog/security-council-record.mdx`, documenting a replacement verifier at index 1 and the expected `VerifierAddressChanged` event with the new verifier address.
> 
> Also updates the `Nonce 70` action text to remove mention of Pause Cooldown support from the verifier description, aligning it with the updated capabilities wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2295efb6cd76556fcc28c9a1ad74bab3888ce5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->