### PR TITLE
fix(maru): update repository docs links

### DIFF
--- a/docs/network/how-to/run-a-node/maru.mdx
+++ b/docs/network/how-to/run-a-node/maru.mdx
@@ -28,7 +28,7 @@ You must run Maru alongside an execution layer client like [Besu](./besu.mdx) or
 
 There are two methods you can use to run Maru using Docker:
 - Clone the Linea monorepo and use `docker compose` 
-- Clone the Maru repository and build a Docker image locally. 
+- Clone the Linea monorepo and build a Maru Docker image locally from `maru/`.
 
 <Tabs className="my-tabs">
   <TabItem value="Linea monorepo" label="Linea monorepo">
@@ -56,14 +56,15 @@ There are two methods you can use to run Maru using Docker:
     ```
 
   </TabItem>
-  <TabItem value="Maru repository" label="Maru repository">
+  <TabItem value="Maru source" label="Maru source">
 
-    ### Step 1. Clone Maru repository
+    ### Step 1. Clone monorepo
 
-    Clone the Maru repository with:
+    Clone the Linea monorepo and enter the Maru directory:
 
     ```bash
-    git clone https://github.com/Consensys/maru.git
+    git clone https://github.com/Consensys/linea-monorepo.git
+    cd linea-monorepo/maru
     ```
 
     ### Step 2. Run Maru
@@ -80,13 +81,14 @@ There are two methods you can use to run Maru using Docker:
 
 ### Prerequisites
 
-- Java 21
+- Java 25
 - [Make](https://www.gnu.org/software/make/make.html) 3.81
 
-### Step 1. Clone the Maru repository
+### Step 1. Clone the Linea monorepo
 
 ```bash
-git clone https://github.com/Consensys/maru.git
+git clone https://github.com/Consensys/linea-monorepo.git
+cd linea-monorepo/maru
 ```
 
 ### Step 2. Build the Maru binary

--- a/docs/protocol/reference/repos.mdx
+++ b/docs/protocol/reference/repos.mdx
@@ -65,6 +65,6 @@ Linea's zk-SNARK with a high-level API to design circuits and efficient cryptogr
 
 A plugin that extends Besu's functionality by maintaining and updating Linea's state. 
 
-## [`maru`](https://github.com/Consensys/maru)
+## [`maru`](https://github.com/Consensys/linea-monorepo/tree/main/maru)
 
 Linea's consensus layer client, implementing the QBFT consensus algorithm.

--- a/docs/stack/how-to/distributed-sequencing.mdx
+++ b/docs/stack/how-to/distributed-sequencing.mdx
@@ -151,7 +151,7 @@ Use direct, static peering between validators rather than P2P discovery. Indirec
 latency and reduces consensus performance.
 
 A key generation script is provided
-([Maru PrivateKeyGenerator](https://github.com/Consensys/maru/tree/main/jvm-libs/utils#1-privatekeygenerator)).
+([Maru PrivateKeyGenerator](https://github.com/Consensys/linea-monorepo/tree/main/maru/jvm-libs/utils#1-privatekeygenerator)).
 Generate validator keys in advance, then populate the genesis file with the validator addresses.
 
 For multi-party deployments where validators are run by independent operators: each operator
@@ -172,9 +172,9 @@ rotations carefully and avoid them when possible.
 ### Configuration
 
 A reference K3S setup is available at
-[`Consensys/maru/chaos-testing`](https://github.com/Consensys/maru/tree/main/chaos-testing). For
+[`linea-monorepo/maru/chaos-testing`](https://github.com/Consensys/linea-monorepo/tree/main/maru/chaos-testing). For
 genesis file structure, see the
-[genesis-maru.json template](https://github.com/Consensys/maru/blob/main/docker/initialization/genesis-maru.json.template).
+[genesis-maru.json template](https://github.com/Consensys/linea-monorepo/blob/main/maru/docker/initialization/genesis-maru.json.template).
 
 ## Operations
 
@@ -186,7 +186,7 @@ Shanghai, Cancun, Prague), so changes apply at a future point all validators agr
 
 Procedure:
 
-1. If the new validator does not yet have a key pair, generate one using the [PrivateKeyGenerator](https://github.com/Consensys/maru/tree/main/jvm-libs/utils#1-privatekeygenerator) tool (see [Prerequisites](#prerequisites)). The new operator keeps the private key locally and shares only the public address.
+1. If the new validator does not yet have a key pair, generate one using the [PrivateKeyGenerator](https://github.com/Consensys/linea-monorepo/tree/main/maru/jvm-libs/utils#1-privatekeygenerator) tool (see [Prerequisites](#prerequisites)). The new operator keeps the private key locally and shares only the public address.
 2. All existing validator operators agree on a future timestamp far enough ahead for everyone to update their genesis file in time.
 3. Each operator updates their genesis file with the new validator list, set to activate at the agreed timestamp.
 4. Block time must remain consistent across validators.
@@ -234,7 +234,7 @@ offline simultaneously, up to the `f` failure tolerance.
 
 ## Resources
 
-- [Maru repository](https://github.com/Consensys/maru)
+- [Maru repository](https://github.com/Consensys/linea-monorepo/tree/main/maru)
 - [Besu QBFT documentation](https://besu.hyperledger.org/private-networks/how-to/configure/consensus/qbft)
-- [PrivateKeyGenerator tool](https://github.com/Consensys/maru/tree/main/jvm-libs/utils#1-privatekeygenerator)
-- [Reference K3S deployment](https://github.com/Consensys/maru/tree/main/chaos-testing)
+- [PrivateKeyGenerator tool](https://github.com/Consensys/linea-monorepo/tree/main/maru/jvm-libs/utils#1-privatekeygenerator)
+- [Reference K3S deployment](https://github.com/Consensys/linea-monorepo/tree/main/maru/chaos-testing)


### PR DESCRIPTION
## Summary
- Update Maru docs to point at `linea-monorepo/maru` after the Maru import.
- Keep existing `docs/getting-started` compose links unchanged.
- Related upstream context: https://github.com/Consensys/linea-monorepo/pull/3080#issuecomment-4436510809

## Test Plan
- `rg -n "https://github\.com/Consensys/maru|git clone https://github\.com/Consensys/maru\.git" docs src static`
- `git diff --check`
- `./node_modules/.bin/docusaurus build --out-dir /private/tmp/doc-linea-maru-build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update repository URLs and clone instructions; no runtime or security-sensitive code paths are affected.
> 
> **Overview**
> Updates Maru docs to point to `Consensys/linea-monorepo/tree/main/maru` instead of the standalone `Consensys/maru` repo, including references in `repos.mdx` and distributed sequencing resources.
> 
> Refreshes the Maru run guides to clone from `linea-monorepo` (and `cd` into `maru/`), renames the Docker tab to *Maru source*, and updates the binary build prerequisites to `Java 25`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adadeeaecc2afb4afe2f7f95bceb8a30036aaf12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->