### PR TITLE
docs: merge Beta v5.2.1 into Beta v5.2 release notes

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -12,12 +12,8 @@ release_toc:
     label: Prover performance optimizations
     mainnet: 4 May 2026 (target)
     sepolia: 27 April 2026
-  beta-v521:
-    label: Pause Cooldown and Dynamic Chain Configuration
-    mainnet: 1 April 2026
-    sepolia: 24 March 2026
   beta-v52:
-    label: Small fields
+    label: Small fields and contract upgrades
     mainnet: 1 April 2026
     sepolia: 24 March 2026
   beta-v51:
@@ -186,19 +182,6 @@ Prover performance optimizations. Proof generation time ~40% faster.
 
 </ChangelogEntry>
 
-## Beta v5.2.1
-
-<ChangelogDate sectionId="beta-v521" />
-
-<ChangelogEntry tag="upgrade">
-
-Upgrades Linea's core rollup, bridge, and messaging contracts and deploys a new verifier to support Pause Cooldown and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 52 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
-
-- **Pause Cooldown.** Adds a new pause mechanism for Linea's core contracts, including an Emergency Pauser account managed by Linea's security operations team. This replaces the previous governance-managed pause process and ensures no non-Security-Council member can pause indefinitely, supporting the user exit window expected for L2Beat Stage 1.
-- **Dynamic Chain Configuration (DCC).** Lets the verifier use chain-specific settings at proof verification time, so each [Linea stack](../stack/index.mdx) network can use its own verifier deployment without requiring a new prover circuit for each chain.
-
-</ChangelogEntry>
-
 <div id="small-fields" className="legacy-anchor" />
 
 ## Beta v5.2
@@ -211,6 +194,15 @@ Upgrades Linea's core rollup, bridge, and messaging contracts and deploys a new 
   ENS resolver contract; you will need to update your configuration to point to the new contract
   address.** More information [on deploying a Linea subdomain](../network/how-to/deploy-subdomain.mdx).
 - Increases throughput to 200 Mgas/s.
+
+</ChangelogEntry>
+
+<ChangelogEntry tag="upgrade">
+
+Upgrades Linea's core rollup, bridge, and messaging contracts and deploys a new verifier to support Pause Cooldown and Dynamic Chain Configuration. Executed via [Security Council nonces 70 (L1) and 52 (L2)](./security-council-record.mdx); see the [audit reports](https://github.com/Consensys/linea-monorepo/blob/main/docs/audits.md#modularization-pause-cooldown-and-dynamic-chain-configuration).
+
+- **Pause Cooldown.** Adds a new pause mechanism for Linea's core contracts, including an Emergency Pauser account managed by Linea's security operations team. This replaces the previous governance-managed pause process and ensures no non-Security-Council member can pause indefinitely, supporting the user exit window expected for L2Beat Stage 1.
+- **Dynamic Chain Configuration (DCC).** Lets the verifier use chain-specific settings at proof verification time, so each [Linea stack](../stack/index.mdx) network can use its own verifier deployment without requiring a new prover circuit for each chain.
 
 </ChangelogEntry>
 


### PR DESCRIPTION
## Summary
- remove the standalone Beta v5.2.1 release note entry
- fold the Pause Cooldown and Dynamic Chain Configuration upgrade notes into Beta v5.2
- update the Beta v5.2 TOC label to reflect the merged scope

## Testing
- checked the page after build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only restructuring of release notes with no product code or behavior changes.
> 
> **Overview**
> Removes the standalone **Beta v5.2.1** entry and folds its contract upgrade details (*Pause Cooldown* and *Dynamic Chain Configuration*) into **Beta v5.2** as a new `upgrade` changelog entry.
> 
> Updates the `release_toc` label for `beta-v52` to reflect the expanded scope (**small fields + contract upgrades**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfebefa03e42d1e074900a41f6d4adef1075ccbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->