### PR TITLE
[Chore ] - Add next 3 transactions for LSC

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -47,9 +47,9 @@ you can take to verify this information.
   - Verification: Events confirming the verifier changes were emitted and are viewable in the transaction logs:
     - `PDGPolicyEnacted` event emitted with `pdgPolicy` having value `2`.
     - `RoleGranted` 1 role granted to the node operator depositor `0xbe315a487bf2839a6d07ee91acfdf189af8bcf9d`.
-      - `NODE_OPERATOR_UNGUARANTEED_DEPOSIT_ROLE` (0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063).
+      - `NODE_OPERATOR_UNGUARANTEED_DEPOSIT_ROLE` (`0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063`).
     - `RoleGranted` 1 role granted to the node operator depositor `0xcf9a8acbedbf57f9ee2f0c9cd0991277dbfb5da1`.
-      - `NODE_OPERATOR_PROVE_UNKNOWN_VALIDATOR_ROLE` (0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063).
+      - `NODE_OPERATOR_PROVE_UNKNOWN_VALIDATOR_ROLE` (`0x7b564705f4e61596c4a9469b6884980f89e475befabdb849d69719f0791628be`).
     - `FeeRecipientSet` set to the payment splitter address `0x4d2504c498bb7e63bcc7bc11f781d30d99b6febb`.
     - `WithdrawalReserveParametersSet`
       - `newTargetWithdrawalReservePercentageBps` should change to `9980`from the old value of `9985`.
@@ -62,7 +62,7 @@ you can take to verify this information.
   - Actions: 
     - Safe upgrade to version 1.4.1
   - Verification
