### PR TITLE
docs: clarify canonical compose file sources

### DIFF
--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -61,10 +61,9 @@ Next actions:
 ## Canonical sources
 
 - Compose files in the Linea monorepo (paths above) are the source of truth for images and versions.
-- Linea Besu package compose profiles (`linea-besu-package/docker`) are for enabling Linea plugins;
-  otherwise use the monorepo compose files.
-- Local `/files` copies for other clients are historical; prefer the monorepo compose for current
-  configuration.
+- **Linea Besu** (with Linea plugins): use the [`linea-besu-package/docker`](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu-package/docker) compose profiles.
+- **All other EL clients** (Besu, Geth, etc.): use the compose files under [`docs/getting-started/`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started).
+
 
 ## Alternative paths
 

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -61,8 +61,8 @@ Next actions:
 ## Canonical sources
 
 - Compose files in the Linea monorepo (paths above) are the source of truth for images and versions.
-- **Linea Besu** (with Linea plugins): use the [`linea-besu-package/docker`](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu-package/docker) compose profiles.
-- **All other EL clients** (Besu, Geth, etc.): use the compose files under [`docs/getting-started/`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started).
+- **Linea Besu** (basic and advanced profiles): use the [`linea-besu-package/docker`](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu-package/docker) compose profiles.
+- **All other execution layer clients** (Besu, Geth, etc.): use the compose files under [`docs/getting-started/`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started).
 
 
 ## Alternative paths


### PR DESCRIPTION
Fixes #1430

The "Canonical sources" section was misleading — it implied `linea-besu-package/docker` was separate from the monorepo. Rewrites the bullets to link both paths directly and distinguish them by client type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates links and guidance; no runtime or behavior impact.
> 
> **Overview**
> Clarifies the docs for running a Linea node by rewriting the *Canonical sources* section to explicitly point readers to the correct Docker Compose sources in the Linea monorepo.
> 
> It now distinguishes between **Linea Besu** (use `linea-besu-package/docker` compose profiles) and **other EL clients** (use `docs/getting-started/` compose files), removing misleading wording about historical local `/files` copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b6d3238362cd64244b047198d7158d6d998df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->