### PR TITLE
docs: update beta delivery dates

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -6,12 +6,12 @@ image: /img/socialCards/release-notes.jpg
 release_toc:
   beta-v54:
     label: Finality under 30min
-    mainnet: 5 May 2026 (target)
-    sepolia: 29 April 2026
+    mainnet: May 2026 (target)
+    sepolia: mid-May 2026
   beta-v53:
     label: Prover performance optimizations
-    mainnet: 4 May 2026 (target)
-    sepolia: 27 April 2026
+    mainnet: May 2026 (target)
+    sepolia: mid-May 2026
   beta-v52:
     label: Small fields and contract upgrades
     mainnet: 1 April 2026


### PR DESCRIPTION
## Summary
- update beta v5.3 and v5.4 delivery dates in release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates planned release timelines; no code or behavior changes.
> 
> **Overview**
> Updates the `release_toc` in `docs/changelog/release-notes.mdx` to revise the planned Mainnet and Sepolia delivery dates for **Beta v5.4** and **Beta v5.3** (switching from specific late-April/early-May dates to broader *May 2026* / *mid-May 2026* targets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fabfc86b768b7cf32fd45693a2615ede5487adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->