### PR TITLE
fix: apply bank/FMI audit typo corrections

### DIFF
--- a/docs/network/risk-disclosures.mdx
+++ b/docs/network/risk-disclosures.mdx
@@ -26,7 +26,7 @@ The team behind Linea is actively pursuing further decentralization of the syste
 
 The Mainnet Beta will integrate some centralized components like the Sequencer, Prover and Security Council, maintained by the Linea team to help bootstrap the network. The Sequencer possesses the capability to postpone transaction inclusion and rearrange transactions.
 
-Additionally, the validity proofs used to verify the computation of Linea batches prove 100% of EVM opcodes and precompiles. This means that the proof has full completeness though a level of trust is still laced on the Linea operator to not maliciously alter the state of the system.
+Additionally, the validity proofs used to verify the computation of Linea batches prove 100% of EVM opcodes and precompiles. This means that the proof has full completeness though a level of trust is still placed on the Linea operator to not maliciously alter the state of the system.
 
 Ensuring the Linea Mainnet Beta's security is an ongoing endeavor. This involves addressing security issues, a task that falls under the jurisdiction of the Linea Security Council. The Council, consisting of nine members, holds the authority to pause the rollup and upgrade the Linea Mainnet Beta immediately without submitting a validity proof, given the threshold of 5 signers, in order to respond to urgent security problems. If council members were to act with malice or collude, it could compromise system integrity, potentially leading to network upgrades that may result in the loss of crypto-assets.
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -49,7 +49,7 @@ The Linea stack is comprised of several broad classes of components:
 - [Nodes](#network-topology): A fully-public network provides externally reachable nodes. In other [deployment types](../../stack/how-it-works/deployment-models), node services may be configured to be private or semi-private.
 - [Internal protocol services](#internal-protocol-services): While these are plugins to or components of Linea Besu nodes, traffic between these services remains within the operator’s trusted network boundary and does not traverse public networks.
 - [Smart contracts](#onchain-system-contracts): Versionable, immutable onchain contracts.
-- [Auxillary services](#auxiliary-services):
+- [Auxiliary services](#auxiliary-services):
   - Block explorer: While theoretically optional, explorer data simplifies transaction building, auditing, and troubleshooting.
   - Web3Signer: Secure signing service ensuring that nodes may sign without revealing keys.
 

--- a/docs/stack/features/compliance.mdx
+++ b/docs/stack/features/compliance.mdx
@@ -33,7 +33,7 @@ Operators can embed compliance into their deployment strategy:
 
 ### Protocol support 
 
-Linea suppors customization:
+Linea supports customization:
 
 - State commitment retention rules
 - Protocol-level selective disclosure primitives (private validium)

--- a/docs/stack/features/index.mdx
+++ b/docs/stack/features/index.mdx
@@ -18,7 +18,7 @@ export const relatedDocs = [
     type: 'link',
     href: '/stack/how-it-works/data-availability-finalization',
     label: 'Data availability and finalization',
-    description: 'Configue data availability and finalization options to suit your business logic.',
+    description: 'Configure data availability and finalization options to suit your business logic.',
   },
 ];
 

--- a/docs/stack/features/validium.mdx
+++ b/docs/stack/features/validium.mdx
@@ -12,7 +12,7 @@ disclosure.
 
 :::important
 
-[Reach out](https://forms.gle/eip4XrYhPFDuLtDQ8) to enquire about rollup-as-a-service, wherein all or part of the operations are supported by Linea and her partners.
+[Reach out](https://forms.gle/eip4XrYhPFDuLtDQ8) to enquire about rollup-as-a-service, wherein all or part of the operations are supported by Linea and its partners.
 
 :::
 

--- a/docs/stack/how-it-works/deployment-models.mdx
+++ b/docs/stack/how-it-works/deployment-models.mdx
@@ -11,7 +11,7 @@ A deployment model describes how a Linea network is configured. Different deploy
 
 The Linea stack is designed to support detailed customizations for factors including, but not restricted to:
 
-- Access control: Who may access the memepool, the ledger, and transaction data all impact the nature of
+- Access control: Who may access the mempool, the ledger, and transaction data all impact the nature of
 the system
 - Data availability: Asset recovery by users ties directly to data availability guarantees
 - Finalization speed: Block size on the ledger impacts the soft finality speed of transactions
@@ -98,7 +98,7 @@ privacy, compliance, and access control features:
 ### Example validium system setup
 
 The following network setup presents how an enterprise validium instance of Linea may be configured
-to serve as an interoperable payment system with KYC and KYT (know your customer and know your trade
+to serve as an interoperable payment system with KYC and KYT (know your customer and know your transaction
 respectively) auditing capabilities. 
 
 The operator determines where transaction data is stored to suit privacy and security requirements (not shown below).

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -57,7 +57,7 @@ rollup architecture.
 
 - **An Ethereum-compatible execution environment:** Run an Ethereum-equivalent network.
 
-- **Composability:** Leverage a trustless bridge for with Ethereum to interact with digital assets and compose with the largest open, modular DeFi ecosystem.
+- **Composability:** Leverage a trustless bridge to Ethereum to interact with digital assets and compose with the largest open, modular DeFi ecosystem.
 
 - **Flexible deployment models:** Deploy rollup networks with customizations to suit your privacy,
 compliance, and availability requirements.


### PR DESCRIPTION
## Summary

Typo and polish corrections from the bank/FMI audit (Notion).

- `memepool` → `mempool`
- `KYT (know your trade)` → `KYT (know your transaction)`
- `Configue` → `Configure`
- `suppors` → `supports`
- `Auxillary` → `Auxiliary`
- `laced on the Linea operator` → `placed on the Linea operator`
- `trustless bridge for with Ethereum` → `trustless bridge to Ethereum`
- `Linea and her partners` → `Linea and its partners`

`mintues` was not found in the repo; existing `minutes` occurrences in `docs/network/overview/transaction-finality.mdx` are already correct.

## Testing

- `rg` checks for the audited bad strings come back clean
- `git diff --check` clean
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only spelling/wording fixes with no behavioral or code changes.
> 
> **Overview**
> Applies audit-driven typo and wording corrections across several MDX docs, improving clarity and consistency (e.g., `mempool`, KYT expansion, “Auxiliary”, and various grammar fixes).
> 
> Also cleans up a few user-facing phrases (e.g., bridge wording and partner pronouns) without changing any technical behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ada005c88eb5480e5803dc20dc389c0010ca48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->