### PR TITLE
docs: update Yield Boost status banner

### DIFF
--- a/docs/network/overview/yield-boost/index.mdx
+++ b/docs/network/overview/yield-boost/index.mdx
@@ -7,7 +7,7 @@ image: /img/socialCards/yield-boost.jpg
 
 :::caution[Status]
 
-🚧 Yield Boost is not yet live. This documentation describes the intended design.
+🚧 Yield Boost is in phased rollout. Initial infrastructure is being deployed on mainnet, with early ETH movements into the `YieldManager` and `StakingVault`. This documentation describes the intended steady-state design, and some components may not yet be active.
 
 :::
 

--- a/docs/network/overview/yield-boost/index.mdx
+++ b/docs/network/overview/yield-boost/index.mdx
@@ -7,7 +7,7 @@ image: /img/socialCards/yield-boost.jpg
 
 :::caution[Status]
 
-🚧 Yield Boost is in phased rollout. Initial infrastructure has been deployed on mainnet, with early ETH movements into the `YieldManager` and `StakingVault`. This documentation describes the intended steady-state design, and some components may not yet be active.
+🚧 Yield Boost is in a phased rollout. Initial infrastructure has been deployed on mainnet, with early ETH movements into the `YieldManager` and `StakingVault`. This documentation describes the intended steady-state design, and some components may not yet be active.
 
 :::
 

--- a/docs/network/overview/yield-boost/index.mdx
+++ b/docs/network/overview/yield-boost/index.mdx
@@ -7,7 +7,7 @@ image: /img/socialCards/yield-boost.jpg
 
 :::caution[Status]
 
-🚧 Yield Boost is in phased rollout. Initial infrastructure is being deployed on mainnet, with early ETH movements into the `YieldManager` and `StakingVault`. This documentation describes the intended steady-state design, and some components may not yet be active.
+🚧 Yield Boost is in phased rollout. Initial infrastructure has been deployed on mainnet, with early ETH movements into the `YieldManager` and `StakingVault`. This documentation describes the intended steady-state design, and some components may not yet be active.
 
 :::
 


### PR DESCRIPTION
## Summary
- update the public Yield Boost page banner to reflect phased rollout status
- replace the absolute 'not yet live' wording with rollout-specific language

## Testing
- not run (docs copy change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single documentation banner wording change with no functional or behavioral impact.
> 
> **Overview**
> Updates the Yield Boost docs *Status* caution banner to replace the "not yet live" message with rollout-specific language, noting a phased mainnet deployment and that some components may not yet be active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5eed7fed2c9fe6c8b9610a0671e7f3036480964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->