### PR TITLE
[Chore] - add links and set rotated addresses

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -22,18 +22,24 @@ you can take to verify this information.
 ### April 21, 2026
 
 #### L1
-- **[Nonce 75](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 75](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x9dedb4f3c41b6306ef681bad3241c77493d95fb30f034d1615404c50d2025d2b)**
   - Actions: 
     - Safe upgrade to version 1.4.1
   - Verification
     - `ChangedMasterCopy` event emitted with `0x41675c099f32341bf84bfc5382af534df5c7461a` as the singleton.
     - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
 
-- **[Nonce 74](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 74](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x7e4b9f81e4f2272285a96d615c831533bd4bdcf61ce3b681036dd05fba97cb8b)**
   - Actions: 
+    - Adjust Yield Manager Withdrawal Parameters.
     - Rotation of two Security Council Addresses.
   - Verification:
-    - Two addresses are removed and replaced with two new ones ( TBD )
+    - `WithdrawalReserveParametersSet`
+      - `newTargetWithdrawalReservePercentageBps` should change to `9980`from the old value of `9888`.
+      - All other parameters old and new remain unchanged.
+    - Two addresses are removed and replaced with two new owners
+      - `RemovedOwner` containing `0x99234cd9b532f30538ac797d33c212e3b69fd087` replaced by `AddedOwner` event containing `0x0f4df4939a6b126a088a40b4bbf9f30337acbfe4`
+      - `RemovedOwner` containing `0x497515578b0be54d2f0f32cf3f08b85bf8ceb6ab` replaced by `AddedOwner` event containing `0xd6481cc92ed746ebc679788654723ce49d45ebea`
     - Thresholds at the end of the transaction remain unchanged.
 
 - **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x4743afd65119c20228fa721e0f40df3c80be8f5cfd533d3e93096c2b57331f0d)**

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -42,6 +42,24 @@ you can take to verify this information.
       - `RemovedOwner` containing `0x497515578b0be54d2f0f32cf3f08b85bf8ceb6ab` replaced by `AddedOwner` event containing `0xd6481cc92ed746ebc679788654723ce49d45ebea`
     - Thresholds at the end of the transaction remain unchanged.
 
+#### L2
+- **[Nonce 54](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+  - Actions: 
+    - Safe upgrade to version 1.4.1
+  - Verification
+    - `ChangedMasterCopy` event emitted with `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` as the singleton.
+    - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
+
+- **[Nonce 53](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
+  - Actions: 
+    - Decrease the rate limit at the entrance of the withdrawal tunnel to 8,000 ETH per day.
+    - Rotation of two Security Council Addresses.
+  - Verification:
+    - `LimitAmountChanged` contains the security council address, the new limit in Wei `8000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
+    - Two addresses are removed and replaced with two new owners
+      - `RemovedOwner` containing `0x99234cd9b532f30538ac797d33c212e3b69fd087` replaced by `AddedOwner` event containing `0x0f4df4939a6b126a088a40b4bbf9f30337acbfe4`
+      - `RemovedOwner` containing `0x497515578b0be54d2f0f32cf3f08b85bf8ceb6ab` replaced by `AddedOwner` event containing `0xd6481cc92ed746ebc679788654723ce49d45ebea`
+
 ### April 21, 2026
 
 - **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x4743afd65119c20228fa721e0f40df3c80be8f5cfd533d3e93096c2b57331f0d)**
@@ -65,27 +83,6 @@ you can take to verify this information.
       - All other parameters old and new remain unchanged.
 
     - `LimitAmountChanged` contains the security council address, the new limit in Wei `10000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
-
-#### L2
-- **[Nonce 55](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
-  - Actions: 
-    - Safe upgrade to version 1.4.1
-  - Verification
-    - `ChangedMasterCopy` event emitted with `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` as the singleton.
-    - `ChangedFallbackHandler`event emitted with `0xfd0732dc9e303f09fcef3a7388ad10a83459ec99` as the handler.
-
-- **[Nonce 54](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
-  - Actions: 
-    - Rotation of two Security Council Addresses.
-  - Verification:
-    - Two addresses are removed and replaced with two new ones ( TBD )
-    - Thresholds at the end of the transaction remain unchanged.
-
-- **[Nonce 53](https://app.safe.global/transactions/tx?safe=linea:0xf5cc7604a5ef3565b4D2050D65729A06B68AA0bD)**
-  - Actions: 
-    - Decrease the rate limit at the entrance of the withdrawal tunnel to 8,000 ETH per day.
-  - Verification:
-    - `LimitAmountChanged` contains the security council address, the new limit in Wei `8000000000000000000000`. The other two parameters will have one `false` and one `true` depending on execution timing.
 
 ### April 17, 2026
 #### L1

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -19,7 +19,7 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
-### April 21, 2026
+### April 28, 2026
 
 #### L1
 - **[Nonce 75](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x9dedb4f3c41b6306ef681bad3241c77493d95fb30f034d1615404c50d2025d2b)**
@@ -41,6 +41,8 @@ you can take to verify this information.
       - `RemovedOwner` containing `0x99234cd9b532f30538ac797d33c212e3b69fd087` replaced by `AddedOwner` event containing `0x0f4df4939a6b126a088a40b4bbf9f30337acbfe4`
       - `RemovedOwner` containing `0x497515578b0be54d2f0f32cf3f08b85bf8ceb6ab` replaced by `AddedOwner` event containing `0xd6481cc92ed746ebc679788654723ce49d45ebea`
     - Thresholds at the end of the transaction remain unchanged.
+
+### April 21, 2026
 
 - **[Nonce 73](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x4743afd65119c20228fa721e0f40df3c80be8f5cfd533d3e93096c2b57331f0d)**
   - Actions: 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add/clarify transaction links and verification details, with no runtime or contract code impact.
> 
> **Overview**
> Updates `docs/changelog/security-council-record.mdx` to record **April 28, 2026** LSC activity, adding direct Safe transaction links (including `id` params) and expanded verification details.
> 
> The entry now documents L1 nonces `74`/`75` and adds an L2 section for nonces `53`/`54`, including explicit owner-rotation addresses and event-based checks (e.g., `WithdrawalReserveParametersSet`, `LimitAmountChanged`) while removing prior *TBD*/duplicate L2 content from the April 21 section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2456fa6f74a7195d0b4a7b48423e9ef224b988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->