### PR TITLE
chore(deps): upgrade TypeScript to 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "stylelint": "^17.8.0",
         "stylelint-config-standard": "^40.0.0",
         "tsc-files": "1.1.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.58.2"
       },
       "engines": {
@@ -10788,6 +10788,20 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/@vercel/node/node_modules/undici": {
       "version": "5.28.4",
@@ -33760,9 +33774,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "stylelint": "^17.8.0",
     "stylelint-config-standard": "^40.0.0",
     "tsc-files": "1.1.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.58.2"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
+    // Docusaurus 3.10 still relies on baseUrl for @site/*; keep TS6 usable until upstream drops it.
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@site/*": ["./*"]
     },


### PR DESCRIPTION
## Summary
- Upgrade `typescript` from `5.9.3` to `6.0.3`.
- Keep the dependency pinned exactly, matching the repository version style.
- Add the TypeScript 6 deprecation guard required by the inherited Docusaurus `baseUrl` setup.

## Migration notes
- TypeScript 6 deprecates `baseUrl` and reports TS5101 unless `ignoreDeprecations` is set.
- The repository still needs a local `baseUrl: "."` because `@docusaurus/tsconfig@3.10.0` defines `baseUrl` relative to its own package. Without the local override, `@site/*` resolves under `node_modules/@docusaurus/tsconfig` and `tsc` cannot resolve site imports.
- `typescript-eslint@8.58.2` accepts TypeScript `>=4.8.4 <6.1.0`, so this compiler bump stays inside the declared peer range.

## Validation
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx -y node@22.22.2 node_modules/typescript/bin/tsc`
- `npx -y node@22.22.2 node_modules/eslint/bin/eslint.js .`
- `npx -y node@22.22.2 node_modules/stylelint/bin/stylelint.mjs '**/*.css'`
- `npm audit --json` unchanged: 33 existing vulnerabilities, 31 moderate and 2 high

Closes #1457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major TypeScript compiler bump can change typechecking behavior and surface new errors in CI/build, even though it’s dev-only. Adds a deprecation suppression in `tsconfig.json`, which could mask future deprecation warnings if not revisited.
> 
> **Overview**
> Upgrades the repo’s pinned `typescript` devDependency from `5.9.3` to `6.0.3` and updates `package-lock.json` accordingly (including keeping a nested `typescript@5.9.3` under `@vercel/node`).
> 
> Updates `tsconfig.json` to keep `baseUrl: "."` for Docusaurus path resolution and adds `ignoreDeprecations: "6.0"` to silence TypeScript 6’s deprecation diagnostics for this setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0906e5a5a9ee23fd6be67090f66fb0bc183cf022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->