### PR TITLE
update forced transactions docs

### DIFF
--- a/docs/protocol/forced-transactions.mdx
+++ b/docs/protocol/forced-transactions.mdx
@@ -11,9 +11,9 @@ image: /img/socialCards/forced-transactions.jpg
 
 :::
 
-Forced transactions allow users to submit L2 transactions directly to the L1 with a guaranteed processing deadline
-on the L2. This manual submission mechanism ensures that users can submit transactions even when the normal L2 path is
-blocked or delayed.
+Forced transactions allow users to submit L2 transactions through L1 with a guaranteed processing deadline on the L2.
+This provides a fallback submission path for users when the normal L2 transaction submission route -- through L2 RPC
+providers -- is unavailable, unreliable, or censoring.
 
 :::info
 
@@ -24,17 +24,18 @@ In the case of the Linea public network, the L1 is Ethereum which serves as the
 
 ## What are forced transactions?
 
-Forced transactions protect users against sequencer censorship or failure. If the sequencer is down or becomes
-uncooperative, users retain the ability to send transactions and withdraw assets at any time by submitting them
-directly to L1, bypassing the sequencer entirely. To undertake a forced transaction, the user submits a signed
-L2 transaction directly to L1.
+Forced transactions protect users against censorship or unavailability of the normal L2 submission path. If L2 RPC
+providers are unreachable, refusing to relay, or otherwise unreliable, users retain the ability to submit
+transactions and withdraw assets by sending them through L1. To undertake a forced transaction, the user submits a
+signed L2 transaction to the `ForcedTransactionGateway` contract on L1.
 
-Forced transactions are guaranteed to be processed by the sequencer within a specified block deadline. Typically, the
-sequencer will process the transaction well before this deadline -- the deadline is
-the **latest acceptable block, not the target block**. If the sequencer fails to process the forced transaction before
-its deadline, the L1 proof verification transaction for that batch will revert. As a result, the batch cannot be finalized
-on Ethereum. This potential for batch failure effectively forces the sequencer to process the transaction else the rollup
-cannot make forward progress.
+Forced transactions do not bypass the sequencer; the sequencer is still required to produce blocks and process them.
+What they bypass is the normal L2 RPC submission path. Once stored on L1, a forced transaction is guaranteed to be
+processed by the sequencer within a specified block deadline. Typically, the sequencer will process the transaction
+well before this deadline -- the deadline is the **latest acceptable block, not the target block**. If the sequencer
+fails to process the forced transaction before its deadline, the L1 proof verification transaction for that batch will
+revert. As a result, the batch cannot be finalized on Ethereum. This potential for batch failure effectively forces
+the sequencer to process the transaction, else the rollup cannot make forward progress.
 
 Forced transactions are chained using a rolling hash that commits to the complete ordered sequence of forced transactions,
 ensuring processing and storage. This mechanism prevents skipped forced transactions, unauthorized inserted transactions,
@@ -42,9 +43,13 @@ and reordering attacks.
 
 ### Processing vs. execution
 
-Note that forced transactions guarantee *inclusion* not success. For example, while sequencer's role is to process the
-transaction, the transaction may still execute and revert. This means that a forced transaction successfully processed by
-the sequencer can still fail on the L2.
+Forced transactions guarantee *processing*, not necessarily inclusion or successful execution. The sequencer is
+required to process each forced transaction before its deadline, but processing can still result in the transaction
+being rejected or failing on the L2.
+
+A forced transaction can be rejected outright -- and proven invalid rather than included -- in cases such as targeting
+an L2 deny-listed address or calling an invalid or unsupported precompile. In other cases, the transaction is included
+in a block but reverts during execution.
 
 After a forced transaction is processed by the sequencer, the prover attempts to generate a zero-knowledge proof attesting
 to the validity of the state transition for that batch. At this stage, the transaction may fail to execute on the L2 for

--- a/docs/protocol/forced-transactions.mdx
+++ b/docs/protocol/forced-transactions.mdx
@@ -12,8 +12,8 @@ image: /img/socialCards/forced-transactions.jpg
 :::
 
 Forced transactions allow users to submit L2 transactions through L1 with a guaranteed processing deadline on the L2.
