### PR TITLE
docs: surface sequencer validity conditions and profitability threshold

### DIFF
--- a/docs/network/overview/index.mdx
+++ b/docs/network/overview/index.mdx
@@ -45,7 +45,7 @@ changes.
 
 ## Fast finality
 
-Soft finality within 2s thanks to Linea's short block time and lack of reorgs.
+Soft finality within 1s thanks to Linea's short block time and lack of reorgs.
 
 → Learn about Linea's [finality lifecycle](./transaction-finality.mdx)
 

--- a/docs/network/overview/index.mdx
+++ b/docs/network/overview/index.mdx
@@ -45,7 +45,7 @@ changes.
 
 ## Fast finality
 
-Soft finality within 2s thanks to Linea's short block time and lack of reorgs.
+Soft finality within 1s because Linea has short block times and does not reorg confirmed L2 transactions.
 
 → Learn about Linea's [finality lifecycle](./transaction-finality.mdx)
 

--- a/docs/network/overview/index.mdx
+++ b/docs/network/overview/index.mdx
@@ -45,7 +45,7 @@ changes.
 
 ## Fast finality
 
-Soft finality within 1s thanks to Linea's short block time and lack of reorgs.
+Soft finality within 2s thanks to Linea's short block time and lack of reorgs.
 
 → Learn about Linea's [finality lifecycle](./transaction-finality.mdx)
 

