### PR TITLE
[Chore] - Add missing links

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -21,7 +21,7 @@ you can take to verify this information.
 
 ### April 13, 2026 (TBD)
 
-- **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0xf2df9a80b654c181f9930b3a152192216d79d6e1f3821d5e3232662512b3c0bf)**
 
 The following addresses are setup-time generated addresses and should be treated as placeholders in review:
 - `Dynamic Vault`: `0x14a022ef11a41770757652aa6607ef9d7e270b72`
@@ -117,13 +117,13 @@ The following addresses are setup-time generated addresses and should be treated
 ### March 31, 2026
 #### L1
 
-- **[Nonce 71](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 71](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x79b3c0c29ffcc04b3f3035e4c07e4558fecde523de668202bfc77cddc1ca358b)**
   - Actions: 
     - Add replacement verifier at index 1 supporting Small Fields and Dynamic Chain Configuration.
   - Verification:
     - Set verifier: `VerifierAddressChanged` records the new verifier `0x0D0f070386edC441A63fB8FAe8FB937Bbd88c5Cb`, at index 1.
 
-- **[Nonce 70](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 70](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x50157aa17891dbfeb34de0a149e7cf6ca28eb85c6fdd8eaf44855e9a15dead5a)**
   - Actions: 
     - Add verifier at index 1 supporting Small Fields and Dynamic Chain Configuration.
     - Upgrade the LineaRollup to support Pause Cooldown and Dynamic Chain Configuration.
@@ -169,7 +169,7 @@ The following addresses are setup-time generated addresses and should be treated
 
 #### L2
 
-- **[Nonce 52](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+- **[Nonce 52](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD&id=multisig_0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD_0x9d01eb3c9c109e02fe603b492fa81538ab1526467116739d45d837b0d4ff00b4)**
   - Actions: 
     - Upgrade the L2 Message Service to support Pause Cooldown.
     - Upgrade the TokenBridge to support Pause Cooldown.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates external links; no runtime or contract logic is affected.
> 
> **Overview**
> Updates the Linea Security Council transaction record to use full Safe transaction deep links (adding the `id=multisig_...` parameter) for several entries (L1 nonces `70`–`72` and L2 nonce `52`), making the referenced on-chain transactions directly resolvable in the Safe UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb7925a0bfc67a516044f36650576e7a7b9f29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->