### PR TITLE
Restructure release notes chronology and custom TOC sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,21 @@ export default function MyComponent({ active }) {
 
 ---
 
+## Release notes data model
+
+`docs/changelog/release-notes.mdx` uses a `release_toc` frontmatter map as the
+single source of truth for both page dates and TOC metadata. When adding or
+editing a release entry:
+
+1. Add/update the entry in `release_toc` frontmatter (one inline YAML line per
+   release: `id: { label, mainnet, sepolia }` or `{ label, date }` or `{ phase }`).
+2. Use `<ChangelogDate sectionId="<id>" />` in the body — it reads dates from
+   frontmatter. Do not pass `mainnet`/`sepolia` as inline props.
+3. The custom TOC (`src/theme/DocItem/TOC/Desktop/index.js`) reads from the same
+   frontmatter map — no separate JS metadata.
+
+---
+
 ## Visual verification
 
 After any CSS change, visually inspect the affected pages in both light and dark

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,16 +158,16 @@ export default function MyComponent({ active }) {
 
 ## Release notes data model
 
-`docs/changelog/release-notes.mdx` uses a `release_toc` frontmatter map as the
+`docs/changelog/release-notes.mdx` uses a `release_toc` front matter map as the
 single source of truth for both page dates and TOC metadata. When adding or
 editing a release entry:
 
-1. Add/update the entry in `release_toc` frontmatter (one inline YAML line per
+1. Add/update the entry in `release_toc` front matter (one inline YAML line per
    release: `id: { label, mainnet, sepolia }` or `{ label, date }` or `{ phase }`).
-2. Use `<ChangelogDate sectionId="<id>" />` in the body — it reads dates from
-   frontmatter. Do not pass `mainnet`/`sepolia` as inline props.
+2. Use `<ChangelogDate sectionId="<id>" />` in the body. It reads dates from
+   front matter. Do not pass `mainnet`/`sepolia` as inline props.
 3. The custom TOC (`src/theme/DocItem/TOC/Desktop/index.js`) reads from the same
-   frontmatter map — no separate JS metadata.
+   front matter map. No separate JS metadata.
 
 ---
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -64,7 +64,7 @@ This page maintains a record and brief explanation of [Linea Security Council tr
 
 <div id="v10" className="legacy-anchor" /><div id="beta-v60" className="legacy-anchor" /><div id="forced-transactions" className="legacy-anchor" />
 
-{/* Version 1.0 — hidden until launch, restore by uncommenting this block and the v10 frontmatter entry
+{/* Version 1.0: hidden until launch. To restore, uncomment this block and the v10 front matter entry.
 
 ## Version 1.0 {#v10}
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -37,6 +37,8 @@ that allows users to submit L2 transactions directly to the L1.
 
 ## Beta v5.3
 
+<ChangelogDate>27 Apr 2026 (target)</ChangelogDate>
+
 <ChangelogEntry tag="performance">
 
 Prover performance optimizations. Proof generation time ~40% faster.

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -24,7 +24,7 @@ This page maintains a record and brief explanation of [Linea Security Council tr
 
 <a id="beta-v60" /><a id="forced-transactions" />
 
-## v1.0
+## Version 1.0 {#v10}
 
 <ChangelogDate mainnet="27 April 2026 (target)" sepolia="20 April 2026 (target)" />
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -22,13 +22,11 @@ This page maintains a record and brief explanation of [Linea Security Council tr
 
 :::
 
-## Beta v6.0
+<a id="beta-v60" /><a id="forced-transactions" />
 
-Beta v6.0 is a phased release comprising several upgrades to the Linea protocol.
+## v1.0
 
-### Forced transactions
-
-<ChangelogDate mainnet="13 April 2026 (target)" sepolia="6 April 2026 (target)" />
+<ChangelogDate mainnet="27 April 2026 (target)" sepolia="20 April 2026 (target)" />
 
 <ChangelogEntry tag="feature">
 
@@ -37,7 +35,17 @@ that allows users to submit L2 transactions directly to the L1.
 
 </ChangelogEntry>
 
-### Small fields
+## Beta v5.3
+
+<ChangelogEntry tag="performance">
+
+Prover performance optimizations. Proof generation time ~40% faster.
+
+</ChangelogEntry>
+
+<a id="small-fields" />
+
+## Beta v5.2
 
 <ChangelogDate mainnet="1 April 2026" sepolia="24 March 2026" />
 
@@ -50,7 +58,19 @@ that allows users to submit L2 transactions directly to the L1.
 
 </ChangelogEntry>
 
-### EIP-7702
+## Beta v5.1
+
+<ChangelogDate mainnet="30 March 2026" sepolia="21 December 2025" />
+
+<ChangelogEntry tag="feature">
+
+Implements Yield Boost, a protocol-level mechanism to stake ETH from the canonical Linea Bridge the `LineaRollup` contract, and distribute rewards to the L2 ecosystem. More documentation coming soon.
+
+</ChangelogEntry>
+
+<a id="eip-7702" />
+
+## Beta v5.0
 
 <ChangelogDate mainnet="23 March 2026" sepolia="6 March 2026" />
 
@@ -60,19 +80,9 @@ Introduces [EIP-7702](/protocol/eip-7702), enabling gasless transactions, batch 
 
 </ChangelogEntry>
 
-## Beta v5.0
+<a id="assertions" />
 
-<ChangelogDate mainnet="30 March 2026" sepolia="21 December 2025" />
-
-**Linea Mainnet: 30 March 2026**
-
-<ChangelogEntry tag="feature">
-
-Implements Yield Boost, a protocol-level mechanism to stake ETH from the canonical Linea Bridge the `LineaRollup` contract, and distribute rewards to the L2 ecosystem. More documentation coming soon.
-
-</ChangelogEntry>
-
-## Assertions
+## Beta v4.5
 
 <ChangelogDate mainnet="28 January 2026" />
 
@@ -81,6 +91,8 @@ Implements Yield Boost, a protocol-level mechanism to stake ETH from the canonic
 Deploys the Credible Layer, a security infrastructure built by [Phylax Systems](https://phylax.systems) that lets you define security rules for your smart contracts and enforce them at the network level. To learn more about writing and deploying assertions, see the [guide](../network/how-to/write-and-deploy-assertions.mdx).
 
 </ChangelogEntry>
+
+<a id="fusaka" />
 
 ## Beta v4.4
 
@@ -112,14 +124,6 @@ Increases throughput to 100 Mgas/s.
 
 Updates the burn mechanism to include LINEA tokens. Details and percentage breakdown in the
 [burn mechanism guide](../protocol/tokenomics.mdx#burning-mechanism).
-
-</ChangelogEntry>
-
-## Fusaka
-
-<ChangelogEntry tag="announcement">
-
-Linea will be implementing upgrades to bring the network into line with the latest updates to the Ethereum network, referred to as [the Fusaka upgrade](https://ethereum.org/roadmap/fusaka/).
 
 </ChangelogEntry>
 
@@ -159,7 +163,7 @@ matter of weeks: from the London hard fork beforehand this release, all the way 
 Due to the complexity of this process, the upgrade will occur in stages, progressing through hard
 forks according to the release schedule above.
 
-For Linea users, the upgrade will enable new use cases and experiences through EIP-7702 (coming in Beta v6.0), unlocking access to apps that rely on this capability.
+For Linea users, the upgrade will enable new use cases and experiences through EIP-7702 (coming in Beta v5.0), unlocking access to apps that rely on this capability.
 
 For builders, Linea becoming even more strongly Ethereum-aligned will make the developer experience
 more streamlined and closely resemble Ethereum. The upgrade adds support for several opcodes and
@@ -168,7 +172,7 @@ precompiles, such as `PUSH0` and `MCOPY`, considerably shortening the list of Li
 
 :::note
 
-EIP-7702 will only be activated in Beta v6.0.
+EIP-7702 will only be activated in Beta v5.0.
 
 :::
 
@@ -194,7 +198,7 @@ Initially, only a single Maru node operated by Linea will produce blocks.
 
 ## Beta v3.1
 
-<ChangelogDate mainnet="early/mid-August 2025 (target)" sepolia="late July 2025 (target)" />
+<ChangelogDate mainnet="early/mid-August 2025" sepolia="late July 2025" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -207,7 +211,7 @@ Increase throughput.
 
 ## Beta v3.0
 
-<ChangelogDate mainnet="early August 2025 (target)" sepolia="late July 2025 (target)" />
+<ChangelogDate mainnet="early August 2025" sepolia="late July 2025" />
 
 <ChangelogEntry tag="upgrade" title="Limitless prover">
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -26,13 +26,14 @@ This page maintains a record and brief explanation of [Linea Security Council tr
 
 Beta v6.0 is a phased release comprising several upgrades to the Linea protocol.
 
-### EIP-7702
+### Forced transactions
 
-<ChangelogDate mainnet="23 March 2026" sepolia="6 March 2026" />
+<ChangelogDate mainnet="13 April 2026 (target)" sepolia="6 April 2026 (target)" />
 
-<ChangelogEntry tag="upgrade">
+<ChangelogEntry tag="feature">
 
-Introduces [EIP-7702](/protocol/eip-7702), enabling gasless transactions, batch transactions, and session keys. No user action or migration required.
+Introduces [forced transactions](../protocol/forced-transactions.mdx), a manual submission mechanism
+that allows users to submit L2 transactions directly to the L1.
 
 </ChangelogEntry>
 
@@ -49,14 +50,13 @@ Introduces [EIP-7702](/protocol/eip-7702), enabling gasless transactions, batch 
 
 </ChangelogEntry>
 
-### Forced transactions
+### EIP-7702
 
-<ChangelogDate mainnet="13 April 2026 (target)" sepolia="6 April 2026 (target)" />
+<ChangelogDate mainnet="23 March 2026" sepolia="6 March 2026" />
 
-<ChangelogEntry tag="feature">
+<ChangelogEntry tag="upgrade">
 
-Introduces [forced transactions](../protocol/forced-transactions.mdx), a manual submission mechanism
-that allows users to submit L2 transactions directly to the L1.
+Introduces [EIP-7702](/protocol/eip-7702), enabling gasless transactions, batch transactions, and session keys. No user action or migration required.
 
 </ChangelogEntry>
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -19,19 +19,19 @@ release_toc:
   beta-v31: { mainnet: "early/mid-August 2025", sepolia: "late July 2025" }
   beta-v30: { label: "Limitless prover", mainnet: "early August 2025", sepolia: "late July 2025" }
   beta-v20: { label: "100% proven", mainnet: "June 9, 2025", sepolia: "mid/late May 2025" }
-  beta-v10: { phase: "Phased release" }
   beta-v14: { date: "April 28, 2025" }
   beta-v13: { mainnet: "March 3, 2025", sepolia: "February 18, 2025" }
   beta-v12: { mainnet: "with Beta v2", sepolia: "February 4, 2025" }
   beta-v11: { mainnet: "with Beta v2", sepolia: "September 26, 2024" }
+  beta-v10: { phase: "Phased release" }
   alpha-v42: { label: "Linea bridge improvements", mainnet: "March 26, 2025", sepolia: "March 18, 2025" }
   alpha-v41: { mainnet: "February 4, 2025", sepolia: "January 28, 2025" }
   alpha-v40: { mainnet: "December 16, 2024", sepolia: "November 27, 2024" }
-  alpha-v350: { label: "finalized tag", mainnet: "October 9", sepolia: "September 17" }
-  alpha-v341: { label: "Reactivate linea_estimateGas", mainnet: "September 30", sepolia: "September 9" }
   alpha-v36: { label: "Block size changes", mainnet: "September 25", sepolia: "September 25" }
   alpha-v352: { label: "Transaction exclusion API", mainnet: "September 23", sepolia: "September 18" }
   alpha-v351: { phase: "Date not listed" }
+  alpha-v350: { label: "finalized tag", mainnet: "October 9", sepolia: "September 17" }
+  alpha-v341: { label: "Reactivate linea_estimateGas", mainnet: "September 30", sepolia: "September 9" }
   alpha-v34: { label: "ENS on Linea", mainnet: "July 30", sepolia: "July 30" }
   alpha-v33: { label: "Block time reduction", mainnet: "June 11, 10:00 UTC", sepolia: "June 3" }
   alpha-v32: { label: "Gas optimization", mainnet: "June 4", sepolia: "May 28" }

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -3,6 +3,46 @@ title: Release notes
 description: Find out all you need to know about the latest Linea versions.
 displayed_sidebar: changelogSidebar
 image: /img/socialCards/release-notes.jpg
+release_toc:
+  # v10: { label: "Forced transactions", mainnet: "27 April 2026 (target)", sepolia: "20 April 2026 (target)" }
+  beta-v53: { label: "Prover performance optimizations", mainnet: "27 April 2026", sepolia: "20 March 2026" }
+  beta-v52: { label: "Small fields", mainnet: "1 April 2026", sepolia: "24 March 2026" }
+  beta-v51: { label: "Yield Boost", mainnet: "30 March 2026", sepolia: "21 December 2025" }
+  beta-v50: { label: "EIP-7702", mainnet: "23 March 2026", sepolia: "6 March 2026" }
+  beta-v45: { label: "Assertions", mainnet: "28 January 2026" }
+  beta-v44: { label: "Fusaka", mainnet: "3 December 2025", sepolia: "1 December 2025" }
+  beta-v43: { mainnet: "17 November 2025", sepolia: "10 November 2025" }
+  beta-v42: { mainnet: "5 November 2025", sepolia: "31 October 2025" }
+  beta-v41: { mainnet: "30 October 2025", sepolia: "30 October 2025" }
+  beta-v40: { label: "Pectra hard fork", date: "22-28 Oct 2025" }
+  beta-v311: { mainnet: "6 October, 2025" }
+  beta-v31: { mainnet: "early/mid-August 2025", sepolia: "late July 2025" }
+  beta-v30: { label: "Limitless prover", mainnet: "early August 2025", sepolia: "late July 2025" }
+  beta-v20: { label: "100% proven", mainnet: "June 9, 2025", sepolia: "mid/late May 2025" }
+  beta-v10: { phase: "Phased release" }
+  beta-v14: { date: "April 28, 2025" }
+  beta-v13: { mainnet: "March 3, 2025", sepolia: "February 18, 2025" }
+  beta-v12: { mainnet: "with Beta v2", sepolia: "February 4, 2025" }
+  beta-v11: { mainnet: "with Beta v2", sepolia: "September 26, 2024" }
+  alpha-v42: { label: "Linea bridge improvements", mainnet: "March 26, 2025", sepolia: "March 18, 2025" }
+  alpha-v41: { mainnet: "February 4, 2025", sepolia: "January 28, 2025" }
+  alpha-v40: { mainnet: "December 16, 2024", sepolia: "November 27, 2024" }
+  alpha-v350: { label: "finalized tag", mainnet: "October 9", sepolia: "September 17" }
+  alpha-v341: { label: "Reactivate linea_estimateGas", mainnet: "September 30", sepolia: "September 9" }
+  alpha-v36: { label: "Block size changes", mainnet: "September 25", sepolia: "September 25" }
+  alpha-v352: { label: "Transaction exclusion API", mainnet: "September 23", sepolia: "September 18" }
+  alpha-v351: { phase: "Date not listed" }
+  alpha-v34: { label: "ENS on Linea", mainnet: "July 30", sepolia: "July 30" }
+  alpha-v33: { label: "Block time reduction", mainnet: "June 11, 10:00 UTC", sepolia: "June 3" }
+  alpha-v32: { label: "Gas optimization", mainnet: "June 4", sepolia: "May 28" }
+  alpha-v31: { mainnet: "May 14" }
+  alpha-v30: { label: "EIP-4844", date: "March 26, 2024" }
+  february-2024: { phase: "Monthly release notes" }
+  alpha-v2: { phase: "Grouped release notes" }
+  december-2023: { phase: "Monthly release notes" }
+  november-2023: { phase: "Monthly release notes" }
+  october-2023: { phase: "Monthly release notes" }
+  summary-release-notes-june---october: { phase: "Historical summary" }
 ---
 
 import CodeBlock from "@theme/CodeBlock";
@@ -22,11 +62,13 @@ This page maintains a record and brief explanation of [Linea Security Council tr
 
 :::
 
-<a id="beta-v60" /><a id="forced-transactions" />
+<div id="v10" className="legacy-anchor" /><div id="beta-v60" className="legacy-anchor" /><div id="forced-transactions" className="legacy-anchor" />
+
+{/* Version 1.0 — hidden until launch, restore by uncommenting this block and the v10 frontmatter entry
 
 ## Version 1.0 {#v10}
 
-<ChangelogDate mainnet="27 April 2026 (target)" sepolia="20 April 2026 (target)" />
+<ChangelogDate sectionId="v10" />
 
 <ChangelogEntry tag="feature">
 
@@ -35,9 +77,11 @@ that allows users to submit L2 transactions directly to the L1.
 
 </ChangelogEntry>
 
+*/}
+
 ## Beta v5.3
 
-<ChangelogDate>27 Apr 2026 (target)</ChangelogDate>
+<ChangelogDate sectionId="beta-v53" />
 
 <ChangelogEntry tag="performance">
 
@@ -45,11 +89,11 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 </ChangelogEntry>
 
-<a id="small-fields" />
+<div id="small-fields" className="legacy-anchor" />
 
 ## Beta v5.2
 
-<ChangelogDate mainnet="1 April 2026" sepolia="24 March 2026" />
+<ChangelogDate sectionId="beta-v52" />
 
 <ChangelogEntry tag="performance">
 
@@ -62,7 +106,7 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 ## Beta v5.1
 
-<ChangelogDate mainnet="30 March 2026" sepolia="21 December 2025" />
+<ChangelogDate sectionId="beta-v51" />
 
 <ChangelogEntry tag="feature">
 
@@ -70,11 +114,11 @@ Implements Yield Boost, a protocol-level mechanism to stake ETH from the canonic
 
 </ChangelogEntry>
 
-<a id="eip-7702" />
+<div id="eip-7702" className="legacy-anchor" />
 
 ## Beta v5.0
 
-<ChangelogDate mainnet="23 March 2026" sepolia="6 March 2026" />
+<ChangelogDate sectionId="beta-v50" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -82,11 +126,11 @@ Introduces [EIP-7702](/protocol/eip-7702), enabling gasless transactions, batch 
 
 </ChangelogEntry>
 
-<a id="assertions" />
+<div id="assertions" className="legacy-anchor" />
 
 ## Beta v4.5
 
-<ChangelogDate mainnet="28 January 2026" />
+<ChangelogDate sectionId="beta-v45" />
 
 <ChangelogEntry tag="feature">
 
@@ -94,11 +138,11 @@ Deploys the Credible Layer, a security infrastructure built by [Phylax Systems](
 
 </ChangelogEntry>
 
-<a id="fusaka" />
+<div id="fusaka" className="legacy-anchor" />
 
 ## Beta v4.4
 
-<ChangelogDate mainnet="3 December 2025" sepolia="1 December 2025" />
+<ChangelogDate sectionId="beta-v44" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -108,7 +152,7 @@ Upgrades Linea to Fusaka (Ethereum's latest EVM upgrade), detailed in the [upgra
 
 ## Beta v4.3
 
-<ChangelogDate mainnet="17 November 2025" sepolia="10 November 2025" />
+<ChangelogDate sectionId="beta-v43" />
 
 <ChangelogEntry tag="performance">
 
@@ -120,7 +164,7 @@ Increases throughput to 100 Mgas/s.
 
 ## Beta v4.2
 
-<ChangelogDate mainnet="5 November 2025" sepolia="31 October 2025" />
+<ChangelogDate sectionId="beta-v42" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -131,7 +175,7 @@ Updates the burn mechanism to include LINEA tokens. Details and percentage break
 
 ## Beta v4.1
 
-<ChangelogDate mainnet="30 October 2025" sepolia="30 October 2025" />
+<ChangelogDate sectionId="beta-v41" />
 
 <ChangelogEntry tag="performance">
 
@@ -189,7 +233,7 @@ Initially, only a single Maru node operated by Linea will produce blocks.
 
 ## Beta v3.1.1
 
-<ChangelogDate mainnet="6 October, 2025" />
+<ChangelogDate sectionId="beta-v311" />
 
 <ChangelogEntry tag="performance">
 
@@ -200,7 +244,7 @@ Initially, only a single Maru node operated by Linea will produce blocks.
 
 ## Beta v3.1
 
-<ChangelogDate mainnet="early/mid-August 2025" sepolia="late July 2025" />
+<ChangelogDate sectionId="beta-v31" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -213,7 +257,7 @@ Increase throughput.
 
 ## Beta v3.0
 
-<ChangelogDate mainnet="early August 2025" sepolia="late July 2025" />
+<ChangelogDate sectionId="beta-v30" />
 
 <ChangelogEntry tag="upgrade" title="Limitless prover">
 
@@ -229,7 +273,7 @@ Note that the higher throughput will not enabled until the sequencer limits are 
 
 ## Beta v2.0
 
-<ChangelogDate mainnet="June 9, 2025" sepolia="mid/late May 2025" />
+<ChangelogDate sectionId="beta-v20" />
 
 <ChangelogEntry tag="feature" title="100% proven">
 
@@ -245,12 +289,8 @@ supporting future decentralization and security.
 
 </ChangelogEntry>
 
-## Beta v1.0
 
-Beta v1 on Linea introduces new arithmetization. The overall objective of the Linea Beta is to prove
-100% of the zkEVM specification, an objective currently scheduled to be completed in Beta v2.
-
-### Beta v1.4
+## Beta v1.4
 
 **Linea Mainnet: April 28, 2025**
 
@@ -264,9 +304,9 @@ and audit Linea state, reducing the risk of having a centralized sequencer.
 
 </ChangelogEntry>
 
-### Beta v1.3
+## Beta v1.3
 
-<ChangelogDate mainnet="March 3, 2025" sepolia="February 18, 2025" />
+<ChangelogDate sectionId="beta-v13" />
 
 <ChangelogEntry tag="performance">
 
@@ -274,9 +314,9 @@ Raises the block gas limit to 2B.
 
 </ChangelogEntry>
 
-### Beta v1.2
+## Beta v1.2
 
-<ChangelogDate mainnet="with Beta v2" sepolia="February 4, 2025" />
+<ChangelogDate sectionId="beta-v12" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -286,9 +326,9 @@ the hub's consistency arguments.
 
 </ChangelogEntry>
 
-### Beta v1.1
+## Beta v1.1
 
-<ChangelogDate mainnet="with Beta v2" sepolia="September 26, 2024" />
+<ChangelogDate sectionId="beta-v11" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -297,9 +337,18 @@ the hub's consistency arguments.
 
 </ChangelogEntry>
 
+## Beta v1.0
+
+<ChangelogEntry tag="announcement">
+
+Beta v1 on Linea introduces new arithmetization. The overall objective of the Linea Beta is to prove
+100% of the zkEVM specification, an objective currently scheduled to be completed in Beta v2.
+
+</ChangelogEntry>
+
 ## Alpha v4.2
 
-<ChangelogDate mainnet="March 26, 2025" sepolia="March 18, 2025" />
+<ChangelogDate sectionId="alpha-v42" />
 
 <ChangelogEntry tag="upgrade" title="Linea bridge improvements">
 
@@ -316,7 +365,7 @@ the hub's consistency arguments.
 
 ## Alpha v4.1
 
-<ChangelogDate mainnet="February 4, 2025" sepolia="January 28, 2025" />
+<ChangelogDate sectionId="alpha-v41" />
 
 <ChangelogEntry tag="feature">
 
@@ -328,7 +377,7 @@ Introduces the [Linea Token API](../api/token-api/) at alpha stage.
 
 ## Alpha v4.0
 
-<ChangelogDate mainnet="December 16, 2024" sepolia="November 27, 2024" />
+<ChangelogDate sectionId="alpha-v40" />
 
 <ChangelogEntry tag="upgrade">
 
@@ -406,7 +455,7 @@ messages.
 
 ## Alpha v3.6
 
-<ChangelogDate mainnet="September 25" sepolia="September 25" />
+<ChangelogDate sectionId="alpha-v36" />
 
 <ChangelogEntry tag="performance" title="Block size changes">
 
@@ -417,7 +466,7 @@ remains the same, at 2 seconds.
 
 ## Alpha v3.5.2
 
-<ChangelogDate mainnet="September 23" sepolia="September 18" />
+<ChangelogDate sectionId="alpha-v352" />
 
 <ChangelogEntry tag="feature" title="Transaction exclusion API">
 
@@ -438,7 +487,7 @@ Upgrades the [Linea bridge](https://linea.build/hub/bridge/) UI.
 
 ## Alpha v3.5.0
 
-<ChangelogDate mainnet="October 9" sepolia="September 17" />
+<ChangelogDate sectionId="alpha-v350" />
 
 <ChangelogEntry tag="feature" title="finalized tag">
 
@@ -450,7 +499,7 @@ See our [guide](../network/overview/transaction-finality.mdx#how-to-check-finali
 
 ## Alpha v3.4.1
 
-<ChangelogDate mainnet="September 30" sepolia="September 9" />
+<ChangelogDate sectionId="alpha-v341" />
 
 <ChangelogEntry tag="upgrade" title="Reactivate linea_estimateGas">
 
@@ -461,7 +510,7 @@ mode.
 
 ## Alpha v3.4
 
-<ChangelogDate mainnet="July 30" sepolia="July 30" />
+<ChangelogDate sectionId="alpha-v34" />
 
 <ChangelogEntry tag="feature" title="ENS on Linea">
 
@@ -504,7 +553,7 @@ See our [reference page](../api/reference/linea-estimategas.mdx) for more inform
 
 ## Alpha v3.3
 
-<ChangelogDate mainnet="June 11, 10:00 UTC" sepolia="June 3" />
+<ChangelogDate sectionId="alpha-v33" />
 
 <ChangelogEntry tag="action-required" title="Breaking change: block time and block size reduction">
 
@@ -535,7 +584,7 @@ In the `besu-sequencer` plugin, adjust:
 
 ## Alpha v3.2
 
-<ChangelogDate mainnet="June 4" sepolia="May 28" />
+<ChangelogDate sectionId="alpha-v32" />
 
 <ChangelogEntry tag="upgrade" title="Smart contract gas optimization">
 
@@ -572,7 +621,7 @@ and [Cyfrin](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/20
 
 ## Alpha v3.1
 
-<ChangelogDate mainnet="May 14" />
+<ChangelogDate sectionId="alpha-v31" />
 
 <ChangelogEntry tag="feature">
 

--- a/docs/network/how-to/deploy-subdomain.mdx
+++ b/docs/network/how-to/deploy-subdomain.mdx
@@ -49,7 +49,7 @@ to gain ownership of an L1 domain on Linea. This solution allows you to deploy o
 ### Use ENS contracts 
 
 :::note ENS resolver contracts updated
-The ENS resolver contracts were redeployed as part of the [Small Fields upgrade](/changelog/release-notes#beta-v60)
+The ENS resolver contracts were redeployed as part of the [Small Fields upgrade](/changelog/release-notes#beta-v52)
 (March 2026). If you configured ENS resolution before this date, you must update 
 your setup to use the new contract addresses below.
 :::

--- a/docs/network/overview/ethereum-differences.mdx
+++ b/docs/network/overview/ethereum-differences.mdx
@@ -131,10 +131,10 @@ primarily for layer 2 rollups to cheaply post data on L1.
 
 ## EIP-7702 (type 4 transactions)
 
-Linea supports [EIP-7702](/protocol/eip-7702) type `0x04` transactions as of the Pectra upgrade
-(Beta v4). This allows EOAs to delegate to smart contract logic, enabling features like transaction
-batching, gas sponsorship, and session keys. See the [EIP-7702 support](/protocol/eip-7702) page
-for details.
+Linea supports [EIP-7702](/protocol/eip-7702) type `0x04` transactions as of
+[Beta v5.0](../../changelog/release-notes.mdx#beta-v50). This allows EOAs to delegate to smart
+contract logic, enabling features like transaction batching, gas sponsorship, and session keys.
+See the [EIP-7702 support](/protocol/eip-7702) page for details.
 
 ## Next steps
 

--- a/docs/protocol/eip-7702.mdx
+++ b/docs/protocol/eip-7702.mdx
@@ -10,7 +10,7 @@ image: /img/socialCards/eip-7702-support.jpg
 [**Prague hardfork**](https://eips.ethereum.org/EIPS/eip-7600) that allows a regular wallet
 (EOA—Externally Owned Account) to behave like a smart contract wallet without changing address,
 migrating funds, or creating a new seed phrase. The delegation persists until explicitly revoked.
-EIP-7702 is supported on Linea as of [Beta v6.0](../changelog/release-notes#beta-v60).
+EIP-7702 is supported on Linea as of [Beta v5.0](../changelog/release-notes#beta-v50).
 
 ## What it enables
 

--- a/docs/protocol/forced-transactions.mdx
+++ b/docs/protocol/forced-transactions.mdx
@@ -144,4 +144,4 @@ sequenceDiagram
 - Learn how to [submit forced transactions](../protocol/how-to/forced-transactions.mdx) on Linea
   Public Mainnet.
 - Consider the normal [transaction lifecycle](./architecture/index.mdx#transaction-lifecycle).
-- See the [changelog](../changelog/release-notes.mdx#v10) detailing when Linea made forced transactions available.
+- See the [changelog](../changelog/release-notes.mdx) for release history.

--- a/docs/protocol/forced-transactions.mdx
+++ b/docs/protocol/forced-transactions.mdx
@@ -144,4 +144,4 @@ sequenceDiagram
 - Learn how to [submit forced transactions](../protocol/how-to/forced-transactions.mdx) on Linea
   Public Mainnet.
 - Consider the normal [transaction lifecycle](./architecture/index.mdx#transaction-lifecycle).
-- See the [changelog](../changelog/release-notes.mdx#beta-v60) detailing when Linea made forced transactions available.
+- See the [changelog](../changelog/release-notes.mdx#v10) detailing when Linea made forced transactions available.

--- a/src/components/changelog/ChangelogEntry.jsx
+++ b/src/components/changelog/ChangelogEntry.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import styles from './styles.module.css';
 
 const TAG_STYLE_MAP = {
@@ -35,22 +36,33 @@ export function ChangelogEntry({ tag, title, children }) {
   );
 }
 
-export function ChangelogDate({ mainnet, sepolia, children }) {
+export function ChangelogDate({ sectionId, mainnet, sepolia, children }) {
+  const { frontMatter } = useDoc();
+  const meta = sectionId ? frontMatter?.release_toc?.[sectionId] : null;
+
   if (children) {
     return <div className={styles.dates}>{children}</div>;
   }
+
+  const effectiveMainnet = mainnet || meta?.mainnet;
+  const effectiveSepolia = sepolia || meta?.sepolia;
+
+  if (!effectiveMainnet && !effectiveSepolia && meta?.date) {
+    return <div className={styles.dates}>{meta.date}</div>;
+  }
+
   return (
     <div className={styles.dates}>
-      {mainnet && (
+      {effectiveMainnet && (
         <div className={styles.date}>
           <span className={styles.dateArrow}>→</span>
-          <span>Linea Mainnet: {mainnet}</span>
+          <span>Linea Mainnet: {effectiveMainnet}</span>
         </div>
       )}
-      {sepolia && (
+      {effectiveSepolia && (
         <div className={styles.date}>
           <span className={styles.dateArrow}>→</span>
-          <span>Linea Sepolia: {sepolia}</span>
+          <span>Linea Sepolia: {effectiveSepolia}</span>
         </div>
       )}
     </div>

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -1009,9 +1009,9 @@ nav[aria-label="Breadcrumbs"] .breadcrumbs__item--active .breadcrumbs__link {
      would otherwise double-offset below our sticky top. */
   [class*="sidebarViewport"] {
     position: sticky !important;
-    top: var(--sidebar-top, 83px) !important;
-    height: calc(100vh - var(--sidebar-top, 83px)) !important;
-    max-height: calc(100vh - var(--sidebar-top, 83px)) !important;
+    top: var(--sidebar-top, var(--linea-sticky-header-offset)) !important;
+    height: calc(100vh - var(--sidebar-top, var(--linea-sticky-header-offset))) !important;
+    max-height: calc(100vh - var(--sidebar-top, var(--linea-sticky-header-offset))) !important;
     overflow: hidden !important;
     padding-top: 0 !important;
   }
@@ -1416,6 +1416,10 @@ a.menu__link {
   margin-right: 5px;
 }
 
+.release-notes-toc.theme-doc-toc-desktop::before {
+  display: none;
+}
+
 button.clean-btn.menu__caret {
   padding: 4px 8px;
   display: flex;
@@ -1516,6 +1520,7 @@ button.clean-btn.menu__caret {
   .theme-doc-toc-desktop {
     background-color: var(--page-background);
     width: 0;
+    overflow: hidden;
   }
 }
 

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -43,6 +43,13 @@
   --linea-radius-round: 100px;
 }
 
+@media (min-width: 997px) {
+  :root {
+    --linea-sticky-header-offset: 83px;
+    --ifm-navbar-height: var(--linea-sticky-header-offset);
+  }
+}
+
 .footer--dark {
   --ifm-footer-background-color: var(--footer-background);
   border-top: 1px solid var(--linea-border);

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -149,6 +149,11 @@
   }
 }
 
+/* Backward-compatible deep-link anchors that inherit sticky-navbar offset */
+.legacy-anchor {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
+}
+
 .my-tabs {
   display: inline-flex;
   justify-content: normal;

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -55,4 +55,5 @@ nav[aria-label="Breadcrumbs"] {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-left: auto;
 }

--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -14,16 +14,15 @@ const LINK_CLASS_NAME = "table-of-contents__link toc-highlight";
 const LINK_ACTIVE_CLASS_NAME = "table-of-contents__link--active";
 
 const RELEASE_TOC_META = {
-  "beta-v60": { phase: "Phased release" },
-  "forced-transactions": { date: "13 Apr 2026 target" },
-  "small-fields": { date: "1 Apr 2026" },
-  "eip-7702": { date: "23 Mar 2026" },
-  "beta-v50": { date: "30 Mar 2026" },
-  assertions: { date: "28 Jan 2026" },
-  "beta-v44": { date: "3 Dec 2025" },
+  v10: { date: "Forced transactions - 27 Apr 2026 target" },
+  "beta-v53": { date: "Prover performance optimizations - 27 Apr 2026 target" },
+  "beta-v52": { date: "Small fields - 1 Apr 2026" },
+  "beta-v51": { date: "Yield Boost - 30 Mar 2026" },
+  "beta-v50": { date: "EIP-7702 - 23 Mar 2026" },
+  "beta-v45": { date: "Assertions - 28 Jan 2026" },
+  "beta-v44": { date: "Fusaka - 3 Dec 2025" },
   "beta-v43": { date: "17 Nov 2025" },
   "beta-v42": { date: "5 Nov 2025" },
-  fusaka: { phase: "Announcement" },
   "beta-v41": { date: "30 Oct 2025" },
   "beta-v40": { date: "22-28 Oct 2025" },
   "beta-v311": { date: "6 Oct 2025" },
@@ -149,7 +148,7 @@ function ReleaseNotesTOC({
 
   return (
     <div className={clsx(styles.root, "release-notes-toc", className)}>
-      <div className={styles.heading}>Release chronology</div>
+      <div className={styles.heading}>Release history</div>
       <div className={clsx(styles.scrollArea, "thin-scrollbar")}>
         <ReleaseNotesTOCItems items={tocTree} />
       </div>

--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -1,0 +1,183 @@
+import React, { useMemo } from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import { ThemeClassNames, useThemeConfig } from "@docusaurus/theme-common";
+import {
+  useFilteredAndTreeifiedTOC,
+  useTOCHighlight,
+} from "@docusaurus/theme-common/internal";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import TOC from "@theme/TOC";
+import styles from "./styles.module.css";
+
+const LINK_CLASS_NAME = "table-of-contents__link toc-highlight";
+const LINK_ACTIVE_CLASS_NAME = "table-of-contents__link--active";
+
+const RELEASE_TOC_META = {
+  "beta-v60": { phase: "Phased release" },
+  "forced-transactions": { date: "13 Apr 2026 target" },
+  "small-fields": { date: "1 Apr 2026" },
+  "eip-7702": { date: "23 Mar 2026" },
+  "beta-v50": { date: "30 Mar 2026" },
+  assertions: { date: "28 Jan 2026" },
+  "beta-v44": { date: "3 Dec 2025" },
+  "beta-v43": { date: "17 Nov 2025" },
+  "beta-v42": { date: "5 Nov 2025" },
+  fusaka: { phase: "Announcement" },
+  "beta-v41": { date: "30 Oct 2025" },
+  "beta-v40": { date: "22-28 Oct 2025" },
+  "beta-v311": { date: "6 Oct 2025" },
+  "beta-v31": { date: "Aug 2025 target" },
+  "beta-v30": { date: "Early Aug 2025 target" },
+  "beta-v20": { date: "9 Jun 2025" },
+  "beta-v10": { phase: "Phased release" },
+  "beta-v14": { date: "28 Apr 2025" },
+  "beta-v13": { date: "3 Mar 2025" },
+  "beta-v12": { date: "With Beta v2" },
+  "beta-v11": { date: "With Beta v2" },
+  "alpha-v42": { date: "26 Mar 2025" },
+  "alpha-v41": { date: "4 Feb 2025" },
+  "alpha-v40": { date: "16 Dec 2024" },
+  "alpha-v350": { date: "9 Oct 2024" },
+  "alpha-v341": { date: "30 Sep 2024" },
+  "alpha-v36": { date: "25 Sep 2024" },
+  "alpha-v352": { date: "23 Sep 2024" },
+  "alpha-v351": { phase: "Date not listed" },
+  "alpha-v34": { date: "30 Jul 2024" },
+  "alpha-v33": { date: "11 Jun 2024" },
+  "alpha-v32": { date: "4 Jun 2024" },
+  "alpha-v31": { date: "14 May 2024" },
+  "alpha-v30": { date: "26 Mar 2024" },
+  "february-2024": { phase: "Monthly release notes" },
+  "alpha-v2": { phase: "Grouped release notes" },
+  "december-2023": { phase: "Monthly release notes" },
+  "november-2023": { phase: "Monthly release notes" },
+  "october-2023": { phase: "Monthly release notes" },
+  "summary-release-notes-june---october": { phase: "Historical summary" },
+};
+
+const GENERIC_CHILD_LABELS = new Set([
+  "summary",
+  "features",
+  "breaking changes",
+]);
+
+function toPlainText(value) {
+  return value
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function getDisplayLabel(item, parentLabel) {
+  const plainLabel = toPlainText(item.value);
+  if (parentLabel && GENERIC_CHILD_LABELS.has(plainLabel.toLowerCase())) {
+    return `${parentLabel}: ${plainLabel}`;
+  }
+  return plainLabel;
+}
+
+function ReleaseNotesTOCItems({ items, parentLabel }) {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <ul className={clsx(styles.list, parentLabel && styles.childList)}>
+      {items.map((item) => {
+        const meta = RELEASE_TOC_META[item.id];
+        const displayLabel = getDisplayLabel(item, parentLabel);
+        const plainLabel = toPlainText(item.value);
+
+        return (
+          <li
+            key={item.id}
+            className={clsx(styles.item, !parentLabel && styles.releaseItem)}>
+            <Link
+              to={`#${item.id}`}
+              className={clsx(
+                LINK_CLASS_NAME,
+                styles.link,
+                !parentLabel ? styles.releaseLink : styles.childLink,
+              )}>
+              <span className={styles.label}>{displayLabel}</span>
+              {meta?.date && <span className={styles.meta}>{meta.date}</span>}
+              {!meta?.date && meta?.phase && (
+                <span className={styles.meta}>{meta.phase}</span>
+              )}
+            </Link>
+            <ReleaseNotesTOCItems
+              items={item.children}
+              parentLabel={plainLabel}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ReleaseNotesTOC({
+  toc,
+  className,
+  minHeadingLevel: minHeadingLevelOption,
+  maxHeadingLevel: maxHeadingLevelOption,
+}) {
+  const themeConfig = useThemeConfig();
+  const minHeadingLevel =
+    minHeadingLevelOption ?? themeConfig.tableOfContents.minHeadingLevel;
+  const maxHeadingLevel =
+    maxHeadingLevelOption ?? themeConfig.tableOfContents.maxHeadingLevel;
+
+  const tocTree = useFilteredAndTreeifiedTOC({
+    toc,
+    minHeadingLevel,
+    maxHeadingLevel,
+  });
+
+  const tocHighlightConfig = useMemo(
+    () => ({
+      linkClassName: LINK_CLASS_NAME,
+      linkActiveClassName: LINK_ACTIVE_CLASS_NAME,
+      minHeadingLevel,
+      maxHeadingLevel,
+    }),
+    [minHeadingLevel, maxHeadingLevel],
+  );
+
+  useTOCHighlight(tocHighlightConfig);
+
+  return (
+    <div className={clsx(styles.root, "release-notes-toc", className)}>
+      <div className={styles.heading}>Release chronology</div>
+      <div className={clsx(styles.scrollArea, "thin-scrollbar")}>
+        <ReleaseNotesTOCItems items={tocTree} />
+      </div>
+    </div>
+  );
+}
+
+export default function DocItemTOCDesktop() {
+  const { toc, frontMatter, metadata } = useDoc();
+  const isReleaseNotesPage = metadata.permalink === "/changelog/release-notes";
+
+  if (!isReleaseNotesPage) {
+    return (
+      <TOC
+        toc={toc}
+        minHeadingLevel={frontMatter.toc_min_heading_level}
+        maxHeadingLevel={frontMatter.toc_max_heading_level}
+        className={ThemeClassNames.docs.docTocDesktop}
+      />
+    );
+  }
+
+  return (
+    <ReleaseNotesTOC
+      toc={toc}
+      minHeadingLevel={frontMatter.toc_min_heading_level}
+      maxHeadingLevel={frontMatter.toc_max_heading_level}
+      className={ThemeClassNames.docs.docTocDesktop}
+    />
+  );
+}

--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -62,10 +62,11 @@ const GENERIC_CHILD_LABELS = new Set([
 ]);
 
 function toPlainText(value) {
-  return value
-    .replace(/<[^>]+>/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  let text = value;
+  while (/<[^>]+>/.test(text)) {
+    text = text.replace(/<[^>]+>/g, "");
+  }
+  return text.replace(/\s+/g, " ").trim();
 }
 
 function getDisplayLabel(item, parentLabel) {

--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -13,48 +13,6 @@ import styles from "./styles.module.css";
 const LINK_CLASS_NAME = "table-of-contents__link toc-highlight";
 const LINK_ACTIVE_CLASS_NAME = "table-of-contents__link--active";
 
-const RELEASE_TOC_META = {
-  v10: { date: "Forced transactions - 27 Apr 2026 target" },
-  "beta-v53": { date: "Prover performance optimizations - 27 Apr 2026 target" },
-  "beta-v52": { date: "Small fields - 1 Apr 2026" },
-  "beta-v51": { date: "Yield Boost - 30 Mar 2026" },
-  "beta-v50": { date: "EIP-7702 - 23 Mar 2026" },
-  "beta-v45": { date: "Assertions - 28 Jan 2026" },
-  "beta-v44": { date: "Fusaka - 3 Dec 2025" },
-  "beta-v43": { date: "17 Nov 2025" },
-  "beta-v42": { date: "5 Nov 2025" },
-  "beta-v41": { date: "30 Oct 2025" },
-  "beta-v40": { date: "22-28 Oct 2025" },
-  "beta-v311": { date: "6 Oct 2025" },
-  "beta-v31": { date: "Aug 2025 target" },
-  "beta-v30": { date: "Early Aug 2025 target" },
-  "beta-v20": { date: "9 Jun 2025" },
-  "beta-v10": { phase: "Phased release" },
-  "beta-v14": { date: "28 Apr 2025" },
-  "beta-v13": { date: "3 Mar 2025" },
-  "beta-v12": { date: "With Beta v2" },
-  "beta-v11": { date: "With Beta v2" },
-  "alpha-v42": { date: "26 Mar 2025" },
-  "alpha-v41": { date: "4 Feb 2025" },
-  "alpha-v40": { date: "16 Dec 2024" },
-  "alpha-v350": { date: "9 Oct 2024" },
-  "alpha-v341": { date: "30 Sep 2024" },
-  "alpha-v36": { date: "25 Sep 2024" },
-  "alpha-v352": { date: "23 Sep 2024" },
-  "alpha-v351": { phase: "Date not listed" },
-  "alpha-v34": { date: "30 Jul 2024" },
-  "alpha-v33": { date: "11 Jun 2024" },
-  "alpha-v32": { date: "4 Jun 2024" },
-  "alpha-v31": { date: "14 May 2024" },
-  "alpha-v30": { date: "26 Mar 2024" },
-  "february-2024": { phase: "Monthly release notes" },
-  "alpha-v2": { phase: "Grouped release notes" },
-  "december-2023": { phase: "Monthly release notes" },
-  "november-2023": { phase: "Monthly release notes" },
-  "october-2023": { phase: "Monthly release notes" },
-  "summary-release-notes-june---october": { phase: "Historical summary" },
-};
-
 const GENERIC_CHILD_LABELS = new Set([
   "summary",
   "features",
@@ -77,7 +35,15 @@ function getDisplayLabel(item, parentLabel) {
   return plainLabel;
 }
 
-function ReleaseNotesTOCItems({ items, parentLabel }) {
+function getMetaText(meta) {
+  if (!meta) return null;
+  const date = meta.date || meta.mainnet;
+  const parts = [meta.label, date].filter(Boolean);
+  if (parts.length) return parts.join(" · ");
+  return meta.phase || null;
+}
+
+function ReleaseNotesTOCItems({ items, parentLabel, releaseMeta }) {
   if (!items.length) {
     return null;
   }
@@ -85,9 +51,11 @@ function ReleaseNotesTOCItems({ items, parentLabel }) {
   return (
     <ul className={clsx(styles.list, parentLabel && styles.childList)}>
       {items.map((item) => {
-        const meta = RELEASE_TOC_META[item.id];
         const displayLabel = getDisplayLabel(item, parentLabel);
         const plainLabel = toPlainText(item.value);
+        const metaText = !parentLabel
+          ? getMetaText(releaseMeta?.[item.id])
+          : null;
 
         return (
           <li
@@ -101,14 +69,12 @@ function ReleaseNotesTOCItems({ items, parentLabel }) {
                 !parentLabel ? styles.releaseLink : styles.childLink,
               )}>
               <span className={styles.label}>{displayLabel}</span>
-              {meta?.date && <span className={styles.meta}>{meta.date}</span>}
-              {!meta?.date && meta?.phase && (
-                <span className={styles.meta}>{meta.phase}</span>
-              )}
+              {metaText && <span className={styles.meta}>{metaText}</span>}
             </Link>
             <ReleaseNotesTOCItems
               items={item.children}
               parentLabel={plainLabel}
+              releaseMeta={releaseMeta}
             />
           </li>
         );
@@ -119,6 +85,7 @@ function ReleaseNotesTOCItems({ items, parentLabel }) {
 
 function ReleaseNotesTOC({
   toc,
+  releaseMeta,
   className,
   minHeadingLevel: minHeadingLevelOption,
   maxHeadingLevel: maxHeadingLevelOption,
@@ -151,7 +118,7 @@ function ReleaseNotesTOC({
     <div className={clsx(styles.root, "release-notes-toc", className)}>
       <div className={styles.heading}>Release history</div>
       <div className={clsx(styles.scrollArea, "thin-scrollbar")}>
-        <ReleaseNotesTOCItems items={tocTree} />
+        <ReleaseNotesTOCItems items={tocTree} releaseMeta={releaseMeta} />
       </div>
     </div>
   );
@@ -175,6 +142,7 @@ export default function DocItemTOCDesktop() {
   return (
     <ReleaseNotesTOC
       toc={toc}
+      releaseMeta={frontMatter.release_toc}
       minHeadingLevel={frontMatter.toc_min_heading_level}
       maxHeadingLevel={frontMatter.toc_max_heading_level}
       className={ThemeClassNames.docs.docTocDesktop}

--- a/src/theme/DocItem/TOC/Desktop/styles.module.css
+++ b/src/theme/DocItem/TOC/Desktop/styles.module.css
@@ -62,7 +62,7 @@
   content: "";
   position: absolute;
   top: 14px;
-  left: -18px;
+  left: -19px;
   width: 7px;
   height: 7px;
   border: 1px solid var(--linea-brand-purple);

--- a/src/theme/DocItem/TOC/Desktop/styles.module.css
+++ b/src/theme/DocItem/TOC/Desktop/styles.module.css
@@ -1,0 +1,113 @@
+.root {
+  color: var(--linea-text-primary);
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
+  display: flex;
+  flex-direction: column;
+}
+
+.heading {
+  margin-bottom: 10px;
+  color: var(--linea-text-primary);
+  font-family: AtypText, sans-serif;
+  font-size: var(--font-body-md);
+  font-weight: 500;
+}
+
+.scrollArea {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.list {
+  margin: 0;
+  padding: 0 0 0 14px;
+  border-left: 1px solid var(--linea-brand-purple);
+  list-style: none;
+}
+
+.childList {
+  margin-top: 4px;
+  margin-left: 4px;
+  padding-left: 12px;
+  border-left: none;
+}
+
+.item {
+  list-style: none;
+}
+
+.releaseItem + .releaseItem {
+  margin-top: 6px;
+}
+
+.link {
+  display: block;
+  padding: 2px 0 2px 12px;
+  color: var(--linea-text-secondary);
+  text-decoration: none;
+}
+
+.link:hover {
+  color: var(--linea-text-primary);
+  text-decoration: none;
+}
+
+.releaseLink {
+  position: relative;
+}
+
+.releaseLink::before {
+  content: "";
+  position: absolute;
+  top: 14px;
+  left: -18px;
+  width: 7px;
+  height: 7px;
+  border: 1px solid var(--linea-brand-purple);
+  border-radius: var(--linea-radius-round);
+  background: var(--ifm-background-color);
+}
+
+.childLink {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.label {
+  display: block;
+  color: inherit;
+  font-family: AtypText, sans-serif;
+  font-size: var(--font-body-sm);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.releaseLink .label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--linea-text-primary);
+}
+
+.meta {
+  display: block;
+  margin-top: 2px;
+  color: var(--linea-text-muted);
+  font-family: AtypText, sans-serif;
+  font-size: var(--font-body-xs);
+  line-height: 1.4;
+}
+
+.root :global(.table-of-contents__link--active) {
+  color: var(--linea-active-color);
+}
+
+.root :global(.table-of-contents__link--active) .label {
+  color: var(--linea-active-color);
+}
+
+.root :global(.table-of-contents__link--active)::before {
+  border-color: var(--linea-active-color);
+  background: var(--linea-active-color);
+}


### PR DESCRIPTION
## Summary

fix #1440, #1434

- Flatten the grouped "Beta v6.0" phased release into standalone versioned entries: v1.0, Beta v5.3, v5.2, v5.1, v5.0
- Rename "Assertions" → Beta v4.5, merge "Fusaka" into Beta v4.4
- Add custom scrollable release chronology TOC with sticky positioning and purple timeline (matching prod visual identity)
- Fix copy-page button alignment on release notes page (missing category label caused left-shift)
- Add legacy anchor targets (`#beta-v60`, `#forced-transactions`, `#small-fields`, `#eip-7702`, `#assertions`, `#fusaka`) for backward compatibility
- Update internal links in `deploy-subdomain.mdx` and `eip-7702.mdx` to point to new anchors
- Update stale "Beta v6.0" prose references to "Beta v5.0"

## Why

The old grouped "phased release" structure was confusing — each release should be a standalone, clearly versioned entry with its own date. The custom TOC makes the long release history navigable with bounded scroll. Anchor compatibility preserves external bookmarks.

## Test plan

- [x] Verify release notes page renders correctly (light + dark)
- [x] Verify TOC scrolls and highlights active section
- [x] Verify copy-page button is right-aligned
- [x] Verify legacy anchors resolve (`#beta-v60`, `#small-fields`, etc.)
- [x] Verify internal links from deploy-subdomain and eip-7702 pages
- [x] Check no regressions on standard docs pages


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `release_toc` front-matter contract consumed by both MDX and a swizzled TOC component, so incorrect IDs or metadata can break release-note navigation and dates. CSS token changes also affect sticky layout offsets site-wide on desktop.
> 
> **Overview**
> Refactors `docs/changelog/release-notes.mdx` to use a new `release_toc` front-matter map as the single source of truth for release labels/dates, and updates entries (including new Beta v5.x sections, renamed Beta v4.5/Beta v4.4, and corrected EIP-7702 version references) to render dates via `<ChangelogDate sectionId=... />` while preserving backward-compatible deep links via `.legacy-anchor` IDs.
> 
> Adds a swizzled `src/theme/DocItem/TOC/Desktop` that renders a custom, scrollable “Release history” timeline TOC on the release-notes page (with per-release metadata text) while keeping the default TOC elsewhere; accompanying CSS introduces a desktop `--linea-sticky-header-offset` token, updates sidebar sticky calculations to use it, tweaks TOC hiding behavior, and fixes title-row right alignment. Related docs are updated to point at the new anchors and the forced-transactions page no longer links to a specific release section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82467ecb5082fbfbf4bd270a2103a5598697a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->