-    - `ChangedMasterCopy` event emitted with `0x29fcb43b46531bca003ddc8fcb67ffe91900c762"` as the singleton.
+    - `ChangedMasterCopy` event emitted with `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` as the singleton.
     - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
 
 - **[Nonce 54](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -22,7 +22,7 @@ you can take to verify this information.
 ### April 21, 2026
 
 #### L1
-- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 74](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
     - Safe upgrade to version 1.4.1
   - Verification

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -38,13 +38,14 @@ you can take to verify this information.
 
 - **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
+    - Add verifier at index 0 fixing 2 correctness issues preventing the generation of proofs in some cases.
     - Set Predeposit Guarantee Policy to non-strict on the vault dashboard.
     - Grant Two Node Operation roles for non-strict flow on the vault dashboard.
     - Set the FeeRecipient on the vault dashboard to the Payment Splitter.
     - Adjust yield parameters to allow 20 BPS worth of ETH to be sent to the vault.
-    - Add verifier at index 0 fixing 2 correctness issues preventing the generation of proofs in some cases.
     - Decrease the rate limit at the exit of the withdrawal tunnel to 10,000 ETH per day.
   - Verification: Events confirming the verifier changes were emitted and are viewable in the transaction logs:
+    - `VerifierAddressChanged` records the new verifier `0x218c3339ff3fea595c02ac31ca8a782f5028c4dc`, at index 0.
     - `PDGPolicyEnacted` event emitted with `pdgPolicy` having value `2`.
     - `RoleGranted` 1 role granted to the node operator depositor `0xbe315a487bf2839a6d07ee91acfdf189af8bcf9d`.
       - `NODE_OPERATOR_UNGUARANTEED_DEPOSIT_ROLE` (`0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063`).
@@ -54,7 +55,7 @@ you can take to verify this information.
     - `WithdrawalReserveParametersSet`
       - `newTargetWithdrawalReservePercentageBps` should change to `9980`from the old value of `9985`.
       - All other parameters old and new remain unchanged.
-    - `VerifierAddressChanged` records the new verifier `0x218c3339ff3fea595c02ac31ca8a782f5028c4dc`, at index 0.
+
     - `LimitAmountChanged` contains the security council address, the new limit in Wei `10000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
 
 #### L2

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -19,8 +19,67 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
-### April 13, 2026 (TBD)
+### April 21, 2026
 
+#### L1
+- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Safe upgrade to version 1.4.1
+  - Verification
+    - `ChangedMasterCopy` event emitted with `0x41675c099f32341bf84bfc5382af534df5c7461a` as the singleton.
+    - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
+
+- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Rotation of two Security Council Addresses.
+  - Verification:
+    - Two addresses are removed and replaced with two new ones ( TBD )
+    - Thresholds at the end of the transaction remain unchanged.
+
+- **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Set Predeposit Guarantee Policy to non-strict on the vault dashboard.
+    - Grant Two Node Operation roles for non-strict flow on the vault dashboard.
+    - Set the FeeRecipient on the vault dashboard to the Payment Splitter.
+    - Adjust yield parameters to allow 20 BPS worth of ETH to be sent to the vault.
+    - Add verifier at index 0 fixing 2 correctness issues preventing the generation of proofs in some cases.
+    - Decrease the rate limit at the exit of the withdrawal tunnel to 10,000 ETH per day.
+  - Verification: Events confirming the verifier changes were emitted and are viewable in the transaction logs:
+    - `PDGPolicyEnacted` event emitted with `pdgPolicy` having value `2`.
+    - `RoleGranted` 1 role granted to the node operator depositor `0xbe315a487bf2839a6d07ee91acfdf189af8bcf9d`.
+      - `NODE_OPERATOR_UNGUARANTEED_DEPOSIT_ROLE` (0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063).
+    - `RoleGranted` 1 role granted to the node operator depositor `0xcf9a8acbedbf57f9ee2f0c9cd0991277dbfb5da1`.
+      - `NODE_OPERATOR_PROVE_UNKNOWN_VALIDATOR_ROLE` (0x5c17b14b08ace6dda14c9642528ae92de2a73d59eacb65c71f39f309a5611063).
+    - `FeeRecipientSet` set to the payment splitter address `0x4d2504c498bb7e63bcc7bc11f781d30d99b6febb`.
+    - `WithdrawalReserveParametersSet`
+      - `newTargetWithdrawalReservePercentageBps` should change to `9980`from the old value of `9985`.
+      - All other parameters old and new remain unchanged.
+    - `VerifierAddressChanged` records the new verifier `0x218c3339ff3fea595c02ac31ca8a782f5028c4dc`, at index 0.
+    - `LimitAmountChanged` contains the security council address, the new limit in Wei `10000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
+
+#### L2
+- **[Nonce 55](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+  - Actions: 
+    - Safe upgrade to version 1.4.1
+  - Verification
+    - `ChangedMasterCopy` event emitted with `0x29fcb43b46531bca003ddc8fcb67ffe91900c762"` as the singleton.
+    - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
+
+- **[Nonce 54](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+  - Actions: 
+    - Rotation of two Security Council Addresses.
+  - Verification:
+    - Two addresses are removed and replaced with two new ones ( TBD )
+    - Thresholds at the end of the transaction remain unchanged.
+
+- **[Nonce 53](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+  - Actions: 
+    - Decrease the rate limit at the entrance of the withdrawal tunnel to 8,000 ETH per day.
+  - Verification:
+    - `LimitAmountChanged` contains the security council address, the new limit in Wei `8000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
+
+### April 17, 2026
+#### L1
 - **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0xf2df9a80b654c181f9930b3a152192216d79d6e1f3821d5e3232662512b3c0bf)**
 
 The following addresses are setup-time generated addresses and should be treated as placeholders in review:


### PR DESCRIPTION
L1 Tx 3:
- Upgrade of the Safe

L1 Tx 2:
- Rotation of 2 members of the LSC

L1 Tx 1
- Execute of the verifier
- The 5 actions of the Yield Boost
- Lower the limit rate to 10k ETH

L2 Tx 3:
- Upgrade of the Safe
- 
L2 Tx 2:
- Rotation of 2 members of the LSC

L2 Tx 1:
- Lower the limit rate to 8k ETH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that adds transaction record entries; no code or onchain logic changes are introduced.
> 
> **Overview**
> Adds a new **April 21, 2026** section to `docs/changelog/security-council-record.mdx`, replacing the previous TBD placeholder.
> 
> Documents the next LSC multisig transactions on **L1 (nonces 72–74)** and **L2 (nonces 53–55)**, including Safe upgrades to `v1.4.1`, member rotations (addresses TBD), verifier update/yield-boost configuration steps, and updated withdrawal tunnel rate limits, along with the expected onchain events for verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86971e29471a5907d86194690a0669d40bf667c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->