### PR TITLE
Update nonce entries in security council record

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -22,21 +22,21 @@ you can take to verify this information.
 ### April 21, 2026
 
 #### L1
-- **[Nonce 74](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 75](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
     - Safe upgrade to version 1.4.1
   - Verification
     - `ChangedMasterCopy` event emitted with `0x41675c099f32341bf84bfc5382af534df5c7461a` as the singleton.
     - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
 
-- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 74](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
     - Rotation of two Security Council Addresses.
   - Verification:
     - Two addresses are removed and replaced with two new ones ( TBD )
     - Thresholds at the end of the transaction remain unchanged.
 
-- **[Nonce 72](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
   - Actions: 
     - Add verifier at index 0 fixing 2 correctness issues preventing the generation of proofs in some cases.
     - Set Predeposit Guarantee Policy to non-strict on the vault dashboard.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renumbers existing L1 nonce entries to match the actual Safe transaction nonces.
> 
> **Overview**
> Updates `docs/changelog/security-council-record.mdx` to **correct the L1 nonce numbering** for the April 21, 2026 Security Council transaction entries (shifting the listed nonces up by 1, e.g. `74→75`, `73→74`, `72→73) while keeping the described actions and verification text the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272cb6e1df0e01a2a3354cf462031494b7f9cb22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->