-This provides a fallback submission path for users when the normal L2 transaction submission route -- through L2 RPC
-providers -- is unavailable, unreliable, or censoring.
+This provides a fallback submission path for users when the normal L2 transaction submission route, through L2 RPC
+providers, is unavailable, unreliable, or censoring.
 
 :::info
 
@@ -32,7 +32,7 @@ signed L2 transaction to the `ForcedTransactionGateway` contract on L1.
 Forced transactions do not bypass the sequencer; the sequencer is still required to produce blocks and process them.
 What they bypass is the normal L2 RPC submission path. Once stored on L1, a forced transaction is guaranteed to be
 processed by the sequencer within a specified block deadline. Typically, the sequencer will process the transaction
-well before this deadline -- the deadline is the **latest acceptable block, not the target block**. If the sequencer
+well before this deadline, which is the **latest acceptable block, not the target block**. If the sequencer
 fails to process the forced transaction before its deadline, the L1 proof verification transaction for that batch will
 revert. As a result, the batch cannot be finalized on Ethereum. This potential for batch failure effectively forces
 the sequencer to process the transaction, else the rollup cannot make forward progress.
@@ -47,7 +47,7 @@ Forced transactions guarantee *processing*, not necessarily inclusion or success
 required to process each forced transaction before its deadline, but processing can still result in the transaction
 being rejected or failing on the L2.
 
-A forced transaction can be rejected outright -- and proven invalid rather than included -- in cases such as targeting
+A forced transaction can be rejected outright, and proven invalid rather than included, in cases such as targeting
 an L2 deny-listed address or calling an invalid or unsupported precompile. In other cases, the transaction is included
 in a block but reverts during execution.
 

--- a/docs/protocol/forced-transactions.mdx
+++ b/docs/protocol/forced-transactions.mdx
@@ -47,9 +47,10 @@ Forced transactions guarantee *processing*, not necessarily inclusion or success
 required to process each forced transaction before its deadline, but processing can still result in the transaction
 being rejected or failing on the L2.
 
-A forced transaction can be rejected outright, and proven invalid rather than included, in cases such as targeting
-an L2 deny-listed address or calling an invalid or unsupported precompile. In other cases, the transaction is included
-in a block but reverts during execution.
+A forced transaction can be rejected outright, and proven invalid rather than included, for a number of reasons.
+Examples include targeting an L2 deny-listed address, calling an invalid or unsupported precompile, supplying an
+invalid gas configuration, or breaching gas-consumption limits. In other cases, the transaction is included in a
+block but reverts during execution.
 
 After a forced transaction is processed by the sequencer, the prover attempts to generate a zero-knowledge proof attesting
 to the validity of the state transition for that batch. At this stage, the transaction may fail to execute on the L2 for

--- a/docs/protocol/how-to/forced-transactions.mdx
+++ b/docs/protocol/how-to/forced-transactions.mdx
@@ -43,7 +43,7 @@ const currentL2BlockNumber: bigint = await lineaRollup.currentL2BlockNumber();
 
 // 2. Target the FinalizedStateUpdated event for that exact block.
 //    The event signature is FinalizedStateUpdated(uint256,uint256,uint256,uint256)
-//    with the L2 block number as the indexed topic — so we can filter on
+//    with the L2 block number as the indexed topic, so we can filter on
 //    [eventTopic, blockNumberTopic] to fetch a single log instead of scanning
 //    the full event history.
 const abiCoder = AbiCoder.defaultAbiCoder();

--- a/docs/protocol/how-to/forced-transactions.mdx
+++ b/docs/protocol/how-to/forced-transactions.mdx
@@ -28,43 +28,65 @@ See the Linea contract addresses and ABIs in the monorepo for production integra
 // Pseudocode example (ethers v6)
 import {
   AbiCoder,
-  keccak256,
   Contract,
-  BrowserProvider
+  JsonRpcProvider,
+  id,
+  keccak256
 } from "ethers";
 
 // assume provider + contract already initialized
-// const provider = new BrowserProvider(window.ethereum);
+// const provider = new JsonRpcProvider(L1_RPC_URL);
 // const lineaRollup = new Contract(address, abi, provider);
 