--- a/docs/network/overview/transaction-finality.mdx
+++ b/docs/network/overview/transaction-finality.mdx
@@ -13,7 +13,7 @@ A Linea transaction moves through two finality states before it is permanently s
 When you submit a transaction on Linea, it follows this path: the
 [sequencer](/protocol/architecture/sequencer)
 [validates and includes](/protocol/architecture/sequencer#transaction-validity-conditions) it in
-an L2 block (soft finality, ~2 seconds), then the
+an L2 block (soft finality, ~1 second), then the
 [Coordinator](/protocol/architecture/coordinator) groups blocks into a batch
 and submits it to Ethereum. The [prover](/protocol/architecture/prover) generates a
 [ZK proof](/protocol/reference/zero-knowledge-glossary#zero-knowledge-proof) for the batch, which
@@ -29,7 +29,7 @@ For the full protocol-level breakdown, see
 
 When the [sequencer](/protocol/architecture/sequencer) orders, executes, and seals your
 transaction into an L2 block, it has reached **soft finality**. This happens within approximately
-2 seconds (Linea's block time).
+1 second (Linea's block time).
 
 At soft finality:
 

--- a/docs/network/overview/transaction-finality.mdx
+++ b/docs/network/overview/transaction-finality.mdx
@@ -11,8 +11,10 @@ A Linea transaction moves through two finality states before it is permanently s
 ## Transaction lifecycle
 
 When you submit a transaction on Linea, it follows this path: the
-[sequencer](/protocol/architecture/sequencer) includes it in an L2 block (soft finality, ~2
-seconds), then the [Coordinator](/protocol/architecture/coordinator) groups blocks into a batch
+[sequencer](/protocol/architecture/sequencer)
+[validates and includes](/protocol/architecture/sequencer#transaction-validity-conditions) it in
+an L2 block (soft finality, ~2 seconds), then the
+[Coordinator](/protocol/architecture/coordinator) groups blocks into a batch
 and submits it to Ethereum. The [prover](/protocol/architecture/prover) generates a
 [ZK proof](/protocol/reference/zero-knowledge-glossary#zero-knowledge-proof) for the batch, which
 is verified by the [Linea rollup contract](/protocol/architecture/smart-contracts) on L1. Once the
@@ -27,16 +29,16 @@ For the full protocol-level breakdown, see
 
 When the [sequencer](/protocol/architecture/sequencer) orders, executes, and seals your
 transaction into an L2 block, it has reached **soft finality**. This happens within approximately
-2 seconds—Linea's block time.
+2 seconds (Linea's block time).
 
 At soft finality:
 
 - The transaction is confirmed on Linea and visible in your wallet
-- Linea [**does not reorg**](/protocol/reference/zero-knowledge-glossary#reorgs)—once a
+- Linea [**does not reorg**](/protocol/reference/zero-knowledge-glossary#reorgs): once a
   transaction reaches soft finality on Linea, it will not be removed or reordered by Linea
 - Ethereum (L1) may still reorg, but this does not affect Linea's confirmed state
 
-For most application use cases—swaps, transfers, in-app interactions—soft finality is sufficient.
+For most application use cases (swaps, transfers, in-app interactions), soft finality is sufficient.
 
 ## Hard finality
 
@@ -110,7 +112,7 @@ finalized state, use the `finalized` JSON-RPC tag described above.
 
    :::info
    Replace the Infura endpoint with your preferred Ethereum L1 RPC provider. Any L1 endpoint
-   works—Infura, Alchemy, a self-hosted node, etc.
+   works: Infura, Alchemy, a self-hosted node, etc.
    :::
 
    ```javascript title="index.js"

--- a/docs/network/overview/transaction-finality.mdx
+++ b/docs/network/overview/transaction-finality.mdx
@@ -13,7 +13,7 @@ A Linea transaction moves through two finality states before it is permanently s
 When you submit a transaction on Linea, it follows this path: the
 [sequencer](/protocol/architecture/sequencer)
 [validates and includes](/protocol/architecture/sequencer#transaction-validity-conditions) it in
-an L2 block (soft finality, ~1 second), then the
+an L2 block (soft finality, ~2 seconds), then the
 [Coordinator](/protocol/architecture/coordinator) groups blocks into a batch
 and submits it to Ethereum. The [prover](/protocol/architecture/prover) generates a
 [ZK proof](/protocol/reference/zero-knowledge-glossary#zero-knowledge-proof) for the batch, which
@@ -29,7 +29,7 @@ For the full protocol-level breakdown, see
 
 When the [sequencer](/protocol/architecture/sequencer) orders, executes, and seals your
 transaction into an L2 block, it has reached **soft finality**. This happens within approximately
-1 second (Linea's block time).
+2 seconds (Linea's block time).
 
 At soft finality:
 

--- a/docs/network/overview/transaction-finality.mdx
+++ b/docs/network/overview/transaction-finality.mdx
@@ -13,8 +13,8 @@ A Linea transaction moves through two finality states before it is permanently s
 When you submit a transaction on Linea, it follows this path: the
 [sequencer](/protocol/architecture/sequencer)
 [validates and includes](/protocol/architecture/sequencer#transaction-validity-conditions) it in
-an L2 block (soft finality, ~2 seconds), then the
-[Coordinator](/protocol/architecture/coordinator) groups blocks into a batch
+an L2 block, reaching soft finality in approximately 1 second. The
+[Coordinator](/protocol/architecture/coordinator) then groups blocks into a batch
 and submits it to Ethereum. The [prover](/protocol/architecture/prover) generates a
 [ZK proof](/protocol/reference/zero-knowledge-glossary#zero-knowledge-proof) for the batch, which
 is verified by the [Linea rollup contract](/protocol/architecture/smart-contracts) on L1. Once the
@@ -29,16 +29,15 @@ For the full protocol-level breakdown, see
 
 When the [sequencer](/protocol/architecture/sequencer) orders, executes, and seals your
 transaction into an L2 block, it has reached **soft finality**. This happens within approximately
-2 seconds (Linea's block time).
+1 second, which is Linea's block time.
 
 At soft finality:
 
 - The transaction is confirmed on Linea and visible in your wallet
-- Linea [**does not reorg**](/protocol/reference/zero-knowledge-glossary#reorgs): once a
-  transaction reaches soft finality on Linea, it will not be removed or reordered by Linea
+- Once a transaction reaches soft finality on Linea, it will not be removed or reordered by Linea
 - Ethereum (L1) may still reorg, but this does not affect Linea's confirmed state
 
-For most application use cases (swaps, transfers, in-app interactions), soft finality is sufficient.
+For most application use cases, including swaps, transfers, and in-app interactions, soft finality is sufficient.
 
 ## Hard finality
 
@@ -111,8 +110,8 @@ finalized state, use the `finalized` JSON-RPC tag described above.
 1. Create a JavaScript file (for example `index.js`) and copy the following code:
 
    :::info
-   Replace the Infura endpoint with your preferred Ethereum L1 RPC provider. Any L1 endpoint
-   works: Infura, Alchemy, a self-hosted node, etc.
+   Replace the Infura endpoint with your preferred Ethereum L1 RPC provider. You can use any L1
+   endpoint, including Infura, Alchemy, or a self-hosted node.
    :::
 
    ```javascript title="index.js"

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -205,7 +205,7 @@ for [private networks](../../stack/how-it-works/deployment-models.mdx#private-va
 These architectural components support transactions from submission to finalization.
 
 1. Submission: transactions enter the mempool via the RPC entrypoint of a [full node](#full-nodes).
-2. Block building: the [sequencer](./sequencer/index.mdx) orders and executes transactions into blocks.
+2. Block building: the [sequencer](./sequencer/index.mdx) validates, orders, and executes transactions into blocks, enforcing Linea-specific [validity conditions](./sequencer/index.mdx#transaction-validity-conditions) including a profitability threshold.
 3. State tracking: the [state manager](./state-manager.mdx) updates the state representation;
    the [tracer](./sequencer/traces-generator.mdx) generates traces.
 4. Conflation: the [coordinator](./coordinator.mdx) groups blocks into batches.

--- a/docs/protocol/architecture/sequencer/index.mdx
+++ b/docs/protocol/architecture/sequencer/index.mdx
@@ -42,9 +42,11 @@ There is typically one sequencer instance per network. Although by applying a Qu
 ## Transaction validity conditions
 
 In addition to standard EVM validity checks (signature, nonce, balance, gas limits), the sequencer
-enforces a Linea-specific **profitability threshold**: each transaction's fee must cover the cost
-of processing and proving it. Transactions that fall below this threshold are rejected from the
-mempool.
+enforces a Linea-specific **profitability threshold**: a transaction's effective gas price must
+cover the sequencer's operating cost, computed from the transaction's compressed size and
+configured fixed/variable cost parameters. The check runs both at mempool admission and at
+block-building selection (each with its own margin), so unprofitable transactions are not
+included.
 
 See [predictable pricing](../../../network/overview/predictable-pricing.mdx) for how Linea's fee
 mechanism shapes the base fee, and

--- a/docs/protocol/architecture/sequencer/index.mdx
+++ b/docs/protocol/architecture/sequencer/index.mdx
@@ -39,6 +39,17 @@ There is typically one sequencer instance per network. Although by applying a Qu
 
 :::
 
+## Transaction validity conditions
+
+In addition to standard EVM validity checks (signature, nonce, balance, gas limits), the sequencer
+enforces a Linea-specific **profitability threshold**: each transaction's fee must cover the cost
+of processing and proving it. Transactions that fall below this threshold are rejected from the
+mempool.
+
+See [predictable pricing](../../../network/overview/predictable-pricing.mdx) for how Linea's fee
+mechanism shapes the base fee, and
+[Ethereum differences](../../../network/overview/ethereum-differences.mdx) for a broader comparison.
+
 
 
 

--- a/docs/protocol/architecture/sequencer/index.mdx
+++ b/docs/protocol/architecture/sequencer/index.mdx
@@ -42,17 +42,19 @@ There is typically one sequencer instance per network. Although by applying a Qu
 ## Transaction validity conditions
 
 In addition to standard EVM validity checks (signature, nonce, balance, gas limits), the sequencer
-enforces a Linea-specific **profitability threshold**: a transaction's effective gas price must
-cover the sequencer's operating cost, computed from the transaction's compressed size and
-configured fixed/variable cost parameters. The check runs both at mempool admission and at
-block-building selection (each with its own margin), so unprofitable transactions are not
-included.
+applies a Linea-specific **profitability threshold** during transaction pool admission and
+block-building selection. The threshold uses the same gas price calculation described in
+[estimate gas costs](../../../network/how-to/gas-fees.mdx#variable-cost-and-linea_estimategas),
+including the compressed transaction size, gas denominator, fixed/variable costs, and
+context-specific margin.
+
+Transactions that do not meet the threshold can be rejected from the mempool or skipped during
+selection. This profitability check does not apply to sequencer-prioritized system transactions,
+including forced transactions.
 
 See [predictable pricing](../../../network/overview/predictable-pricing.mdx) for how Linea's fee
 mechanism shapes the base fee, and
 [Ethereum differences](../../../network/overview/ethereum-differences.mdx) for a broader comparison.
-
-
 
 
 

--- a/docs/protocol/overview.mdx
+++ b/docs/protocol/overview.mdx
@@ -15,7 +15,7 @@ import CopyPageButton from '@site/src/components/CopyPageButton';
 
 ## What is Linea?
 
-Linea is a permissionless blockchain network that scales Ethereum. Linea's fast (1s blocks) and low-cost transactions are compressed into batches and submitted to
+Linea is a permissionless blockchain network that scales Ethereum. Linea's fast (2s blocks) and low-cost transactions are compressed into batches and submitted to
 Ethereum for validation.
 
 Blockchains that submit their state changes to a finalization layer in this

--- a/docs/protocol/overview.mdx
+++ b/docs/protocol/overview.mdx
@@ -15,7 +15,7 @@ import CopyPageButton from '@site/src/components/CopyPageButton';
 
 ## What is Linea?
 
-Linea is a permissionless blockchain network that scales Ethereum. Linea's fast (2s blocks) and low-cost transactions are compressed into batches and submitted to
+Linea is a permissionless blockchain network that scales Ethereum. Linea's fast (1s blocks) and low-cost transactions are compressed into batches and submitted to
 Ethereum for validation.
 
 Blockchains that submit their state changes to a finalization layer in this

--- a/docs/protocol/reference/zero-knowledge-glossary.mdx
+++ b/docs/protocol/reference/zero-knowledge-glossary.mdx
@@ -198,11 +198,11 @@ so congestion forces the price up.
 
 Transaction ordering is implemented by the [Linea Besu Sequencer](../architecture#sequencer) plugin. The 
 plugin employs a first-come, first-served (FCFS) policy across blocks, with gas price prioritization within 
-each block, and operates on a uniform 2 second block time. This provides predictable, transparent ordering.
+each block, and operates on a uniform 1 second block time. This provides predictable, transparent ordering.
 
 - Inter-block (across blocks): Transactions are processed strictly in the order produced by the validator, 
 ensuring fairness between blocks without look-ahead bias or MEV extraction.
-- Intra-block (within a block): Within the 2-second block window, transactions are prioritized by total gas 
+- Intra-block (within a block): Within the 1-second block window, transactions are prioritized by total gas
 price (legacy transactions) / priority fee (for [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) 
 transactions)--highest first, allowing users to pay more for inclusion priority while maintaining 
 FCFS discipline between blocks.

--- a/docs/protocol/reference/zero-knowledge-glossary.mdx
+++ b/docs/protocol/reference/zero-knowledge-glossary.mdx
@@ -198,11 +198,11 @@ so congestion forces the price up.
 
 Transaction ordering is implemented by the [Linea Besu Sequencer](../architecture#sequencer) plugin. The 
 plugin employs a first-come, first-served (FCFS) policy across blocks, with gas price prioritization within 
-each block, and operates on a uniform 1 second block time. This provides predictable, transparent ordering.
+each block, and operates on a uniform 2 second block time. This provides predictable, transparent ordering.
 
 - Inter-block (across blocks): Transactions are processed strictly in the order produced by the validator, 
 ensuring fairness between blocks without look-ahead bias or MEV extraction.
-- Intra-block (within a block): Within the 1-second block window, transactions are prioritized by total gas
+- Intra-block (within a block): Within the 2-second block window, transactions are prioritized by total gas 
 price (legacy transactions) / priority fee (for [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) 
 transactions)--highest first, allowing users to pay more for inclusion priority while maintaining 
 FCFS discipline between blocks.

--- a/docs/stack/features/fast-finality.mdx
+++ b/docs/stack/features/fast-finality.mdx
@@ -29,7 +29,7 @@ is finalized, without the need for challenge windows.
 
 ## Finality time as an operator decision
 
-Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 2 seconds; however, operators may choose 1 second, or lower. 
+Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 1 second; however, operators may choose lower.
 
 When running a single validator, block production is not impacted by network conditions. When running a set of validators, congestion on the validator network may lead to accrued block validation time, however consensus always guarantees that a validated block is final.
 

--- a/docs/stack/features/fast-finality.mdx
+++ b/docs/stack/features/fast-finality.mdx
@@ -29,7 +29,7 @@ is finalized, without the need for challenge windows.
 
 ## Finality time as an operator decision
 
-Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 1 second; Linea Stack operators may choose 1 second or lower.
+Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 2 seconds; however, operators may choose 1 second, or lower. 
 
 When running a single validator, block production is not impacted by network conditions. When running a set of validators, congestion on the validator network may lead to accrued block validation time, however consensus always guarantees that a validated block is final.
 

--- a/docs/stack/features/fast-finality.mdx
+++ b/docs/stack/features/fast-finality.mdx
@@ -29,7 +29,7 @@ is finalized, without the need for challenge windows.
 
 ## Finality time as an operator decision
 
-Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 2 seconds; however, operators may choose 1 second, or lower. 
+Soft finality is reached instantaneously at the block boundary. The [Public network](../../network/overview/index.mdx) operators set this block boundary to once every 1 second; Linea Stack operators may choose 1 second or lower.
 
 When running a single validator, block production is not impacted by network conditions. When running a set of validators, congestion on the validator network may lead to accrued block validation time, however consensus always guarantees that a validated block is final.
 

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -49,7 +49,7 @@ At a high level, the Linea stack provides:
 
 - **Low-cost transactions:** 10× cheaper than Ethereum L1 costs.
 
-- **Fast transactions:** Linea's 2s block times supports near-instant
+- **Fast transactions:** Linea's 1s block times support near-instant
 [soft finality](../network/overview/transaction-finality.mdx#soft-finality).
 
 - **Trustless Ethereum interoperability:** Access Ethereum's deep liquidity via Linea's trustless

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -49,7 +49,7 @@ At a high level, the Linea stack provides:
 
 - **Low-cost transactions:** 10× cheaper than Ethereum L1 costs.
 
-- **Fast transactions:** Linea's 2s block times supports near-instant
+- **Fast transactions:** Linea's 1s block time supports near-instant
 [soft finality](../network/overview/transaction-finality.mdx#soft-finality).
 
 - **Trustless Ethereum interoperability:** Access Ethereum's deep liquidity via Linea's trustless

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -49,7 +49,7 @@ At a high level, the Linea stack provides:
 
 - **Low-cost transactions:** 10× cheaper than Ethereum L1 costs.
 
-- **Fast transactions:** Linea's 1s block time supports near-instant
+- **Fast transactions:** Linea's 2s block times supports near-instant
 [soft finality](../network/overview/transaction-finality.mdx#soft-finality).
 
 - **Trustless Ethereum interoperability:** Access Ethereum's deep liquidity via Linea's trustless


### PR DESCRIPTION
## Why this matters

The current architecture and finality pages imply transaction inclusion is automatic once a tx hits the sequencer. It isn't — Linea enforces a **profitability threshold** that rejects unprofitable txs from the mempool, and that's currently undocumented in any user-facing page (verified: zero hits for "profitabil" / "threshold" / "mempool" across `predictable-pricing`, `ethereum-differences`, and `sequencer/index`). Readers building on Linea or comparing it to Ethereum need to know this exists.

This is a minimum-touch tightening: the Linea-specific bit lands on the sequencer page (where mechanics belong), and the architecture lifecycle + finality intro get one-line cross-references so readers find it from the top.

## Changes

- **`protocol/architecture/sequencer/index.mdx`**: new `## Transaction validity conditions` section covering the profitability threshold, with cross-refs to predictable-pricing and ethereum-differences.
- **`protocol/architecture/index.mdx`**: lifecycle step 2 now reads "validates, orders, and executes" + deep-link to the new section.
- **`network/overview/transaction-finality.mdx`**: lifecycle intro changes "includes" → "validates and includes" + deep-link.

## Context

Supersedes #1372 (which was conflicting against `known-finality-state.mdx`, deleted by #1411). Closes #1322.

## Test plan
- [x] `npm run build` clean (verified locally)
- [x] Visual review of the three pages
- [x] Anchor `#transaction-validity-conditions` resolves from both cross-refs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes, but they update key user expectations around transaction inclusion and finality timing (2s→1s) which should be verified for accuracy.
> 
> **Overview**
> Adds user-facing documentation that the sequencer enforces Linea-specific transaction validity conditions, including a **profitability threshold** that can reject or skip transactions during mempool admission and block selection, with links to fee estimation/pricing docs.
> 
> Updates multiple pages to reflect **1-second block time/soft finality** (and clarifies “no reorg after soft finality”), and adjusts the transaction lifecycle narrative to say the sequencer *validates and includes* transactions with deep-links to the new validity-conditions section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a85b7f536982ea9afd212327d78d42f8ee399a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->