### PR TITLE
feat(seo+geo): foundational AI search visibility (llms.txt, sameAs, security headers, robots.txt)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -561,8 +561,16 @@ const config = {
       {
         "@context": "https://schema.org",
         "@type": "Organization",
+        "name": "Linea",
         "url": "https://docs.linea.build",
-        "logo": "https://docs.linea.build/img/favicons/favicon-96x96.png"
+        "logo": "https://docs.linea.build/img/favicons/favicon-96x96.png",
+        "sameAs": [
+          "https://github.com/Consensys/doc.linea",
+          "https://x.com/LineaBuild",
+          "https://www.linkedin.com/company/lineabuild/",
+          "https://www.youtube.com/@LineaBuild",
+          "https://www.reddit.com/r/LineaBuild/"
+        ]
       }
     `,
     },

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,116 @@
+# Linea Documentation
+
+> Linea is a secure, low-cost, Ethereum-equivalent layer 2 zk-rollup developed by Consensys. It scales Ethereum by leveraging zero-knowledge proofs (zk-SNARKs) over a fully EVM-equivalent execution environment, providing fast finality, low fees, and recoverable state guarantees. This site is the canonical developer and operator documentation for the Linea network, the Linea protocol, the Linea stack, and the Linea JSON-RPC and SDK APIs.
+
+## About Linea
+- Type: zkEVM Layer 2 (Ethereum rollup)
+- Equivalence: EVM-equivalent (Type 2 zkEVM)
+- Proof system: lattice-based zk-SNARKs
+- Finality: fast, deterministic on Ethereum L1
+- Builder: Consensys
+- Ecosystem hub: https://linea.build
+- Bridge: https://bridge.linea.build
+- Block explorer: https://lineascan.build
+- Status page: https://linea.statuspage.io
+- Source: https://github.com/Consensys/linea-monorepo
+
+## Quickstart and onboarding
+- [Network quickstart](https://docs.linea.build/network/quickstart): Get started building on Linea, including network endpoints, wallet setup, and first deploys.
+- [Network overview](https://docs.linea.build/network/overview): What Linea is, the security and equivalence guarantees, and core network features.
+- [API quickstart](https://docs.linea.build/api/quickstart): How to read and write to Linea over JSON-RPC.
+- [Protocol quickstart](https://docs.linea.build/protocol/quickstart): Entry point for protocol architecture, prover, sequencer, and coordinator details.
+- [Stack quickstart](https://docs.linea.build/stack/quickstart): Entry point for operators deploying their own Linea-stack network.
+
+## Network features
+- [Transaction finality](https://docs.linea.build/network/overview/transaction-finality): How and when transactions are final on Linea and on Ethereum L1.
+- [Predictable pricing](https://docs.linea.build/network/overview/predictable-pricing): Linea's gas pricing model and fee components.
+- [Public data](https://docs.linea.build/network/overview/public-data): What data is published on L1 and how to access it.
+- [Recoverable state](https://docs.linea.build/network/overview/recoverable-state): The guarantees that allow Linea state to be recovered without trusted operators.
+- [Differences from Ethereum](https://docs.linea.build/network/overview/ethereum-differences): Concrete behavioural differences developers must account for.
+- [Yield Boost](https://docs.linea.build/network/overview/yield-boost): Native ETH yield mechanism and risk disclosures.
+
+## Build on Linea
+- [Build overview](https://docs.linea.build/network/build): Index of build guides, tools, and references.
+- [Launch an app](https://docs.linea.build/network/build/launch-an-app): End-to-end path from deploy to listing in the Linea Hub.
+- [Connect to Linea](https://docs.linea.build/network/build/connect): RPC endpoints and chain IDs (mainnet 59144, Sepolia testnet 59141).
+- [Block explorers](https://docs.linea.build/network/build/block-explorers): Lineascan and other explorers.
+- [Bridge](https://docs.linea.build/network/build/bridge): The canonical Linea bridge to and from Ethereum.
+- [Smart contracts](https://docs.linea.build/network/build/contracts): Pre-deployed contracts, addresses, and verified code.
+- [Get testnet ETH](https://docs.linea.build/network/build/get-testnet-eth): Faucets and testnet onboarding.
+- [Send and receive messages](https://docs.linea.build/network/build/send-receive-messages): Cross-chain messaging on Linea.
+- [Tools](https://docs.linea.build/network/build/tools): Account abstraction, indexing, paymasters, and developer tooling.
+
+## How-to guides
+- [Recover state](https://docs.linea.build/network/how-to/recover-state)
+- [Estimate gas costs](https://docs.linea.build/network/how-to/gas-fees)
+- [Bridge tokens to Linea](https://docs.linea.build/network/how-to/bridge)
+- [Connect a wallet to your dapp](https://docs.linea.build/network/how-to/connect-wallet)
+- [Deploy a smart contract](https://docs.linea.build/network/how-to/deploy-smart-contract): Hardhat, Foundry, Remix, thirdweb, Cookbook, Atlas.
+- [Verify a smart contract](https://docs.linea.build/network/how-to/verify-smart-contract): Hardhat, Foundry, Atlas.
+- [Run a node](https://docs.linea.build/network/how-to/run-a-node): Linea Besu, Maru, Besu, Geth, Erigon, plus bootnodes and migration guides.
+- [Migrate a dapp](https://docs.linea.build/network/how-to/migrate-dapp)
+- [Add an RPC fallback](https://docs.linea.build/network/how-to/fallback)
+- [Verify users with Proof of Humanity](https://docs.linea.build/network/how-to/verify-users-with-proof-of-humanity)
+- [Write and deploy assertions](https://docs.linea.build/network/how-to/write-and-deploy-assertions)
+
+## Tutorials
+- [Build an AI agent on Linea](https://docs.linea.build/network/tutorials/aiagent-quickstart)
+- [Build your first dapp](https://docs.linea.build/network/tutorials/first-dapp)
+- [Build a marketplace dapp](https://docs.linea.build/network/tutorials/marketplace-dapp)
+- [Build a voting dapp](https://docs.linea.build/network/tutorials/voting-dapp)
+- [Upgrade an EOA to a smart account (EIP-7702)](https://docs.linea.build/network/tutorials/eip-7702)
+- [Ecosystem tutorials, including USDC](https://docs.linea.build/network/tutorials/ecosystem-tutorials)
+
+## API reference
+- [JSON-RPC API overview](https://docs.linea.build/api/reference): Index of every supported JSON-RPC method on rpc.linea.build.
+- [Linea SDK](https://docs.linea.build/api/linea-sdk): TypeScript SDK for cross-chain messaging and bridge claim flows.
+- [Token API](https://docs.linea.build/api/token-api): Token metadata and balance API reference.
+- Linea-specific JSON-RPC methods:
+  - [linea_estimateGas](https://docs.linea.build/api/reference/linea-estimategas)
+  - [eth_sendBundle](https://docs.linea.build/api/reference/eth-sendbundle)
+  - [eth_sendRawTransaction](https://docs.linea.build/api/reference/eth-sendrawtransaction)
+  - [linea_getProof](https://docs.linea.build/api/reference/linea-getproof)
+  - [linea_getTransactionExclusionStatusV1](https://docs.linea.build/api/reference/linea-gettransactionexclusionstatusv1)
+- Smart contract reference:
+  - [LineaRollup](https://docs.linea.build/api/linea-smart-contracts/linearollup)
+  - [zkEVM v2](https://docs.linea.build/api/linea-smart-contracts/zkevmv2)
+  - [Token bridge](https://docs.linea.build/api/linea-smart-contracts/tokenbridge)
+  - [Message service](https://docs.linea.build/api/linea-smart-contracts/messageservice)
+
+## Protocol
+- [Architecture overview](https://docs.linea.build/protocol/architecture): Core components and how they interact.
+- [Sequencer](https://docs.linea.build/protocol/architecture/sequencer): Block building, traces generation, conflation.
+- [Prover](https://docs.linea.build/protocol/architecture/prover): Circuit building, proving pipeline, prover limits.
+- [State manager](https://docs.linea.build/protocol/architecture/state-manager): EVM state representation in the rollup.
+- [Smart contracts](https://docs.linea.build/protocol/architecture/smart-contracts): On-L1 contracts that anchor Linea.
+- [Coordinator](https://docs.linea.build/protocol/architecture/coordinator): Orchestrates sequencing, proving, and finalisation.
+- [Interoperability](https://docs.linea.build/protocol/architecture/interoperability): Canonical token bridge and message service.
+- [RPC services](https://docs.linea.build/protocol/architecture/rpc-services): RPC topology, scaling, and operational design.
+- [Forced transactions](https://docs.linea.build/protocol/forced-transactions): Censorship-resistance via L1-forced inclusion.
+- [EIP-7702 on Linea](https://docs.linea.build/protocol/eip-7702): Account-abstraction support for EOAs.
+- [Tokenomics](https://docs.linea.build/protocol/tokenomics): The LINEA token, supply, distribution, and burn mechanics.
+- [Glossary of zero-knowledge terms](https://docs.linea.build/protocol/reference/zero-knowledge-glossary)
+- [Linea repositories](https://docs.linea.build/protocol/reference/repos)
+
+## Linea stack (operators)
+- [Stack overview](https://docs.linea.build/stack): What the Linea stack is and who it is for.
+- [Features](https://docs.linea.build/stack/features): Compliance, data availability, instant finality, security, privacy (Validium).
+- [How it works](https://docs.linea.build/stack/how-it-works): Protocol components, deployment models, data availability and finalisation.
+- [Forced transactions for stack operators](https://docs.linea.build/stack/how-to/forced-transactions)
+
+## Changelog and risk
+- [Changelog and release notes](https://docs.linea.build/changelog/release-notes): Network upgrades and deployments by date.
+- [Risk disclosures](https://docs.linea.build/network/risk-disclosures): Known risks for users and integrators.
+
+## Key facts
+- Linea mainnet chain ID: 59144
+- Linea Sepolia testnet chain ID: 59141
+- Public RPC base URL: https://rpc.linea.build
+- Linea is fully EVM-equivalent: contracts compiled for Ethereum mainnet run unmodified on Linea.
+- Linea uses zero-knowledge proofs to remove the seven-day fraud-proof window required by optimistic rollups.
+- Linea is incubated within Consensys, the company behind MetaMask, Infura, and Truffle.
+- The canonical bridge anchors withdrawals and deposits on Ethereum L1 with state recovery guarantees.
+
+## Authoring and licensing
+- Source repository for these docs: https://github.com/Consensys/doc.linea
+- Docs licence: see repository LICENSE

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,9 +1,9 @@
 # Default group + Content Signals (Cloudflare-led robots.txt extension)
-# Institutional posture: index us, use us as RAG/answer-engine context,
-# but do NOT use us for training corpora. Training-corpus inclusion is a
-# separate decision flagged for leadership.
+# Posture: index us, cite us as RAG/answer-engine context, and yes,
+# use us as training data. Docs are public and we want models to
+# know Linea natively, not just fetch at query time.
 User-agent: *
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 # Explicit allow for major AI search and answer-engine crawlers.
@@ -15,27 +15,27 @@ Allow: /
 # none of the search/ai-input/ai-train signals. Do not "DRY this up"
 # by collapsing it back into User-agent: * only.
 User-agent: GPTBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 User-agent: OAI-SearchBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 User-agent: ClaudeBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 User-agent: PerplexityBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 User-agent: Google-Extended
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 User-agent: CCBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 Sitemap: https://docs.linea.build/sitemap.xml

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -6,23 +6,36 @@ User-agent: *
 Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
-# Explicit allow for major AI search and answer-engine crawlers
+# Explicit allow for major AI search and answer-engine crawlers.
+#
+# IMPORTANT: per RFC 9309 each crawler picks the single most-specific
+# matching group and does NOT merge in directives from the wildcard
+# group. Content-Signal must therefore be repeated in every named
+# group below, otherwise these crawlers would see "Allow: /" but
+# none of the search/ai-input/ai-train signals. Do not "DRY this up"
+# by collapsing it back into User-agent: * only.
 User-agent: GPTBot
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 User-agent: OAI-SearchBot
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 User-agent: ClaudeBot
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 User-agent: PerplexityBot
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 User-agent: Google-Extended
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 User-agent: CCBot
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 Sitemap: https://docs.linea.build/sitemap.xml

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,28 @@
+# Default group + Content Signals (Cloudflare-led robots.txt extension)
+# Institutional posture: index us, use us as RAG/answer-engine context,
+# but do NOT use us for training corpora. Training-corpus inclusion is a
+# separate decision flagged for leadership.
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+Allow: /
+
+# Explicit allow for major AI search and answer-engine crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
 Allow: /
 
 Sitemap: https://docs.linea.build/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -70,5 +70,17 @@
       "destination": "https://linea.build/developers",
       "permanent": true
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Foundational AI search visibility and security-posture changes from the May 2026 SEO/GEO audit. PR 1 of 2; title and meta description rewrites land separately in PR 2.

- **`static/llms.txt`** (new): site map for AI search engines (ChatGPT, Claude, Perplexity, AI Overviews). Drafted in the audit's Appendix B.
- **Organization JSON-LD**: add `name: "Linea"` and a 5-URL `sameAs` array (GitHub doc.linea, X, LinkedIn, YouTube, Reddit) so AI engines recognize Linea as a known entity. All 5 URLs verified HTTP 200.
- **`vercel.json` security headers**: HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy. CSP deferred (needs embed inventory).
- **`static/robots.txt`**: explicit allow for 6 AI crawlers (GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot) plus Content Signals (`search=yes, ai-input=yes, ai-train=yes`).

References:
- Audit: https://www.notion.so/consensys/SEO-and-GEO-Proposal-355fc61a326e80ffa1f5d8856fe49d75
- Agent-readiness scan: https://isitagentready.com/docs.linea.build (Level 1/5 baseline; target Level 2 after this PR)

## Key decisions

- **Content Signals: `ai-train=yes`.** Linea wants to be in model training memory, not just answer-engine fetches at query time. Docs are public; refusing training is largely symbolic. Aligns with the open / Linux Foundation positioning. Decided by Moris, 2026-05-04.
- **No Content-Security-Policy header in this PR.** CSP requires an inventory of all embedded third parties (CodeSandbox, StackBlitz, YouTube, Algolia, GTM, GA, etc.) to avoid breaking the site. Implication: tracked as tech debt; lands in a separate PR after the embed inventory. Decided by Moris, 2026-05-04.

## Test plan (verify on Vercel preview deploy)

- [x] `curl -sI https://<preview-url>/llms.txt` returns 200 with `Content-Type: text/plain`
- [x] `curl -sI https://<preview-url>/` shows the 5 new security headers
- [x] `curl -s https://<preview-url>/robots.txt` shows the 6 AI crawler allow blocks plus the Content-Signal line
- [x] View source on the homepage: Organization JSON-LD includes `name: "Linea"` and the 5-URL `sameAs` array
- [x] Run https://isitagentready.com against the preview URL: score moves from Level 1 to Level 2 (Content Signals check passes)
- [x] No new build warnings, no broken links, no Lighthouse regression

## Local verification done before push

- `npm run build` completed successfully (no new warnings beyond pre-existing `vscode-languageserver` umd warning).
- `build/llms.txt` ships at root.
- `build/robots.txt` contains the Content-Signal line and all 6 AI crawler allow blocks.
- `build/index.html` JSON-LD verified to contain `name: "Linea"` and all 5 sameAs URLs.

## Noticed but deferred (out of scope)

- Title and meta description rewrites for top 10 entry pages (PR 2)
- TechArticle JSON-LD swizzle on `src/theme/DocItem/Layout/`
- llms-full.txt build-time generation
- Replace pseudonymous author bylines
- Promote highest-traffic redirects.json entries to server-side vercel.json redirects
- Add Consensys/linea-monorepo back to `sameAs` if it remains public long-term

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds site-wide HTTP security headers and changes crawler directives, which could affect embedding/framing behavior or how bots index the site if misconfigured. Content/metadata additions are otherwise low-impact and static.
> 
> **Overview**
> Improves AI/SEO discoverability by adding a new root `static/llms.txt` index for key docs entry points, and by enriching the Organization JSON-LD in `docusaurus.config.js` with `name` and `sameAs` social/profile links.
> 
> Updates `static/robots.txt` to publish `Content-Signal` directives and explicitly allow several AI crawlers, and adds site-wide security response headers in `vercel.json` (HSTS, nosniff, frame protection, referrer policy, permissions policy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 333f6a46b0b550ad7235541f95a750801813cdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