-// 1. Get the latest FinalizedStateUpdated event
-const events = await lineaRollup.queryFilter(
-  lineaRollup.filters.FinalizedStateUpdated()
-);
+// 1. Read the last finalized L2 block number from the rollup contract
+const currentL2BlockNumber: bigint = await lineaRollup.currentL2BlockNumber();
 
-if (events.length === 0) {
-  throw new Error("No FinalizedStateUpdated events found");
+// 2. Target the FinalizedStateUpdated event for that exact block.
+//    The event signature is FinalizedStateUpdated(uint256,uint256,uint256,uint256)
+//    with the L2 block number as the indexed topic — so we can filter on
+//    [eventTopic, blockNumberTopic] to fetch a single log instead of scanning
+//    the full event history.
+const abiCoder = AbiCoder.defaultAbiCoder();
+const eventTopic = id("FinalizedStateUpdated(uint256,uint256,uint256,uint256)");
+const blockNumberTopic = abiCoder.encode(["uint256"], [currentL2BlockNumber]);
+
+const logs = await provider.getLogs({
+  address: await lineaRollup.getAddress(),
+  topics: [eventTopic, blockNumberTopic],
+  fromBlock: 0,
+  toBlock: "latest"
+});
+
+if (logs.length === 0) {
+  throw new Error(
+    `No FinalizedStateUpdated event found for L2 block ${currentL2BlockNumber}`
+  );
 }
 
-const latestEvent = events[events.length - 1];
+// 3. Decode the event
+const latestLog = logs[logs.length - 1];
+const parsed = lineaRollup.interface.parseLog({
+  topics: latestLog.topics as string[],
+  data: latestLog.data
+});
 
-// 2. Extract values from the event
+if (!parsed) {
+  throw new Error("Failed to parse FinalizedStateUpdated event");
+}
+
 const {
-  blockNumber,              // L2 block number (indexed)
   timestamp,                // Finalization timestamp
   messageNumber,            // L1->L2 message number
   forcedTransactionNumber   // Last finalized forced tx number
-} = latestEvent.args;
+} = parsed.args;
 
-// 3. Query rolling hashes from contract state
-const messageRollingHash = await lineaRollup.rollingHashes(messageNumber);
+// 4. Query rolling hashes from contract state
+const [messageRollingHash, forcedTransactionRollingHash] = await Promise.all([
+  lineaRollup.rollingHashes(messageNumber),
+  lineaRollup.forcedTransactionRollingHashes(forcedTransactionNumber)
+]);
 
