### PR TITLE
update feature relase date + highlight them as planned

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -6,12 +6,12 @@ image: /img/socialCards/release-notes.jpg
 release_toc:
   beta-v54:
     label: Finality under 30min
-    mainnet: May 2026 (target)
-    sepolia: mid-May 2026
+    mainnet: Late June 2026 (target)
+    sepolia: June 2026
   beta-v53:
     label: Prover performance optimizations
-    mainnet: May 2026 (target)
-    sepolia: mid-May 2026
+    mainnet: Late June 2026 (target)
+    sepolia: June 2026
   beta-v52:
     label: Small fields and contract upgrades
     mainnet: 1 April 2026
@@ -163,7 +163,7 @@ that allows users to submit L2 transactions directly to the L1.
 */}
 
 ## Beta v5.4
-
+#### Planned release
 <ChangelogDate sectionId="beta-v54" />
 
 <ChangelogEntry tag="performance">
@@ -173,7 +173,7 @@ Finality under 30min: Reduce Linea's [hard finality](../network/overview/transac
 </ChangelogEntry>
 
 ## Beta v5.3
-
+#### Planned release
 <ChangelogDate sectionId="beta-v53" />
 
 <ChangelogEntry tag="performance">

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -173,7 +173,7 @@ Finality under 30min: Reduce Linea's [hard finality](../network/overview/transac
 </ChangelogEntry>
 
 ## Beta v5.3
-#### Planned release
+### Planned release
 <ChangelogDate sectionId="beta-v53" />
 
 <ChangelogEntry tag="performance">

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -163,7 +163,7 @@ that allows users to submit L2 transactions directly to the L1.
 */}
 
 ## Beta v5.4
-#### Planned release
+### Planned release
 <ChangelogDate sectionId="beta-v54" />
 
 <ChangelogEntry tag="performance">

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -6,11 +6,11 @@ image: /img/socialCards/release-notes.jpg
 release_toc:
   beta-v54:
     label: Finality under 30min
-    mainnet: Late June 2026 (target)
+    mainnet: late June 2026 (target)
     sepolia: June 2026
   beta-v53:
     label: Prover performance optimizations
-    mainnet: Late June 2026 (target)
+    mainnet: late June 2026 (target)
     sepolia: June 2026
   beta-v52:
     label: Small fields and contract upgrades


### PR DESCRIPTION
Update release notes dates for Beta  5.3 and 5.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only date and heading updates with no product or protocol code changes.
> 
> **Overview**
> **Beta v5.3** and **Beta v5.4** release timelines in `release-notes.mdx` are pushed from May / mid-May 2026 to **June 2026** (Sepolia) and **late June 2026 (target)** (mainnet) in the `release_toc` front matter that feeds `ChangelogDate`.
> 
> Both sections now include a **### Planned release** subheading so readers can tell these entries are scheduled, not shipped yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41283d099b35d296f2e28c0c26090e4e159e5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->