### PR TITLE
docs: separate official from community block explorers

### DIFF
--- a/docs/network/build/block-explorers.mdx
+++ b/docs/network/build/block-explorers.mdx
@@ -12,89 +12,113 @@ If you're new to public blockchain networks, you might not be familiar with _blo
 
 As users take actions on the network, there are changes to those accounts and tokens. A block explorer is an interface through which you can look at that information in all its raw, gritty detail.
 
+**Official** explorers are maintained or operated in partnership with Linea. **Community** explorers are independently built by third parties and listed for convenience — they are not audited or endorsed by Linea.
+
 > If you want to learn more about explorers and how to use them, check out the [MetaMask help center](https://support.metamask.io/managing-my-wallet/how-to-check-my-wallet-activity-on-the-blockchain-explorer/)
 
 <Tabs groupId="Mainnet-Testnet" className="my-tabs">
   <TabItem value="Mainnet" label="Mainnet" default>
-    <table>
-      <thead>
-        <tr>
-          <th>Explorer name</th>
-          <th>URL</th>
-          <th>API URL</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Lineascan</td>
-          <td>https://lineascan.build</td>
-          <td>`https://api.lineascan.build/api`</td>
-        </tr>
-        <tr>
-          <td>Lineaplorer</td>
-          <td>https://lineaplorer.build/</td>
-          <td>`https://lineaplorer.build/api`</td>
-        </tr>
-        {/* It would appear that L2Scan, as of Aug 14, 2025, only supports the Merlin and B2 networks.
-        Removing this entry.*/}
-        <tr> 
-          <td>Blockscout</td>
-          <td>https://explorer.linea.build</td>
-          <td>`https://explorer.linea.build/api`</td>
-        </tr>
-        <tr>
-          <td>OKLink</td>
-          <td>https://oklink.com/linea</td>
-          <td>`https://oklink.com/docs/en/#welcome-to-oklink-api`</td>
-        </tr>
-        {/* It would appear that, as of August 14, 2025, Socialscan has deprecated the Linea explorer.
-        However, manta.socialscan.io for example still exists; leaving this here for now in case the Linea instance is fixed. */}
-        {/* <tr>
-          <td>Socialscan</td>
-          <td>https://linea.socialscan.io/</td>
-          <td>`https://api.socialscan.io/linea`</td>
-        </tr> */}
-        <tr>
-          <td>Linea for Humans</td>
-          <td>https://linea.forhumans.app/</td>
-          <td>n/a</td>
-        </tr>
-        <tr>
-          <td>0xPPL</td>
-          <td>https://0xppl.com/Linea/overview</td>
-          <td>n/a</td>
-        </tr>
-        <tr>
-          <td>Arkham</td>
-          <td>https://platform.arkhamintelligence.com/</td>
-          <td>n/a</td>
-        </tr>
-        {/* As of August 14, 2025, it would appear NFTScan no longer supports Linea.
-        Removing their entry. */}
-      </tbody>
-    </table>
+
+#### Official
+
+<table>
+  <thead>
+    <tr>
+      <th>Explorer name</th>
+      <th>URL</th>
+      <th>API URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Lineascan</td>
+      <td>https://lineascan.build</td>
+      <td>`https://api.lineascan.build/api`</td>
+    </tr>
+    <tr>
+      <td>Blockscout</td>
+      <td>https://explorer.linea.build</td>
+      <td>`https://explorer.linea.build/api`</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Community
+
+<table>
+  <thead>
+    <tr>
+      <th>Explorer name</th>
+      <th>URL</th>
+      <th>API URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Lineaplorer</td>
+      <td>https://lineaplorer.build/</td>
+      <td>`https://lineaplorer.build/api`</td>
+    </tr>
+    {/* It would appear that L2Scan, as of Aug 14, 2025, only supports the Merlin and B2 networks.
+    Removing this entry.*/}
+    <tr>
+      <td>OKLink</td>
+      <td>https://oklink.com/linea</td>
+      <td>`https://oklink.com/docs/en/#welcome-to-oklink-api`</td>
+    </tr>
+    {/* It would appear that, as of August 14, 2025, Socialscan has deprecated the Linea explorer.
+    However, manta.socialscan.io for example still exists; leaving this here for now in case the Linea instance is fixed. */}
+    {/* <tr>
+      <td>Socialscan</td>
+      <td>https://linea.socialscan.io/</td>
+      <td>`https://api.socialscan.io/linea`</td>
+    </tr> */}
+    <tr>
+      <td>Linea for Humans</td>
+      <td>https://linea.forhumans.app/</td>
+      <td>n/a</td>
+    </tr>
+    <tr>
+      <td>0xPPL</td>
+      <td>https://0xppl.com/Linea/overview</td>
+      <td>n/a</td>
+    </tr>
+    <tr>
+      <td>Arkham</td>
+      <td>https://platform.arkhamintelligence.com/</td>
+      <td>n/a</td>
+    </tr>
+    {/* As of August 14, 2025, it would appear NFTScan no longer supports Linea.
+    Removing their entry. */}
+  </tbody>
+</table>
+
   </TabItem>
-  <TabItem value="Linea Sepolia" label="Linea Sepolia" default>
-    <table>
-      <thead>
-        <tr>
-          <th>Explorer name</th>
-          <th>URL</th>
-          <th>API URL</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Lineascan</td>
-          <td>https://sepolia.lineascan.build</td>
-          <td>`https://api-sepolia.lineascan.build/api`</td>
-        </tr>
-        <tr>
-          <td>Blockscout</td>
-          <td>https://explorer.sepolia.linea.build/</td>
-          <td>`https://explorer.sepolia.linea.build/api`</td>
-        </tr>
-      </tbody>
-    </table>
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
+
+#### Official
+
+<table>
+  <thead>
+    <tr>
+      <th>Explorer name</th>
+      <th>URL</th>
+      <th>API URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Lineascan</td>
+      <td>https://sepolia.lineascan.build</td>
+      <td>`https://api-sepolia.lineascan.build/api`</td>
+    </tr>
+    <tr>
+      <td>Blockscout</td>
+      <td>https://explorer.sepolia.linea.build/</td>
+      <td>`https://explorer.sepolia.linea.build/api`</td>
+    </tr>
+  </tbody>
+</table>
+
   </TabItem>
 </Tabs>

--- a/docs/network/build/block-explorers.mdx
+++ b/docs/network/build/block-explorers.mdx
@@ -83,13 +83,6 @@ As users take actions on the network, there are changes to those accounts and to
       <td>https://0xppl.com/Linea/overview</td>
       <td>n/a</td>
     </tr>
-    <tr>
-      <td>Arkham</td>
-      <td>https://platform.arkhamintelligence.com/</td>
-      <td>n/a</td>
-    </tr>
-    {/* As of August 14, 2025, it would appear NFTScan no longer supports Linea.
-    Removing their entry. */}
   </tbody>
 </table>
 

--- a/docs/network/build/block-explorers.mdx
+++ b/docs/network/build/block-explorers.mdx
@@ -12,7 +12,7 @@ If you're new to public blockchain networks, you might not be familiar with _blo
 
 As users take actions on the network, there are changes to those accounts and tokens. A block explorer is an interface through which you can look at that information in all its raw, gritty detail.
 
-**Official** explorers are maintained or operated in partnership with Linea. **Community** explorers are independently built by third parties and listed for convenience — they are not audited or endorsed by Linea.
+**Official** explorers are maintained or operated in partnership with Linea. **Community** explorers are independently built by third parties and listed for convenience—they are not audited or endorsed by Linea.
 
 > If you want to learn more about explorers and how to use them, check out the [MetaMask help center](https://support.metamask.io/managing-my-wallet/how-to-check-my-wallet-activity-on-the-blockchain-explorer/)
 
@@ -56,8 +56,8 @@ As users take actions on the network, there are changes to those accounts and to
   <tbody>
     <tr>
       <td>Lineaplorer</td>
-      <td>https://lineaplorer.build/</td>
-      <td>`https://lineaplorer.build/api`</td>
+      <td>https://Lineaplorer.build/</td>
+      <td>`https://Lineaplorer.build/api`</td>
     </tr>
     {/* It would appear that L2Scan, as of Aug 14, 2025, only supports the Merlin and B2 networks.
     Removing this entry.*/}

--- a/docs/network/build/block-explorers.mdx
+++ b/docs/network/build/block-explorers.mdx
@@ -78,11 +78,6 @@ As users take actions on the network, there are changes to those accounts and to
       <td>https://linea.forhumans.app/</td>
       <td>n/a</td>
     </tr>
-    <tr>
-      <td>0xPPL</td>
-      <td>https://0xppl.com/Linea/overview</td>
-      <td>n/a</td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

Closes #1448.

Splits the block explorers page into two tiers per network tab:

- **Official**: Lineascan, Blockscout — maintained or operated in partnership with Linea.
- **Community**: Lineaplorer, OKLink, Linea for Humans, 0xPPL, Arkham — third-party, not audited or endorsed by Linea.

Intro paragraph updated to explain the distinction. Existing tables, styling, and code comments (L2Scan / Socialscan / NFTScan notes) preserved.

Sepolia tab only shows Official, since no community explorers support it.

## Test plan

- [ ] Visit `/get-started/build/block-explorers` on the preview build
- [ ] Mainnet tab: Official table (2 rows) then Community table (5 rows)
- [ ] Sepolia tab: Official table only (2 rows)
- [ ] Light + dark themes render correctly
- [ ] Mobile layout OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring; main risk is incorrect/outdated explorer URLs or listings after the table split.
> 
> **Overview**
> Updates the `block-explorers.mdx` doc to explicitly distinguish **Official** vs **Community** explorers, including a new disclaimer that community listings aren’t audited or endorsed by Linea.
> 
> Restructures the Mainnet section from a single table into two tables (Official: Lineascan/Blockscout; Community: Lineaplorer/OKLink/Linea for Humans) and adjusts the tabs so `Linea Sepolia` shows only the Official table (and is no longer marked `default`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3208df44aa29ba5f278d369ec7d02e4ce2e82994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->