### PR TITLE
[Chore] - add link to nonce 73

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -36,7 +36,7 @@ you can take to verify this information.
     - Two addresses are removed and replaced with two new ones ( TBD )
     - Thresholds at the end of the transaction remain unchanged.
 
-- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x4743afd65119c20228fa721e0f40df3c80be8f5cfd533d3e93096c2b57331f0d)**
   - Actions: 
     - Add verifier at index 0 fixing 2 correctness issues preventing the generation of proofs in some cases.
     - Set Predeposit Guarantee Policy to non-strict on the vault dashboard.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts a hyperlink; no runtime or protocol behavior is affected.
> 
> **Overview**
> Updates the Linea Security Council transaction record to link **Nonce 73** directly to its specific Safe multisig transaction by adding the transaction `id` query parameter to the existing URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37fb730485e17f5c336ad7fd4c940e68d86aa31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->