### PR TITLE
docs(stack): add Trust model page

### DIFF
--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -52,12 +52,11 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 
 ## Trust assumptions per deployment model
 
-| Trust dimension | Public rollup (L1 = Ethereum) | Private validium (L2 on Ethereum) | Private validium (L3 on Linea Mainnet) |
+| Trust dimension | Rollup, finalized to Ethereum | Validium, finalized to Ethereum | Validium, finalized to Linea Mainnet |
 | --- | --- | --- | --- |
-| Data availability | Ethereum | Operator-run archive nodes or DA committee | Operator-run archive nodes or DA committee |
-| Finality anchor | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
-| Sequencer trust | Operator can reorder/delay; cannot forge state | Same | Same |
-| Bridge trust | Cryptographic proof + admin key for upgrades/pauses | Same | Adds Linea Mainnet bridge trust on top |
+| Data availability provided by | Ethereum (EIP-4844 blobs) | Operator-run archive nodes or DA committee | Operator-run archive nodes or DA committee |
+| Finalization layer | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
+| Bridge trust to the finalization layer | Canonical bridge: ZK proofs + admin keys for upgrades/pauses | Same as rollup | Canonical bridge to Linea Mainnet (proofs + admin keys), plus Linea Mainnet's own canonical bridge to Ethereum |
 | Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
 | State reconstruction without operator | Yes, from L1 blobs | No, depends on operator-run DA | No, depends on operator-run DA |
 

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -13,34 +13,36 @@ What this page covers: who operates each component, what each component can do u
 
 What this page does not cover: configuration flags, deployment topology, or component internals. For those, see [Core components](./core-components) and [Deployment models](./deployment-models).
 
+In this page, **operator** means the entity or consortium responsible for deploying, administering, and running the network infrastructure, contracts, keys, access controls, and operational procedures for a Linea Stack deployment.
+
 ## Trust assumptions per component
 
 | Component | Operated by | Can do unilaterally | Cannot do | Independently verifiable by participants |
 | --- | --- | --- | --- | --- |
-| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state, since invalid blocks fail proof verification | Block contents and ordering, by running a full or archive node |
+| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state, since invalid blocks fail proof verification | Public rollup block contents and ordering by running a full or archive node; in validium or RBAC deployments, transactions or blocks only to the extent participants have the relevant data and access |
 | Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
-| Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
+| Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to the finalization layer | Modify state independently of the sequencer or prover | Submission events on the finalization layer |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
-| Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via access to the operator's DA layer |
+| Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on the finalization layer | Data and state claims that participants are authorized to access, including checks with [Merkle proofs](/protocol/architecture/state-manager#merkle-trees) against posted state roots |
 | Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts through the proxy upgrade path | In the normal protocol path, process unproved messages, since messages are tied to verified state transitions | Bridge events, proof verification, role assignments, proxy admin, and implementation addresses on the finalization layer |
 | Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | In the normal relayer path, process messages that are not signed over source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer, its keys, and the bridge upgrade/admin model |
 | System contracts | Operator (role holders) + proxy upgrade authority | Pause, change verifier address, change rate limits, and upgrade contracts through the proxy upgrade path | Bypass role gating in the deployed implementation, since privileged functions are role-gated | Role assignments, contract state, proxy admin, and implementation addresses on the finalization layer |
-| Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, by running a node |
+| Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, subject to the deployment's data access model; not every participant in a validium or RBAC deployment necessarily runs a full or archive node |
 
 ## Admin keys and upgrade authority
 
-The Stack contracts ship with a fixed set of roles. Holders are decided by the operator at deploy time. The most consequential decisions:
+The Stack contracts ship with a fixed set of roles. Holders are decided by the operator at deploy time. A governance contract is the high-security onchain control path that can hold privileged roles or proxy admin authority for a deployment. In production-oriented deployments, governance and upgrade authority should sit behind an appropriately secured multisig, governance contract, or timelock, and may involve multiple independent parties.
 
 | Role | What it can do | Recommended holder |
 | --- | --- | --- |
-| `DEFAULT_ADMIN_ROLE` | Grant or revoke AccessControl roles | Multisig or governance contract; initial holder set during initialization |
+| `DEFAULT_ADMIN_ROLE` | Grant or revoke AccessControl roles | High-security multisig or governance contract; initial holder set during initialization |
 | `OPERATOR_ROLE` | Submit blobs/calldata, finalize blocks | Day-to-day operator address |
-| `SECURITY_COUNCIL_ROLE` | Reserved for governance pause/upgrade authority | Governance contract |
+| `SECURITY_COUNCIL_ROLE` | Reserved for governance pause/upgrade authority | High-security governance contract or multisig |
 | `PAUSE_*_ROLE` / `UNPAUSE_*_ROLE` | Pause and unpause specific subsystems (L1↔L2, L2→L1, finalization, state submission, etc.) | Split between operator (pause) and governance (unpause) for fast incident containment |
 | `VERIFIER_SETTER_ROLE` | Change the verifier contract for a given proof type | Governance contract |
 | `RATE_LIMIT_SETTER_ROLE` | Change L2→L1 withdrawal rate limits | Governance contract |
 
-Contracts are upgradeable via the OpenZeppelin Transparent Upgradeable Proxy pattern. Proxy upgrade authority is separate from `DEFAULT_ADMIN_ROLE` and depends on who controls the proxy admin or governance contract for the deployment. Operators should place upgrade authority behind an appropriate multisig, governance contract, or timelock.
+Contracts are upgradeable via the [OpenZeppelin Transparent Upgradeable Proxy pattern](/protocol/architecture/smart-contracts#contract-versioning). Proxy upgrade authority is separate from `DEFAULT_ADMIN_ROLE` and depends on who controls the proxy admin or governance contract for the deployment. Operators should place upgrade authority behind an appropriate multisig, governance contract, or timelock. The [Linea Security Council transaction record](/changelog/security-council-record) shows a public Linea example of multisig-governed security and upgrade operations.
 
 :::warning
 
@@ -58,26 +60,22 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 | Finalization layer | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
 | Bridge trust to the finalization layer | Canonical bridge: ZK proofs, plus admin and upgrade authority for pauses, verifier configuration, and contract upgrades | Same as rollup | Canonical bridge to Linea Mainnet (proofs plus admin and upgrade authority), plus Linea Mainnet's own bridge and governance assumptions |
 | Inherited trust assumptions | Ethereum L1 finality, plus the deployment's sequencer, prover, admin key, verifier configuration, and upgrade-authority assumptions | Ethereum L1 finality, plus the deployment's sequencer, prover, admin key, verifier, upgrade, and DA assumptions | Ethereum L1 + Linea Mainnet finality, plus Linea Mainnet sequencer, prover, Security Council, admin key, verifier, upgrade, and bridge assumptions |
-| State reconstruction without operator | Yes, while L1 blob data is available; long-term reconstruction requires independent archival of EIP-4844 blob data | No, depends on operator-run DA | No, depends on operator-run DA |
+| State reconstruction without operator | Yes, while L1 blob data is available; long-term reconstruction requires independent archival of EIP-4844 blob data | No, depends on operator-run DA and the deployment's data access model | No, depends on operator-run DA and the deployment's data access model |
 
 A private validium on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
 
-[VERIFY] Confirm whether a public L3 on Linea Mainnet deployment should be added to this trust comparison before publishing if that deployment mode is in scope.
-
 ## Failure modes and recovery
 
-| Failure | Participant impact | Recovery path | Status |
-| --- | --- | --- | --- |
-| Sequencer halt | Block production stops; pending transactions not included | Operator restart; distributed sequencing or validator consensus with QBFT where configured | Single-sequencer is the default; multi-sequencer or multi-validator setups are operator-implemented |
-| Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to L1 | Operator restart; alternate prover instance where deployed | Single-prover is the default |
-| Coordinator stall | L1 submission stops; same effect as prover stall downstream | Operator restart; alternate coordinator instance where deployed | Single-coordinator is the default |
-| DA withhold (validium) | Participants cannot reconstruct state independently; new state still verifiable via proof | Operator-defined wind-down procedure; depends on consortium agreement | Operator-defined; not protocol-enforced |
-| Finality layer reorg | Affects depth of L1 finality; ZK proofs once accepted on L1 cannot be reorged without breaking L1 | Wait for L1 finality depth | Inherent to L1 finality model |
-| Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer or equivalent KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via the multi-sig governance contract | Operator-implemented |
-| Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption via unpause role | Live |
-| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | Not yet live; planned |
-
-The default deployment topology assumes single-instance sequencer, prover, and coordinator. QBFT applies to distributed sequencing or validator consensus where configured; prover and coordinator high availability depends on operator-run redundant instances and operational failover.
+| Failure | Participant impact | Recovery path |
+| --- | --- | --- |
+| Sequencer halt | Block production stops; pending transactions not included | Operator restart or failover to redundant sequencer infrastructure. In distributed sequencing or validator consensus deployments, recovery follows the configured QBFT or validator process. |
+| Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to the finalization layer | Operator restart or failover to an alternate prover instance where deployed |
+| Coordinator stall | Submission to the finalization layer stops; same effect as prover stall downstream | Operator restart or failover to an alternate coordinator instance where deployed |
+| DA withhold (validium) | Participants without the required DA or RBAC access cannot reconstruct or verify affected private data | Operator-defined wind-down procedure; depends on consortium agreement and is not protocol-enforced |
+| Finality layer reorg | Affects depth of finality on the selected finalization layer | Wait for the required finality depth on the selected finalization layer |
+| Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Revoke or rotate compromised authority through the deployment's governance or multisig process; use emergency pause roles where available |
+| Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption depends on the corresponding unpause role |
+| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer where forced transactions are enabled | L1-submitted forced transactions, gated by `AddressFilter` when configured |
 
 ## What participants can independently verify
 
@@ -85,23 +83,25 @@ The set of guarantees a participant can verify *without* trusting the operator d
 
 **Public rollup on Ethereum**
 
+- Proof validity and state-transition correctness, by reading the verifier contract on L1. A valid proof means the operator cannot finalize an invalid state transition through the normal proof path.
 - Full transaction history while L1 blobs are retained, by reading L1 blobs and reconstructing L2 state. After EIP-4844 blob expiry, long-term reconstruction depends on independent archival of blob data.
-- Proof validity, by reading the verifier contract on L1.
 - Bridge events and message status, on L1.
 - Contract role assignments and admin actions, on L1.
 
 **Private validium on Ethereum**
 
-- Proof validity, by reading the verifier contract on L1.
-- That a state transition was proved, even if its contents are private.
+- Proof validity and state-transition correctness, by reading the verifier contract on L1. A valid proof means the operator cannot finalize an invalid state transition through the normal proof path.
+- That a state transition was proved, even if its transaction contents are private.
+- Transactions or blocks they are authorized to access, using the relevant data and [Merkle proofs](/protocol/architecture/state-manager#merkle-trees) against posted state roots. This does not by itself establish global transaction ordering for participants who do not have access to the full ordered data set.
 - Bridge events on L1.
-- Their own observed state, by running a node with access to the operator's DA layer.
-- They cannot reconstruct state without access to the operator's DA layer. This is the validium trade-off.
+- Their own observed state, by running a node or using an authorized interface where the deployment grants access.
+- They cannot reconstruct full state or history without the required operator DA access. This is the validium trade-off, and RBAC settings may further limit which data each participant can observe.
 
 **Private validium on Linea Mainnet**
 
-- Same as private validium on Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
-- Verifying the L3 chain end-to-end requires verifying both the L3 proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
+- Proof validity and state-transition correctness, by reading the verifier contract on Linea Mainnet. A valid proof means the operator cannot finalize an invalid state transition through the normal proof path.
+- Same validium and RBAC caveats as private validium on Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
+- Verifying the chain end-to-end requires verifying both the private validium proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
 
 ## See also
 
@@ -110,3 +110,5 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - [Deployment models](./deployment-models)
 - [Security](/stack/features/security)
 - [LineaRollup contracts reference](/network/build/contracts)
+- [Merkle trees](/protocol/architecture/state-manager#merkle-trees)
+- [Linea Security Council transaction record](/changelog/security-council-record)

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -1,0 +1,108 @@
+---
+title: Trust model
+description: >-
+  Trust assumptions, control responsibilities, and failure modes for Linea stack
+  deployments
+sidebar_position: 3
+image: /img/socialCards/trust-model.jpg
+---
+
+This page describes the trust assumptions, control responsibilities, and failure modes of a Linea Stack deployment. It is meant for architects and operators evaluating Linea Stack before deployment.
+
+What this page covers: who operates each component, what each component can do unilaterally, what participants can independently verify, what happens when something fails, and how trust assumptions change across deployment models.
+
+What this page does not cover: configuration flags, deployment topology, or component internals. For those, see [Core components](./core-components) and [Deployment models](./deployment-models).
+
+## Trust assumptions per component
+
+| Component | Operated by | Can do unilaterally | Cannot do | Independently verifiable by participants |
+| --- | --- | --- | --- | --- |
+| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state. Invalid blocks fail proof verification | Block contents and ordering, by running a full or archive node |
+| Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
+| Coordinator | Operator | Stall the conflation, prover, submission pipeline | Modify state independently of the sequencer or prover | L1 submission events |
+| Data availability (rollup) | Ethereum | (none) | Withhold data: DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
+| Data availability (validium) | DA committee chosen by operator | Withhold data, halting recovery | Forge state: proofs still verify on L1 | What participants observe via DA committee access |
+| Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages: both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
+| Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages: relayer signs over verified source-chain events | Bridge events on each side; no shared proof. Depends on trust in the relayer |
+| System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating: every privileged function is role-gated | Role assignments and contract state on the finalization layer |
+| Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, by running a node |
+
+## Admin keys and upgrade authority
+
+The Stack contracts ship with a fixed set of roles. Holders are decided by the operator at deploy time. The most consequential decisions:
+
+| Role | What it can do | Recommended holder |
+| --- | --- | --- |
+| `DEFAULT_ADMIN_ROLE` | Grant or revoke any other role | Multisig or governance contract; assignable only at initialization |
+| `OPERATOR_ROLE` | Submit blobs/calldata, finalize blocks | Day-to-day operator address |
+| `SECURITY_COUNCIL_ROLE` | Reserved for governance pause/upgrade authority | Governance contract |
+| `PAUSE_*_ROLE` / `UNPAUSE_*_ROLE` | Pause and unpause specific subsystems (L1↔L2, L2→L1, finalization, state submission, etc.) | Split between operator (pause) and governance (unpause) for fast incident containment |
+| `VERIFIER_SETTER_ROLE` | Change the verifier contract for a given proof type | Governance contract |
+| `RATE_LIMIT_SETTER_ROLE` | Change L2→L1 withdrawal rate limits | Governance contract |
+
+Contracts are upgradeable via the OpenZeppelin upgradeable proxy pattern. Upgrade authority is held by `DEFAULT_ADMIN_ROLE`. There is no protocol-enforced timelock: operators must implement timelocks via the governance contract holding the role.
+
+:::warning
+`DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`. It is set only via the explicit `defaultAdmin` initializer field. Plan the holder before initialization.
+:::
+
+For the full list of roles, see [LineaRollup contracts reference](/network/build/contracts).
+
+## Trust assumptions per deployment model
+
+| Trust dimension | Public rollup (L1=Ethereum) | Private validium (L2 on Ethereum) | Private validium (L3 on Linea Mainnet) |
+| --- | --- | --- | --- |
+| Data availability | Ethereum | Operator-run DA committee | Operator-run DA committee |
+| Finality anchor | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
+| Sequencer trust | Operator can reorder/delay; cannot forge state | Same | Same |
+| Bridge trust | Cryptographic proof + admin key for upgrades/pauses | Same | Adds Linea Mainnet bridge trust on top |
+| Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
+| State reconstruction without operator | Yes, from L1 blobs | No: depends on DA committee | No: depends on DA committee |
+
+A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
+
+## Failure modes and recovery
+
+| Failure | Participant impact | Recovery path | Status |
+| --- | --- | --- | --- |
+| Sequencer halt | Block production stops; pending transactions not included | Operator restart; multi-sequencer setups via distributed sequencing (QBFT) | Single-sequencer is the default; multi-sequencer is operator-implemented |
+| Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to L1 | Operator restart; alternate prover instance | Single-prover is the default |
+| Coordinator stall | L1 submission stops; same effect as prover stall downstream | Operator restart | Single-coordinator is the default |
+| DA withhold (validium) | Participants cannot reconstruct state independently; new state still verifiable via proof | Operator-defined wind-down procedure; depends on consortium agreement | Operator-defined; not protocol-enforced |
+| Finality layer reorg | Affects depth of L1 finality; ZK proofs once accepted on L1 cannot be reorged without breaking L1 | Wait for L1 finality depth | Inherent to L1 finality model |
+| Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer/KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via Multi-Sig Governance Contract | Operator-implemented |
+| Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption via unpause role | Live |
+| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | **Not yet live**; planned |
+
+The default deployment topology assumes single-instance sequencer, prover, and coordinator. For high availability, operators run multi-instance setups via the Fleet plugin (documented separately).
+
+## What participants can independently verify
+
+The set of guarantees a participant can verify *without* trusting the operator depends on the deployment model.
+
+**Public rollup**
+
+- Full transaction history, by reading L1 blobs and reconstructing L2 state.
+- Proof validity, by reading the verifier contract on L1.
+- Bridge events and message status, on L1.
+- Contract role assignments and admin actions, on L1.
+
+**Private validium (L2 on Ethereum)**
+
+- Proof validity, by reading the verifier contract on L1.
+- That a state transition was proved, even if its contents are private.
+- Bridge events on L1.
+- Their own observed state, by running a node with DA committee access.
+- They cannot reconstruct state without DA committee access. This is the validium trade-off.
+
+**Private validium (L3 on Linea Mainnet)**
+
+- Same as private validium on L2, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
+- Verifying the L3 chain end-to-end requires verifying both the L3 proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
+
+## See also
+
+- [Linea Mainnet risk disclosures](/network/risk-disclosures): applies when finalizing to Linea Mainnet
+- [Core components](./core-components)
+- [Deployment models](./deployment-models)
+- [LineaRollup contracts reference](/network/build/contracts)

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -21,7 +21,7 @@ What this page does not cover: configuration flags, deployment topology, or comp
 | Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
 | Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
-| Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via DA committee access |
+| Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via access to the operator's DA layer |
 | Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages, since both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
 | Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages, since the relayer signs over verified source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer |
 | System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating, since every privileged function is role-gated | Role assignments and contract state on the finalization layer |
@@ -60,7 +60,7 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 | Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
 | State reconstruction without operator | Yes, from L1 blobs | No, depends on operator-run DA | No, depends on operator-run DA |
 
-A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
+A validium finalized to Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
 
 ## Failure modes and recovery
 
@@ -81,14 +81,14 @@ The default deployment topology assumes single-instance sequencer, prover, and c
 
 The set of guarantees a participant can verify *without* trusting the operator depends on the deployment model.
 
-**Public rollup**
+**Rollup, finalized to Ethereum**
 
 - Full transaction history, by reading L1 blobs and reconstructing L2 state.
 - Proof validity, by reading the verifier contract on L1.
 - Bridge events and message status, on L1.
 - Contract role assignments and admin actions, on L1.
 
-**Private validium (L2 on Ethereum)**
+**Validium, finalized to Ethereum**
 
 - Proof validity, by reading the verifier contract on L1.
 - That a state transition was proved, even if its contents are private.
@@ -96,9 +96,9 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - Their own observed state, by running a node with access to the operator's DA layer.
 - They cannot reconstruct state without access to the operator's DA layer. This is the validium trade-off.
 
-**Private validium (L3 on Linea Mainnet)**
+**Validium, finalized to Linea Mainnet**
 
-- Same as private validium on L2, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
+- Same as validium finalized to Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
 - Verifying the L3 chain end-to-end requires verifying both the L3 proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
 
 ## See also

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -22,9 +22,9 @@ What this page does not cover: configuration flags, deployment topology, or comp
 | Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
 | Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via access to the operator's DA layer |
-| Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages, since both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
-| Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages, since the relayer signs over verified source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer |
-| System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating, since every privileged function is role-gated | Role assignments and contract state on the finalization layer |
+| Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts through the proxy upgrade path | In the normal protocol path, process unproved messages, since messages are tied to verified state transitions | Bridge events, proof verification, role assignments, proxy admin, and implementation addresses on the finalization layer |
+| Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | In the normal relayer path, process messages that are not signed over source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer, its keys, and the bridge upgrade/admin model |
+| System contracts | Operator (role holders) + proxy upgrade authority | Pause, change verifier address, change rate limits, and upgrade contracts through the proxy upgrade path | Bypass role gating in the deployed implementation, since privileged functions are role-gated | Role assignments, contract state, proxy admin, and implementation addresses on the finalization layer |
 | Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, by running a node |
 
 ## Admin keys and upgrade authority
@@ -33,18 +33,18 @@ The Stack contracts ship with a fixed set of roles. Holders are decided by the o
 
 | Role | What it can do | Recommended holder |
 | --- | --- | --- |
-| `DEFAULT_ADMIN_ROLE` | Grant or revoke any other role | Multisig or governance contract; assignable only at initialization |
+| `DEFAULT_ADMIN_ROLE` | Grant or revoke AccessControl roles | Multisig or governance contract; initial holder set during initialization |
 | `OPERATOR_ROLE` | Submit blobs/calldata, finalize blocks | Day-to-day operator address |
 | `SECURITY_COUNCIL_ROLE` | Reserved for governance pause/upgrade authority | Governance contract |
 | `PAUSE_*_ROLE` / `UNPAUSE_*_ROLE` | Pause and unpause specific subsystems (L1↔L2, L2→L1, finalization, state submission, etc.) | Split between operator (pause) and governance (unpause) for fast incident containment |
 | `VERIFIER_SETTER_ROLE` | Change the verifier contract for a given proof type | Governance contract |
 | `RATE_LIMIT_SETTER_ROLE` | Change L2→L1 withdrawal rate limits | Governance contract |
 
-Contracts are upgradeable via the OpenZeppelin upgradeable proxy pattern. Upgrade authority is held by `DEFAULT_ADMIN_ROLE`. There is no protocol-enforced timelock: operators must implement timelocks via the governance contract holding the role.
+Contracts are upgradeable via the OpenZeppelin Transparent Upgradeable Proxy pattern. Proxy upgrade authority is separate from `DEFAULT_ADMIN_ROLE` and depends on who controls the proxy admin or governance contract for the deployment. Operators should place upgrade authority behind an appropriate multisig, governance contract, or timelock.
 
 :::warning
 
-`DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`. It is set only via the explicit `defaultAdmin` initializer field. Plan the holder before initialization.
+`DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`. The initial holder is set via the explicit `defaultAdmin` initializer field. Plan the initial holder before initialization.
 
 :::
 
@@ -56,26 +56,28 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 | --- | --- | --- | --- |
 | Data availability provided by | Ethereum (EIP-4844 blobs) | Operator-run archive nodes or DA committee | Operator-run archive nodes or DA committee |
 | Finalization layer | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
-| Bridge trust to the finalization layer | Canonical bridge: ZK proofs + admin keys for upgrades/pauses | Same as rollup | Canonical bridge to Linea Mainnet (proofs + admin keys), plus Linea Mainnet's own canonical bridge to Ethereum |
-| Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
-| State reconstruction without operator | Yes, from L1 blobs | No, depends on operator-run DA | No, depends on operator-run DA |
+| Bridge trust to the finalization layer | Canonical bridge: ZK proofs, plus admin and upgrade authority for pauses, verifier configuration, and contract upgrades | Same as rollup | Canonical bridge to Linea Mainnet (proofs plus admin and upgrade authority), plus Linea Mainnet's own bridge and governance assumptions |
+| Inherited trust assumptions | Ethereum L1 finality, plus the deployment's sequencer, prover, admin key, verifier configuration, and upgrade-authority assumptions | Ethereum L1 finality, plus the deployment's sequencer, prover, admin key, verifier, upgrade, and DA assumptions | Ethereum L1 + Linea Mainnet finality, plus Linea Mainnet sequencer, prover, Security Council, admin key, verifier, upgrade, and bridge assumptions |
+| State reconstruction without operator | Yes, while L1 blob data is available; long-term reconstruction requires independent archival of EIP-4844 blob data | No, depends on operator-run DA | No, depends on operator-run DA |
 
 A private validium on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
+
+[VERIFY] Confirm whether a public L3 on Linea Mainnet deployment should be added to this trust comparison before publishing if that deployment mode is in scope.
 
 ## Failure modes and recovery
 
 | Failure | Participant impact | Recovery path | Status |
 | --- | --- | --- | --- |
-| Sequencer halt | Block production stops; pending transactions not included | Operator restart; multi-sequencer setups via distributed sequencing (QBFT) | Single-sequencer is the default; multi-sequencer is operator-implemented |
-| Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to L1 | Operator restart; alternate prover instance | Single-prover is the default |
-| Coordinator stall | L1 submission stops; same effect as prover stall downstream | Operator restart | Single-coordinator is the default |
+| Sequencer halt | Block production stops; pending transactions not included | Operator restart; distributed sequencing or validator consensus with QBFT where configured | Single-sequencer is the default; multi-sequencer or multi-validator setups are operator-implemented |
+| Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to L1 | Operator restart; alternate prover instance where deployed | Single-prover is the default |
+| Coordinator stall | L1 submission stops; same effect as prover stall downstream | Operator restart; alternate coordinator instance where deployed | Single-coordinator is the default |
 | DA withhold (validium) | Participants cannot reconstruct state independently; new state still verifiable via proof | Operator-defined wind-down procedure; depends on consortium agreement | Operator-defined; not protocol-enforced |
 | Finality layer reorg | Affects depth of L1 finality; ZK proofs once accepted on L1 cannot be reorged without breaking L1 | Wait for L1 finality depth | Inherent to L1 finality model |
 | Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer or equivalent KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via the multi-sig governance contract | Operator-implemented |
 | Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption via unpause role | Live |
 | Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | Not yet live; planned |
 
-The default deployment topology assumes single-instance sequencer, prover, and coordinator. For high availability, operators run multi-instance setups via distributed sequencing (QBFT).
+The default deployment topology assumes single-instance sequencer, prover, and coordinator. QBFT applies to distributed sequencing or validator consensus where configured; prover and coordinator high availability depends on operator-run redundant instances and operational failover.
 
 ## What participants can independently verify
 
@@ -83,7 +85,7 @@ The set of guarantees a participant can verify *without* trusting the operator d
 
 **Public rollup on Ethereum**
 
-- Full transaction history, by reading L1 blobs and reconstructing L2 state.
+- Full transaction history while L1 blobs are retained, by reading L1 blobs and reconstructing L2 state. After EIP-4844 blob expiry, long-term reconstruction depends on independent archival of blob data.
 - Proof validity, by reading the verifier contract on L1.
 - Bridge events and message status, on L1.
 - Contract role assignments and admin actions, on L1.

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -22,9 +22,9 @@ What this page does not cover: configuration flags, deployment topology, or comp
 | Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
 | Data availability (validium) | DA committee chosen by operator | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via DA committee access |
-| Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages: both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
+| Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages, since both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
 | Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages, since the relayer signs over verified source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer |
-| System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating: every privileged function is role-gated | Role assignments and contract state on the finalization layer |
+| System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating, since every privileged function is role-gated | Role assignments and contract state on the finalization layer |
 | Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, by running a node |
 
 ## Admin keys and upgrade authority
@@ -59,7 +59,7 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 | Sequencer trust | Operator can reorder/delay; cannot forge state | Same | Same |
 | Bridge trust | Cryptographic proof + admin key for upgrades/pauses | Same | Adds Linea Mainnet bridge trust on top |
 | Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
-| State reconstruction without operator | Yes, from L1 blobs | No: depends on DA committee | No: depends on DA committee |
+| State reconstruction without operator | Yes, from L1 blobs | No, depends on DA committee | No, depends on DA committee |
 
 A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
 

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -17,13 +17,13 @@ What this page does not cover: configuration flags, deployment topology, or comp
 
 | Component | Operated by | Can do unilaterally | Cannot do | Independently verifiable by participants |
 | --- | --- | --- | --- | --- |
-| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state. Invalid blocks fail proof verification | Block contents and ordering, by running a full or archive node |
+| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state, since invalid blocks fail proof verification | Block contents and ordering, by running a full or archive node |
 | Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
-| Coordinator | Operator | Stall the conflation, prover, submission pipeline | Modify state independently of the sequencer or prover | L1 submission events |
-| Data availability (rollup) | Ethereum | (none) | Withhold data: DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
-| Data availability (validium) | DA committee chosen by operator | Withhold data, halting recovery | Forge state: proofs still verify on L1 | What participants observe via DA committee access |
+| Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
+| Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
+| Data availability (validium) | DA committee chosen by operator | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via DA committee access |
 | Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages: both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
-| Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages: relayer signs over verified source-chain events | Bridge events on each side; no shared proof. Depends on trust in the relayer |
+| Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages, since the relayer signs over verified source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer |
 | System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating: every privileged function is role-gated | Role assignments and contract state on the finalization layer |
 | Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, by running a node |
 
@@ -43,7 +43,9 @@ The Stack contracts ship with a fixed set of roles. Holders are decided by the o
 Contracts are upgradeable via the OpenZeppelin upgradeable proxy pattern. Upgrade authority is held by `DEFAULT_ADMIN_ROLE`. There is no protocol-enforced timelock: operators must implement timelocks via the governance contract holding the role.
 
 :::warning
+
 `DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`. It is set only via the explicit `defaultAdmin` initializer field. Plan the holder before initialization.
+
 :::
 
 For the full list of roles, see [LineaRollup contracts reference](/network/build/contracts).
@@ -72,9 +74,9 @@ A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trus
 | Finality layer reorg | Affects depth of L1 finality; ZK proofs once accepted on L1 cannot be reorged without breaking L1 | Wait for L1 finality depth | Inherent to L1 finality model |
 | Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer/KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via Multi-Sig Governance Contract | Operator-implemented |
 | Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption via unpause role | Live |
-| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | **Not yet live**; planned |
+| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | Not yet live; planned |
 
-The default deployment topology assumes single-instance sequencer, prover, and coordinator. For high availability, operators run multi-instance setups via the Fleet plugin (documented separately).
+The default deployment topology assumes single-instance sequencer, prover, and coordinator. For high availability, operators run multi-instance setups via distributed sequencing (QBFT).
 
 ## What participants can independently verify
 

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -74,8 +74,6 @@ A private validium on Linea Mainnet inherits Linea Mainnet's trust assumptions i
 | DA withhold (validium) | Participants without the required DA or RBAC access cannot reconstruct or verify affected private data | Operator-defined wind-down procedure; depends on consortium agreement and is not protocol-enforced |
 | Finality layer reorg | Affects depth of finality on the selected finalization layer | Wait for the required finality depth on the selected finalization layer |
 | Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Revoke or rotate compromised authority through the deployment's governance or multisig process; use emergency pause roles where available |
-| Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption depends on the corresponding unpause role |
-| Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer where forced transactions are enabled | L1-submitted forced transactions, gated by `AddressFilter` when configured |
 
 ## What participants can independently verify
 

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -52,7 +52,7 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 
 ## Trust assumptions per deployment model
 
-| Trust dimension | Rollup, finalized to Ethereum | Validium, finalized to Ethereum | Validium, finalized to Linea Mainnet |
+| Trust dimension | Public rollup on Ethereum | Private validium on Ethereum | Private validium on Linea Mainnet |
 | --- | --- | --- | --- |
 | Data availability provided by | Ethereum (EIP-4844 blobs) | Operator-run archive nodes or DA committee | Operator-run archive nodes or DA committee |
 | Finalization layer | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
@@ -60,7 +60,7 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 | Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
 | State reconstruction without operator | Yes, from L1 blobs | No, depends on operator-run DA | No, depends on operator-run DA |
 
-A validium finalized to Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
+A private validium on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
 
 ## Failure modes and recovery
 
@@ -81,14 +81,14 @@ The default deployment topology assumes single-instance sequencer, prover, and c
 
 The set of guarantees a participant can verify *without* trusting the operator depends on the deployment model.
 
-**Rollup, finalized to Ethereum**
+**Public rollup on Ethereum**
 
 - Full transaction history, by reading L1 blobs and reconstructing L2 state.
 - Proof validity, by reading the verifier contract on L1.
 - Bridge events and message status, on L1.
 - Contract role assignments and admin actions, on L1.
 
-**Validium, finalized to Ethereum**
+**Private validium on Ethereum**
 
 - Proof validity, by reading the verifier contract on L1.
 - That a state transition was proved, even if its contents are private.
@@ -96,9 +96,9 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - Their own observed state, by running a node with access to the operator's DA layer.
 - They cannot reconstruct state without access to the operator's DA layer. This is the validium trade-off.
 
-**Validium, finalized to Linea Mainnet**
+**Private validium on Linea Mainnet**
 
-- Same as validium finalized to Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
+- Same as private validium on Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
 - Verifying the L3 chain end-to-end requires verifying both the L3 proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
 
 ## See also

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -21,7 +21,7 @@ What this page does not cover: configuration flags, deployment topology, or comp
 | Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
 | Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to L1 | Modify state independently of the sequencer or prover | L1 submission events |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
-| Data availability (validium) | DA committee chosen by operator | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via DA committee access |
+| Data availability (validium) | Operator-run archive nodes or DA committee | Withhold data, halting recovery | Forge state, since proofs still verify on L1 | What participants observe via DA committee access |
 | Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts | Forge messages, since both sides verify ZK proofs | Bridge events and proof verification on the finalization layer |
 | Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | Forge messages, since the relayer signs over verified source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer |
 | System contracts | Operator (role holders) | Pause, upgrade, change verifier address, change rate limits | Bypass role gating, since every privileged function is role-gated | Role assignments and contract state on the finalization layer |
@@ -52,14 +52,14 @@ For the full list of roles, see [LineaRollup contracts reference](/network/build
 
 ## Trust assumptions per deployment model
 
-| Trust dimension | Public rollup (L1=Ethereum) | Private validium (L2 on Ethereum) | Private validium (L3 on Linea Mainnet) |
+| Trust dimension | Public rollup (L1 = Ethereum) | Private validium (L2 on Ethereum) | Private validium (L3 on Linea Mainnet) |
 | --- | --- | --- | --- |
-| Data availability | Ethereum | Operator-run DA committee | Operator-run DA committee |
+| Data availability | Ethereum | Operator-run archive nodes or DA committee | Operator-run archive nodes or DA committee |
 | Finality anchor | Ethereum | Ethereum | Linea Mainnet (which itself anchors to Ethereum) |
 | Sequencer trust | Operator can reorder/delay; cannot forge state | Same | Same |
 | Bridge trust | Cryptographic proof + admin key for upgrades/pauses | Same | Adds Linea Mainnet bridge trust on top |
 | Inherited trust assumptions | Ethereum L1 only | Ethereum L1 only | Ethereum L1 + Linea Mainnet (sequencer, prover, Security Council, admin keys) |
-| State reconstruction without operator | Yes, from L1 blobs | No, depends on DA committee | No, depends on DA committee |
+| State reconstruction without operator | Yes, from L1 blobs | No, depends on operator-run DA | No, depends on operator-run DA |
 
 A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trust assumptions in addition to its own. See [Linea Mainnet risk disclosures](/network/risk-disclosures) for those.
 
@@ -72,7 +72,7 @@ A private validium deployed as L3 on Linea Mainnet inherits Linea Mainnet's trus
 | Coordinator stall | L1 submission stops; same effect as prover stall downstream | Operator restart | Single-coordinator is the default |
 | DA withhold (validium) | Participants cannot reconstruct state independently; new state still verifiable via proof | Operator-defined wind-down procedure; depends on consortium agreement | Operator-defined; not protocol-enforced |
 | Finality layer reorg | Affects depth of L1 finality; ZK proofs once accepted on L1 cannot be reorged without breaking L1 | Wait for L1 finality depth | Inherent to L1 finality model |
-| Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer/KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via Multi-Sig Governance Contract | Operator-implemented |
+| Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Multi-sig key revocation via Web3Signer or equivalent KMS; emergency pause via `PAUSE_ALL_ROLE`; contract pause via the multi-sig governance contract | Operator-implemented |
 | Bridge halt | Cross-chain transfers stop | Pause roles can halt bridging; resumption via unpause role | Live |
 | Forced transaction (escape hatch) | Allows participants to bypass a censoring sequencer | L1-submitted forced transactions, gated by `AddressFilter` | Not yet live; planned |
 
@@ -94,8 +94,8 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - Proof validity, by reading the verifier contract on L1.
 - That a state transition was proved, even if its contents are private.
 - Bridge events on L1.
-- Their own observed state, by running a node with DA committee access.
-- They cannot reconstruct state without DA committee access. This is the validium trade-off.
+- Their own observed state, by running a node with access to the operator's DA layer.
+- They cannot reconstruct state without access to the operator's DA layer. This is the validium trade-off.
 
 **Private validium (L3 on Linea Mainnet)**
 
@@ -107,4 +107,5 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - [Linea Mainnet risk disclosures](/network/risk-disclosures): applies when finalizing to Linea Mainnet
 - [Core components](./core-components)
 - [Deployment models](./deployment-models)
+- [Security](/stack/features/security)
 - [LineaRollup contracts reference](/network/build/contracts)

--- a/sidebars.js
+++ b/sidebars.js
@@ -467,6 +467,7 @@ const sidebars = {
           label: "Protocol components",
         },
         "stack/how-it-works/deployment-models",
+        "stack/how-it-works/trust-model",
         "stack/how-it-works/data-availability-finalization",
       ],
     },


### PR DESCRIPTION
## Summary
New page: Trust model for the Stack tab. Source: see notion.

## What this covers
- Trust assumptions per component
- Admin keys and upgrade authority
- Trust assumptions per deployment model
- Failure modes and recovery
- What participants can independently verify

## Cross-checked against linea-monorepo

### ✅ Verified
- **Role names exist as declared in the contracts.** `OPERATOR_ROLE`, `SECURITY_COUNCIL_ROLE`, `VERIFIER_SETTER_ROLE`, `RATE_LIMIT_SETTER_ROLE` are declared as `bytes32 public constant` in `contracts/src/`. `DEFAULT_ADMIN_ROLE` comes from OZ `AccessControlUpgradeable` (it is `bytes32(0)`), so no local declaration is expected. The `PAUSE_*_ROLE` / `UNPAUSE_*_ROLE` family is declared in `contracts/src/security/pausing/`.
- **`DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`.** Confirmed in `contracts/src/security/access/PermissionsManager.sol:24-26`: the initializer reverts with `ZeroHashNotAllowed()` when role is `0x0`. The explicit assignment is in `LineaRollupBase.sol:117-121` via `_grantRole(DEFAULT_ADMIN_ROLE, _initializationData.defaultAdmin)`, with an in-code comment stating the permissions init purposefully does not allow it.
- **Forced transactions disabled by default in coordinator config.** `config/coordinator/coordinator-config-v2.toml:257` has `disabled = true` under `[forced-transactions]`.
- **OpenZeppelin upgradeable proxy pattern.** All upgradeable contracts inherit from `@openzeppelin/contracts-upgradeable`; deployment uses `upgrades.deployProxy` (transparent proxy + ProxyAdmin) per `contracts/deploy/*.ts`.

### ⚠️ Verification flags

1. **`AddressFilter` wiring is on a feature branch, not main.** The `ForcedTransactionGateway` contract that uses `IAddressFilter` lives on `origin/feat/tx-gateway` and related branches; it is not yet on `main` in `linea-monorepo`. The published `contracts/abi/LineaRollupV8.0.abi` references `addressFilter`, suggesting it is part of the v8.0 deployment artifact set. The page already states forced transactions are **Not yet live; planned**, which is consistent. Flagging for visibility.
2. **A `TimeLock` governance contract exists in the repo.** `contracts/src/governance/TimeLock.sol` wraps OZ `TimelockController`, and `contracts/deploy/02_deploy_Timelock.ts` deploys it. The page's claim that "there is no protocol-enforced timelock" remains accurate (the rollup proxy itself has no timelock check; the timelock is an *operator-implemented* governance contract that holds `DEFAULT_ADMIN_ROLE`), but you may want to mention the in-repo helper for completeness in a future revision.

### 🔗 Link adjustments

- The plan called for `/protocol/contracts` for the LineaRollup contracts reference, but that path does not exist on `main`. The canonical slug is `/network/build/contracts`. Used that instead. Build passes.
- The Notion draft linked distributed sequencing to a Vercel preview URL. The production page `docs/stack/how-to/distributed-sequencing.mdx` exists only on `origin/maru-multi-validator`, not on `main`. With `onBrokenLinks: "throw"` in `docusaurus.config.js`, linking would break the build, so the failure-modes table mentions "distributed sequencing (QBFT)" as plain text. Re-link once the page lands on `main`.

## Build
`yarn build` passes locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds documentation content and a sidebar entry, with no runtime or contract changes. Main risk is potential broken links or inaccurate operational/security guidance.
> 
> **Overview**
> Adds a new `stack/how-it-works/trust-model` doc describing **trust assumptions, admin/upgrade roles, deployment-model differences, failure modes, and participant-verifiability** for Linea Stack deployments.
> 
> Updates `sidebars.js` to include the new page under *Stack → How it works*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578a94ca9df9a77857c5f3fb845dedcd2b2a050a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->