### PR TITLE
fix: improve release notes mobile TOC

### DIFF
--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -1578,6 +1578,47 @@ button.clean-btn.menu__caret {
   .theme-doc-toc-mobile .table-of-contents__link {
     font-size: 14px !important;
   }
+
+  .release-notes-mobile-toc .table-of-contents__link {
+    padding: 4px 0;
+  }
+
+  .release-notes-mobile-toc__version,
+  .release-notes-mobile-toc__feature,
+  .release-notes-mobile-toc__date {
+    display: block;
+    font-family: AtypText, sans-serif;
+    line-height: 1.4;
+  }
+
+  .release-notes-mobile-toc__version {
+    color: var(--linea-text-primary);
+    font-weight: 500;
+  }
+
+  .release-notes-mobile-toc__feature {
+    margin-top: 2px;
+    color: var(--linea-text-secondary);
+    font-size: var(--font-body-xs);
+  }
+
+  .release-notes-mobile-toc__date {
+    margin-top: 2px;
+    color: var(--linea-text-muted);
+    font-size: var(--font-body-xs);
+  }
+
+  .release-notes-mobile-toc
+    .table-of-contents__link--active
+    .release-notes-mobile-toc__version {
+    color: var(--linea-active-color);
+  }
+}
+
+@media (min-width: 997px), print {
+  .release-notes-mobile-toc {
+    display: none;
+  }
 }
 
 /* Expand sidebar button styles are in section 14b above */

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -1608,11 +1608,6 @@ button.clean-btn.menu__caret {
     font-size: var(--font-body-xs);
   }
 
-  .release-notes-mobile-toc
-    .table-of-contents__link--active
-    .release-notes-mobile-toc__version {
-    color: var(--linea-active-color);
-  }
 }
 
 @media (min-width: 997px), print {

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import clsx from "clsx";
-import { useWindowSize } from "@docusaurus/theme-common";
+import { ThemeClassNames, useWindowSize } from "@docusaurus/theme-common";
 import {
   useDoc,
   useSidebarBreadcrumbs,
@@ -11,6 +11,7 @@ import DocVersionBadge from "@theme/DocVersionBadge";
 import DocItemFooter from "@theme/DocItem/Footer";
 import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
 import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
+import TOCCollapsible from "@theme/TOCCollapsible";
 import DocItemContent from "@theme/DocItem/Content";
 import DocBreadcrumbs from "@theme/DocBreadcrumbs";
 import ContentVisibility from "@theme/ContentVisibility";
@@ -20,15 +21,108 @@ import ContractsWarning from "../../../components/ContractsWarning";
 import CopyPageButton from "../../../components/CopyPageButton";
 import FeedbackWidget from "../../../components/FeedbackWidget";
 
+const RELEASE_NOTES_PERMALINK = "/changelog/release-notes";
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function getReleaseDateText(meta) {
+  if (!meta) {
+    return null;
+  }
+
+  if (meta.date) {
+    return meta.date;
+  }
+
+  if (meta.mainnet) {
+    return meta.mainnet;
+  }
+
+  if (meta.sepolia) {
+    return meta.sepolia;
+  }
+
+  return meta.phase || null;
+}
+
+function getReleaseNotesMobileValue(item, meta) {
+  if (!meta) {
+    return item.value;
+  }
+
+  const label = meta.label;
+  const date = getReleaseDateText(meta);
+
+  if (!label && !date) {
+    return item.value;
+  }
+
+  return [
+    `<span class="release-notes-mobile-toc__version">${item.value}</span>`,
+    label
+      ? `<span class="release-notes-mobile-toc__feature">${escapeHtml(label)}</span>`
+      : null,
+    date
+      ? `<span class="release-notes-mobile-toc__date">${escapeHtml(date)}</span>`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+function enrichReleaseNotesMobileTOC(toc, releaseMeta) {
+  if (!releaseMeta) {
+    return toc;
+  }
+
+  return toc.map((item) => ({
+    ...item,
+    value: getReleaseNotesMobileValue(item, releaseMeta[item.id]),
+  }));
+}
+
+function ReleaseNotesMobileTOC({ toc, frontMatter }) {
+  const enrichedToc = React.useMemo(
+    () => enrichReleaseNotesMobileTOC(toc, frontMatter.release_toc),
+    [frontMatter.release_toc, toc],
+  );
+
+  return (
+    <TOCCollapsible
+      toc={enrichedToc}
+      minHeadingLevel={frontMatter.toc_min_heading_level}
+      maxHeadingLevel={frontMatter.toc_max_heading_level}
+      className={clsx(
+        ThemeClassNames.docs.docTocMobile,
+        "release-notes-mobile-toc",
+      )}
+    />
+  );
+}
+
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
  */
 function useDocTOC() {
-  const { frontMatter, toc } = useDoc();
+  const { frontMatter, metadata, toc } = useDoc();
   const windowSize = useWindowSize();
   const hidden = frontMatter.hide_table_of_contents;
   const canRender = !hidden && toc.length > 0;
-  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const isReleaseNotesPage = metadata.permalink === RELEASE_NOTES_PERMALINK;
+  const mobile = canRender ? (
+    isReleaseNotesPage ? (
+      <ReleaseNotesMobileTOC toc={toc} frontMatter={frontMatter} />
+    ) : (
+      <DocItemTOCMobile />
+    )
+  ) : undefined;
   const desktop =
     canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
       <DocItemTOCDesktop />


### PR DESCRIPTION
## Summary
- enrich the release notes mobile TOC with feature labels and dates from `release_toc`
- keep the existing mobile dropdown and desktop TOC behavior unchanged
- add scoped mobile styles for the version, feature, and date lines

Closes #1487

## Testing
- `npm run lint`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters TOC rendering on the release notes page; main risk is minor layout/markup regressions on mobile due to custom HTML values and new CSS.
> 
> **Overview**
> **Release notes mobile TOC now shows richer entries.** The mobile TOC on `/changelog/release-notes` is switched to a custom `TOCCollapsible` variant that injects a multi-line value (version + optional feature label + optional date) using `frontMatter.release_toc`, with HTML escaping for injected metadata.
> 
> **Adds scoped styling for the new layout.** New CSS targets `.release-notes-mobile-toc` to space and typographically style the version/feature/date lines on mobile, and hides this custom TOC wrapper on desktop so existing desktop TOC behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af20fae45862abcbe09e8d436dcbfa8c5200c7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->