-const forcedTransactionRollingHash =
-  await lineaRollup.forcedTransactionRollingHashes(
-    forcedTransactionNumber
-  );
-
-// 4. Construct the LastFinalizedState object
+// 5. Construct the LastFinalizedState object
 const lastFinalizedState = {
   timestamp,
   messageNumber,
@@ -73,21 +95,19 @@ const lastFinalizedState = {
   forcedTransactionRollingHash
 };
 
-// 5. OPTIONAL: Verify it matches the contract's stored hash
-const abiCoder = AbiCoder.defaultAbiCoder();
-
-const encoded = abiCoder.encode(
-  ["uint256", "bytes32", "uint256", "bytes32", "uint256"],
-  [
-    messageNumber,
-    messageRollingHash,
-    forcedTransactionNumber,
-    forcedTransactionRollingHash,
-    timestamp
-  ]
+// 6. OPTIONAL: Verify it matches the contract's stored hash
+const expectedHash = keccak256(
+  abiCoder.encode(
+    ["uint256", "bytes32", "uint256", "bytes32", "uint256"],
+    [
+      messageNumber,
+      messageRollingHash,
+      forcedTransactionNumber,
+      forcedTransactionRollingHash,
+      timestamp
+    ]
+  )
 );
-
-const expectedHash = keccak256(encoded);
 
 const storedHash = await lineaRollup.currentFinalizedState();
 

--- a/docs/protocol/how-to/forced-transactions.mdx
+++ b/docs/protocol/how-to/forced-transactions.mdx
@@ -116,6 +116,15 @@ if (expectedHash !== storedHash) {
 }
 ```
 
+:::caution[Retry on stale finalized state]
+
+The rollup may finalize a new batch on L1 between the moment you read `LastFinalizedState` and the moment your
+`submitForcedTransaction` call is included on L1. If that happens, the gateway will revert because the supplied
+state no longer matches `currentFinalizedState`. Be prepared to re-read the latest finalized state and retry the
+submission.
+
+:::
+
 Once you have the correct values, you can construct a forced transaction submission with the following fields:
 The last finalized L2 state on L1:
 

--- a/docs/stack/how-to/forced-transactions.mdx
+++ b/docs/stack/how-to/forced-transactions.mdx
@@ -24,7 +24,8 @@ obligations such as anti-money laundering (AML) and know-your-customer (KYC) req
 2. Deploy the
 [`ForcedTransactionGateway`](https://github.com/Consensys/linea-monorepo/blob/feat/tx-gateway/docs/forced-transactions-architecture.md#1-forcedtransactiongateway)
 contract. It is the user-facing contract that validates and submits forced transactions.
-3. Have the `DEFAULT_ADMIN_ROLE` or access to that administrator.
+3. Have the `DEFAULT_ADMIN_ROLE` on the Linea Rollup contract, or access to the administrator account that can grant
+or configure it.
 
 :::tip
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -337,9 +337,9 @@ const sidebars = {
       label: "Mechanisms",
       collapsible: false,
       items: [
-        "protocol/forced-transactions",
-        "protocol/eip-7702",
         "protocol/tokenomics",
+        "protocol/eip-7702",
+        "protocol/forced-transactions",
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Removed misleading "sequencer is down/uncooperative/bypass the sequencer" framing. Forced transactions do **not** bypass the sequencer — the sequencer still produces blocks and processes them. The feature is a fallback for when the normal L2 RPC submission path is unavailable, unreliable, or censoring.
- Reworked the "Processing vs. execution" section: forced transactions guarantee *processing*, not necessarily inclusion or successful execution. Added a note on outright-rejection cases (e.g. L2 deny-listed addresses, invalid/unsupported precompiles).
- Refactored the `LastFinalizedState` code example: instead of a full-history `queryFilter` scan, read `currentL2BlockNumber()` on-chain and target the matching `FinalizedStateUpdated` event via `getLogs({ topics: [eventTopic, blockNumberTopic] })`. Pattern adapted from [linea-monorepo PR #2284](https://github.com/Consensys/linea-monorepo/pull/2284).
- Added Linea Rollup contract context to the `DEFAULT_ADMIN_ROLE` prerequisite in the stack how-to.

## Files changed

- `docs/protocol/forced-transactions.mdx` — intro, "What are forced transactions?", "Processing vs. execution"
- `docs/protocol/how-to/forced-transactions.mdx` — code example
- `docs/stack/how-to/forced-transactions.mdx` — prerequisite point 3

## Test plan

- [x] Render the three pages locally and visually check formatting (code block highlighting, admonitions, tables).
- [ ] Have Grant verify the technical wording on rejection cases and the fee API.
- [x] Confirm internal links (`../stack/how-to/forced-transactions.mdx`, `../../protocol/forced-transactions.mdx`, etc.) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes, but they update conceptual guarantees and the example query flow, so reviewers should sanity-check technical accuracy.
> 
> **Overview**
> Updates forced transaction docs to **remove “bypass the sequencer” framing** and instead position forced transactions as an L1-backed fallback when the *normal L2 RPC submission path* is unavailable/censoring, with submission explicitly going via `ForcedTransactionGateway`.
> 
> Clarifies guarantees by describing forced transactions as *processing-required* (not necessarily inclusion/success), adding examples of outright rejection cases.
> 
> Refactors the `LastFinalizedState` retrieval example to avoid scanning all `FinalizedStateUpdated` events: it reads `currentL2BlockNumber()`, fetches the matching log via `getLogs` topic filtering, queries rolling hashes in parallel, and adds guidance to retry if `currentFinalizedState` becomes stale. Also tightens the stack enablement prerequisite to specify `DEFAULT_ADMIN_ROLE` on the Linea Rollup contract and reorders the sidebar entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a820fc141d9f99d8a0e6b28dc001e4f3fa868461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->