### PR TITLE
Add Beta v5.2.1 release note: Pause Cooldown and Dynamic Chain Configuration

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -192,10 +192,10 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 <ChangelogEntry tag="upgrade">
 
-Refactors the `LineaRollup`, `TokenBridge`, and `L2MessageService` contracts into modular components and deploys a new verifier supporting Small Fields and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 67 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
+Upgrades Linea's core rollup, bridge, and messaging contracts and deploys a new verifier to support Pause Cooldown and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 52 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
 
-- **`Pause Cooldown`.** New pause mechanism enforced by `PAUSE_ALL_ROLE` (granted to an `Emergency Pauser` EOA controlled by the SOC) and `SECURITY_COUNCIL_ROLE` (granted to the Security Council multisig). Applied to `LineaRollup`, `L2MessageService`, and the L1/L2 `TokenBridge` contracts; replaces the prior Zodiac-based pause flow. Satisfies the user-exit-window requirement of [L2Beat Stage 1](https://medium.com/l2beat/introducing-stages-a-framework-to-evaluate-rollups-maturity-d290bb22befe).
-- **Dynamic Chain Configuration (DCC).** The verifier accepts chain-specific parameters (`chainId`, `l2MessageServiceAddress`, `baseFee`, `coinbase`) at proof verification time, allowing a single verifier contract to validate proofs for multiple [Linea stack](../stack/index.mdx) networks instead of requiring a per-chain verifier deployment.
+- **Pause Cooldown.** Adds a new pause mechanism for Linea's core contracts, including an Emergency Pauser account managed by Linea's security operations team and the Security Council multisig. This replaces the previous governance-managed pause process and supports the user exit window expected for L2Beat Stage 1.
+- **Dynamic Chain Configuration (DCC).** Lets the verifier use chain-specific settings at proof verification time, so a single verifier can support multiple [Linea stack](../stack/index.mdx) networks instead of requiring a separate verifier deployment for each one.
 
 </ChangelogEntry>
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -10,8 +10,12 @@ release_toc:
     sepolia: 29 April 2026
   beta-v53:
     label: Prover performance optimizations
-    mainnet: 29 April 2026
-    sepolia: 20 March 2026
+    mainnet: 4 May 2026 (target)
+    sepolia: 27 April 2026
+  beta-v521:
+    label: Pause Cooldown and Dynamic Chain Configuration
+    mainnet: 1 April 2026
+    sepolia: 24 March 2026
   beta-v52:
     label: Small fields
     mainnet: 1 April 2026
@@ -179,6 +183,19 @@ Finality under 30min: Reduce Linea's [hard finality](../network/overview/transac
 <ChangelogEntry tag="performance">
 
 Prover performance optimizations. Proof generation time ~40% faster.
+
+</ChangelogEntry>
+
+## Beta v5.2.1
+
+<ChangelogDate sectionId="beta-v521" />
+
+<ChangelogEntry tag="upgrade">
+
+Modularizes the `LineaRollup`, `TokenBridge`, and `L2MessageService` contracts and deploys a new verifier supporting Small Fields and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 67 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
+
+- **Pause Cooldown.** New pause mechanism enforced by `PAUSE_ALL_ROLE` (granted to an Emergency Pauser EOA controlled by the SOC) and `SECURITY_COUNCIL_ROLE` (granted to the Security Council multisig). Applied to `LineaRollup`, `L2MessageService`, and the L1/L2 `TokenBridge` contracts; replaces the prior Zodiac-based pause flow. Satisfies the user-exit-window requirement of [L2Beat Stage 1](https://medium.com/l2beat/introducing-stages-a-framework-to-evaluate-rollups-maturity-d290bb22befe).
+- **Dynamic Chain Configuration (DCC).** The verifier accepts chain-specific parameters (`chainId`, `l2MessageServiceAddress`, `baseFee`, `coinbase`) at proof verification time, allowing a single verifier contract to validate proofs for multiple [Linea stack](../stack/index.mdx) networks instead of requiring a per-chain verifier deployment.
 
 </ChangelogEntry>
 

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -192,9 +192,9 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 <ChangelogEntry tag="upgrade">
 
-Modularizes the `LineaRollup`, `TokenBridge`, and `L2MessageService` contracts and deploys a new verifier supporting Small Fields and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 67 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
+Refactors the `LineaRollup`, `TokenBridge`, and `L2MessageService` contracts into modular components and deploys a new verifier supporting Small Fields and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 67 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
 
-- **Pause Cooldown.** New pause mechanism enforced by `PAUSE_ALL_ROLE` (granted to an Emergency Pauser EOA controlled by the SOC) and `SECURITY_COUNCIL_ROLE` (granted to the Security Council multisig). Applied to `LineaRollup`, `L2MessageService`, and the L1/L2 `TokenBridge` contracts; replaces the prior Zodiac-based pause flow. Satisfies the user-exit-window requirement of [L2Beat Stage 1](https://medium.com/l2beat/introducing-stages-a-framework-to-evaluate-rollups-maturity-d290bb22befe).
+- **`Pause Cooldown`.** New pause mechanism enforced by `PAUSE_ALL_ROLE` (granted to an `Emergency Pauser` EOA controlled by the SOC) and `SECURITY_COUNCIL_ROLE` (granted to the Security Council multisig). Applied to `LineaRollup`, `L2MessageService`, and the L1/L2 `TokenBridge` contracts; replaces the prior Zodiac-based pause flow. Satisfies the user-exit-window requirement of [L2Beat Stage 1](https://medium.com/l2beat/introducing-stages-a-framework-to-evaluate-rollups-maturity-d290bb22befe).
 - **Dynamic Chain Configuration (DCC).** The verifier accepts chain-specific parameters (`chainId`, `l2MessageServiceAddress`, `baseFee`, `coinbase`) at proof verification time, allowing a single verifier contract to validate proofs for multiple [Linea stack](../stack/index.mdx) networks instead of requiring a per-chain verifier deployment.
 
 </ChangelogEntry>

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -194,8 +194,8 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 Upgrades Linea's core rollup, bridge, and messaging contracts and deploys a new verifier to support Pause Cooldown and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 52 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
 
-- **Pause Cooldown.** Adds a new pause mechanism for Linea's core contracts, including an Emergency Pauser account managed by Linea's security operations team and the Security Council multisig. This replaces the previous governance-managed pause process and supports the user exit window expected for L2Beat Stage 1.
-- **Dynamic Chain Configuration (DCC).** Lets the verifier use chain-specific settings at proof verification time, so a single verifier can support multiple [Linea stack](../stack/index.mdx) networks instead of requiring a separate verifier deployment for each one.
+- **Pause Cooldown.** Adds a new pause mechanism for Linea's core contracts, including an Emergency Pauser account managed by Linea's security operations team. This replaces the previous governance-managed pause process and ensures no non-Security-Council member can pause indefinitely, supporting the user exit window expected for L2Beat Stage 1.
+- **Dynamic Chain Configuration (DCC).** Lets the verifier use chain-specific settings at proof verification time, so each [Linea stack](../stack/index.mdx) network can use its own verifier deployment without requiring a new prover circuit for each chain.
 
 </ChangelogEntry>
 


### PR DESCRIPTION
## Summary
fix #1438

- Adds a new `## Beta v5.2.1` section to `docs/changelog/release-notes.mdx` covering the previously-unlogged Pause Cooldown + Dynamic Chain Configuration release (mainnet 1 Apr 2026, sepolia 24 Mar 2026).
- Documents the modularization of `LineaRollup`, `TokenBridge`, and `L2MessageService`, the new verifier supporting Small Fields + DCC, and the role grants (`PAUSE_ALL_ROLE`, `SECURITY_COUNCIL_ROLE`) that replace the Zodiac pause flow.
- Cross-links the matching [Security Council nonces 70 (L1) / 67 (L2)](docs/changelog/security-council-record.mdx) and the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration); refreshes Beta v5.3 dates in `release_toc`.

## Test plan

- [x] `npm run build` (or local Docusaurus dev server) renders the new section without anchor or link warnings
- [x] `#beta-v521` anchor resolves and `ChangelogDate` shows the new mainnet/sepolia dates
- [x] Outbound links to `security-council-record.mdx`, the audits page, the L2Beat Stage 1 article, and `stack/index.mdx` all resolve
- [x] Front-matter `release_toc` ordering is correct (v5.2.1 sits between v5.3 and v5.2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating release note content and TOC metadata, with no runtime or contract code modifications.
> 
> **Overview**
> Adds a new `## Beta v5.2.1` release-notes section describing the Pause Cooldown + Dynamic Chain Configuration upgrade, including links to the Security Council record and relevant audit reports.
> 
> Updates the `release_toc` metadata by inserting the new `beta-v521` entry and revising `beta-v53` mainnet/sepolia dates (marking mainnet as *target*).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b2b3acee60f41cf5e660407549ba55f78d4537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->