### PR TITLE
Restore Erigon node guide

### DIFF
--- a/docs/network/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/network/how-to/run-a-node/beta-v4-migration.mdx
@@ -4,7 +4,7 @@ description: >-
   Detailed walkthroughs and how-tos for upgrading your Linea node to the latest
   hard fork or other upgrade
 image: /img/socialCards/network-upgrades.jpg
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 ## Fusaka upgrade guide

--- a/docs/network/how-to/run-a-node/bootnodes.mdx
+++ b/docs/network/how-to/run-a-node/bootnodes.mdx
@@ -2,7 +2,7 @@
 title: Bootnodes
 description: Bootnodes available for Linea Mainnet
 image: /img/socialCards/bootnodes.jpg
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 The following bootnodes enable your node to find a peer node when initializing. To 
@@ -57,4 +57,3 @@ Any of the nodes on this page can be used for peer discovery.
 ### `eu-north`
 
 - `/ip4/13.50.94.193/tcp/31003/p2p/16Uiu2HAmVcX8oB9KxmJdVAGybMyxuqtbY959i6uaew1agDBv9wk3`
-

--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -2,8 +2,7 @@
 title: Erigon
 description: Install the Erigon client to run a Linea node.
 image: /img/socialCards/erigon.jpg
-unlisted: true
-sidebar_position: 8
+sidebar_position: 6
 ---
 
 import Tabs from "@theme/Tabs";
@@ -11,39 +10,167 @@ import TabItem from "@theme/TabItem";
 
 import VolumeCreation from "./volume-creation.mdx";
 
-:::note
-
-This section is undergoing maintenance. Similarly to Ethereum, and as of Linea [Beta v4](../../../changelog/release-notes.mdx#beta-v40), 
-Linea uses a dual-layer architecture, with a consensus layer client, Maru, and an execution layer 
-client of your choice. 
-
-This section will be updated shortly to reflect this new architecture and is inaccurate for the time
-being.
-
-:::
-
 Erigon is a client implementation focused on performance and saving disk space, written in Go.
 
 :::info important
-Install and run an Erigon if you want to follow the Linea network by 
+Install and run Erigon if you want to follow the Linea network by
 maintaining a local copy of the blockchain. However, if you want to interact with the network and use
 Linea-specific methods and features, you should [install Linea Besu](./linea-besu.mdx) instead.
 :::
 
-You can run Erigon from a [binary distribution](#run-using-the-binary-distribution) or [using Docker](#run-using-docker).
+Please note that you must run any execution layer client such as Erigon alongside Linea's consensus
+layer client, [Maru](./maru.mdx), for the node to function.
 
-## Run using the binary distribution
+## Run using Docker
 
-:::info
-Ensure you review [Erigon's software prerequisites](https://erigon.gitbook.io/erigon/basic-usage/getting-started#software-prerequisites)
-before installing the Erigon client.
+:::warning Current Erigon support
 
-If you're not comfortable with installing the binary distribution, consider using [Docker](#run-using-docker) instead.
+Erigon support for current Linea is merged upstream in
+[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298), and the Erigon team
+said it will land in `v3.5`. Until an official `v3.5` or later Docker image is published, build a
+local image from the #20298 merge commit and use that image in the compose file.
+
 :::
 
-### Step 1. Install Erigon
+### Prerequisites
 
-[Download and install the Erigon client](https://erigon.gitbook.io/erigon/basic-usage/getting-started).
+- [Docker](https://docker.com/products/docker-desktop/)
+
+### Step 1. Build an Erigon image from the Linea merge commit
+
+Build the Docker image from the #20298 merge commit:
+
+```bash
+git clone https://github.com/erigontech/erigon.git
+cd erigon
+git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
+docker build -t erigon-linea:pr-20298 .
+```
+
+After Erigon publishes a `v3.5` or later image, you can skip this step and use the official release
+image in the compose file instead.
+
+### Step 2. Download the Linea node example config
+
+Use the Linea monorepo's `docs/getting-started` directory as the example Docker Compose
+configuration. The same directory contains the Geth genesis file that Erigon should initialize from.
+
+<Tabs groupId="networks" className="my-tabs">
+  <TabItem value="mainnet" label="Mainnet">
+  
+  Download or clone the
+  [`docs/getting-started/linea-mainnet`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-mainnet)
+  directory from the Linea monorepo.
+
+  Use the
+  [`geth/geth-genesis.json`](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/geth/geth-genesis.json)
+  file as the Erigon genesis file. The Erigon services in the example compose file expect
+  `./genesis.json`, so copy the Geth genesis file to that name:
+
+  ```bash
+  cp geth/geth-genesis.json genesis.json
+  ```
+
+  :::note[bootnodes]
+  You can choose from a range of bootnodes for Linea Mainnet. The Docker Compose file uses all
+  bootnodes by default.
+
+  The [bootnodes page](bootnodes.mdx) contains a full list of available bootnodes.
+  :::
+  
+  </TabItem>
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
+  
+  Download or clone the
+  [`docs/getting-started/linea-sepolia`](https://github.com/Consensys/linea-monorepo/tree/main/docs/getting-started/linea-sepolia)
+  directory from the Linea monorepo.
+
+  Use the
+  [`geth/geth-genesis.json`](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/geth/geth-genesis.json)
+  file as the Erigon genesis file. The Erigon services in the example compose file expect
+  `./genesis.json`, so copy the Geth genesis file to that name:
+
+  ```bash
+  cp geth/geth-genesis.json genesis.json
+  ```
+
+  </TabItem>
+</Tabs>
+
+### Step 3. Update the Erigon services in Docker Compose
+
+The monorepo's Docker Compose example includes Erigon services, but it may still reference an older
+published Erigon image, for example `erigontech/erigon:2.61.0`.
+
+:::warning
+
+Until Erigon publishes `v3.5` or later, do not use the Erigon image tag already set in the
+monorepo compose file. Replace the Erigon image in both `erigon-init` and `erigon-node` with the
+local image you built in Step 1.
+
+:::
+
+```yaml
+erigon-init:
+  image: erigon-linea:pr-20298
+
+erigon-node:
+  image: erigon-linea:pr-20298
+```
+
+Also make sure Erigon initializes the same data directory that the node uses. The compose example
+mounts the Erigon volume at `/home/erigon/.local/share/erigon/`; if `erigon-init` still has
+`--datadir=/data`, change it to:
+
+```yaml
+erigon-init:
+  command:
+    - init
+    - /genesis.json
+    - --datadir=/home/erigon/.local/share/erigon
+```
+
+When Erigon publishes `v3.5` or later, replace `erigon-linea:pr-20298` with the official release
+image tag.
+
+### Step 4. Start the Erigon node
+
+In a terminal, navigate to the Linea monorepo directory for your network. Start the Erigon services
+from that compose file:
+
+```bash
+docker compose up erigon-init erigon-node
+```
+
+The compose file initializes Erigon from the Geth genesis JSON, then starts the Erigon execution
+client. Keep [Maru](./maru.mdx) running alongside your chosen execution client for a full Linea
+node.
+
+## Alternative: Run using the binary distribution
+
+:::info
+Until Erigon publishes `v3.5` or later, use a binary built from the
+[#20298 merge commit](https://github.com/erigontech/erigon/pull/20298) rather than a published
+release binary. Ensure you review
+[Erigon's software prerequisites](https://erigon.gitbook.io/erigon/basic-usage/getting-started#software-prerequisites)
+before building the Erigon client.
+
+If you're not comfortable with installing the binary distribution, use [Docker](#run-using-docker)
+instead.
+:::
+
+### Step 1. Build Erigon
+
+Build Erigon from the #20298 merge commit:
+
+```bash
+git clone https://github.com/erigontech/erigon.git
+cd erigon
+git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
+make erigon
+```
+
+Use the resulting `build/bin/erigon` binary in the commands below, or add it to your `PATH`.
 
 ### Step 2. Download the genesis file
 
@@ -53,21 +180,23 @@ directory specified by [`datadir` in Step 4](#step-4-bootstrap-your-node).
 <Tabs groupId="networks" className="my-tabs">
   <TabItem value="mainnet" label="Mainnet">
   
-  Mainnet [`genesis.json`](pathname:///files/erigon/mainnet/genesis.json) file.
+  Download the current Linea Mainnet
+  [`geth-genesis.json`](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-mainnet/geth/geth-genesis.json)
+  file from the Linea monorepo. Save it in your Erigon data directory as `genesis.json`.
   
   </TabItem>
   <TabItem value="Linea Sepolia" label="Linea Sepolia">
   
-  Sepolia [`genesis.json`](pathname:///files/erigon/sepolia/genesis.json) file.
+  Download the current Linea Sepolia
+  [`geth-genesis.json`](https://github.com/Consensys/linea-monorepo/blob/main/docs/getting-started/linea-sepolia/geth/geth-genesis.json)
+  file from the Linea monorepo. Save it in your Erigon data directory as `genesis.json`.
   
   </TabItem>
 </Tabs>
 
 ### Step 3. Define disk space volume (optional)
 
-Define a volume size appropriate to your expected usage. As of October 8, 2024, Erigon nodes use:
-- Full nodes: 122GB.
-- Archive nodes: 472GB.
+Define a volume size appropriate to your expected usage. Erigon full nodes use over 200GB.
 
 Use these figures as a basis to determine the extent to which you want to future-proof your node.
 
@@ -158,46 +287,6 @@ Start the node using the following command:
 </Tabs>
 
 The Erigon node will attempt to find peers to begin synchronizing and to download the world state.
-
-## Run using Docker
-
-### Prerequisites
-
-Download and install [Docker](https://docker.com/products/docker-desktop/) and ensure it is 
-running.
-
-### Step 1. Download configuration files
-
-Download the configuration files for the relevant network. Ensure that you download the files to the same directory.
-
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
-  
-  Download the mainnet [`docker-compose.yml`](pathname:///files/erigon/mainnet/docker-compose.yml) and [`genesis.json`](pathname:///files/erigon/mainnet/genesis.json)
-  files.
-
-  :::note[bootnodes]
-  You can choose from a range of bootnodes for Linea Mainnet. The above command uses 
-  all bootnodes by default.
-
-  The [bootnodes page](bootnodes.mdx) contains a full list of available bootnodes.
-  :::
-  
-  </TabItem>
-  <TabItem value="Linea Sepolia" label="Linea Sepolia">
-  
-  Download the Sepolia testnet [`docker-compose.yml`](pathname:///files/erigon/sepolia/docker-compose.yml) and [`genesis.json`](pathname:///files/erigon/sepolia/genesis.json)
-  files.
-
-  </TabItem>
-</Tabs>
-
-### Step 2. Start the Erigon node
-
-Open up a terminal where the both `docker-compose.yml` and `genesis.json` are located (they should be in the same directory)
-and run `docker compose up`
-
-The node should now be running and looking for peers to sync.
 
 ## Confirm the node is running
 

--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -26,9 +26,9 @@ layer client, [Maru](./maru.mdx), for the node to function.
 :::warning Current Erigon support
 
 Erigon support for current Linea is merged upstream in
-[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298), and the Erigon team
-said it will land in `v3.5`. Until an official `v3.5` or later Docker image is published, build a
-local image from the #20298 merge commit and use that image in the compose file.
+[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298). Until an official
+Erigon release containing that change is available, build a local image from the #20298 merge commit
+and use that image in the compose file.
 
 :::
 
@@ -47,8 +47,8 @@ git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
 docker build -t erigon-linea:pr-20298 .
 ```
 
-After Erigon publishes a `v3.5` or later image, you can skip this step and use the official release
-image in the compose file instead.
+After Erigon publishes an official image containing #20298, you can skip this step and use the
+official release image in the compose file instead.
 
 ### Step 2. Download the Linea node example config
 
@@ -104,9 +104,9 @@ published Erigon image, for example `erigontech/erigon:2.61.0`.
 
 :::warning
 
-Until Erigon publishes `v3.5` or later, do not use the Erigon image tag already set in the
-monorepo compose file. Replace the Erigon image in both `erigon-init` and `erigon-node` with the
-local image you built in Step 1.
+Until Erigon publishes an official image containing #20298, do not use the Erigon image tag already
+set in the monorepo compose file. Replace the Erigon image in both `erigon-init` and `erigon-node`
+with the local image you built in Step 1.
 
 :::
 
@@ -130,8 +130,8 @@ erigon-init:
     - --datadir=/home/erigon/.local/share/erigon
 ```
 
-When Erigon publishes `v3.5` or later, replace `erigon-linea:pr-20298` with the official release
-image tag.
+When Erigon publishes an official image containing #20298, replace `erigon-linea:pr-20298` with the
+official release image tag.
 
 ### Step 4. Start the Erigon node
 
@@ -149,7 +149,7 @@ node.
 ## Alternative: Run using the binary distribution
 
 :::info
-Until Erigon publishes `v3.5` or later, use a binary built from the
+Until Erigon publishes an official release containing #20298, use a binary built from the
 [#20298 merge commit](https://github.com/erigontech/erigon/pull/20298) rather than a published
 release binary. Ensure you review
 [Erigon's software prerequisites](https://erigon.gitbook.io/erigon/basic-usage/getting-started#software-prerequisites)

--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -26,9 +26,9 @@ layer client, [Maru](./maru.mdx), for the node to function.
 :::warning Current Erigon support
 
 Erigon support for current Linea is merged upstream in
-[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298). Until an official
-Erigon release containing that change is available, build a local image from the #20298 merge commit
-and use that image in the compose file.
+[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298) and is included in the
+Erigon `v3.5` milestone. Until an official `v3.5` or later Docker image is published, build a local
+image from the #20298 merge commit and use that image in the compose file.
 
 :::
 
@@ -47,7 +47,7 @@ git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
 docker build -t erigon-linea:pr-20298 .
 ```
 
-After Erigon publishes an official image containing #20298, you can skip this step and use the
+After an official Erigon `v3.5` or later image is published, you can skip this step and use the
 official release image in the compose file instead.
 
 ### Step 2. Download the Linea node example config
@@ -104,7 +104,7 @@ published Erigon image, for example `erigontech/erigon:2.61.0`.
 
 :::warning
 
-Until Erigon publishes an official image containing #20298, do not use the Erigon image tag already
+Until an official Erigon `v3.5` or later image is published, do not use the Erigon image tag already
 set in the monorepo compose file. Replace the Erigon image in both `erigon-init` and `erigon-node`
 with the local image you built in Step 1.
 
@@ -130,7 +130,7 @@ erigon-init:
     - --datadir=/home/erigon/.local/share/erigon
 ```
 
-When Erigon publishes an official image containing #20298, replace `erigon-linea:pr-20298` with the
+When an official Erigon `v3.5` or later image is published, replace `erigon-linea:pr-20298` with the
 official release image tag.
 
 ### Step 4. Start the Erigon node
@@ -149,7 +149,7 @@ node.
 ## Alternative: Run using the binary distribution
 
 :::info
-Until Erigon publishes an official release containing #20298, use a binary built from the
+Until an official Erigon `v3.5` or later release is published, use a binary built from the
 [#20298 merge commit](https://github.com/erigontech/erigon/pull/20298) rather than a published
 release binary. Ensure you review
 [Erigon's software prerequisites](https://erigon.gitbook.io/erigon/basic-usage/getting-started#software-prerequisites)

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -36,7 +36,7 @@ to Linea-specific features.
     </tr>
     <tr>
       <td>[Erigon](./erigon.mdx)</td>
-      <td>A Go-based Ethereum client focused on performance and saving disk space. Until an official Erigon release containing the Linea support change is available, build the image from the Linea support merge commit.</td>
+      <td>A Go-based Ethereum client focused on performance and saving disk space. Until a published Erigon `v3.5` or later image is available, build the image from the Linea support merge commit.</td>
       <td>❌</td>
     </tr>
   </tbody>
@@ -60,8 +60,8 @@ Quick steps:
 Next actions:
 - Default compose examples: [Linea Besu](./linea-besu.mdx) and [Maru](./maru.mdx).
 - Alternative EL clients: [Besu](./besu.mdx), [Geth](./geth.mdx), or [Erigon](./erigon.mdx) to follow the chain.
-  Erigon currently requires a locally built image until an official release containing the Linea
-  support change is available.
+  Erigon currently requires a locally built image until a published Erigon `v3.5` or later release is
+  available.
 - Upgrades: see [upgrade guides](./beta-v4-migration.mdx).
 - Bootnodes: see [bootnodes](./bootnodes.mdx) if you need to override defaults.
 

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -34,6 +34,11 @@ to Linea-specific features.
       <td>The most widely used open-source Ethereum client, written in Go.</td>
       <td>❌</td>
     </tr>
+    <tr>
+      <td>[Erigon](./erigon.mdx)</td>
+      <td>A Go-based Ethereum client focused on performance and saving disk space. Until Erigon `v3.5` is published, build the image from the Linea support merge commit.</td>
+      <td>❌</td>
+    </tr>
   </tbody>
 </table>
 
@@ -54,7 +59,9 @@ Quick steps:
 
 Next actions:
 - Default compose examples: [Linea Besu](./linea-besu.mdx) and [Maru](./maru.mdx).
-- Alternative EL clients: [Besu](./besu.mdx) or [Geth](./geth.mdx) to follow the chain.
+- Alternative EL clients: [Besu](./besu.mdx), [Geth](./geth.mdx), or [Erigon](./erigon.mdx) to follow the chain.
+  Erigon currently requires a locally built image until its Linea support lands in a published
+  `v3.5` or later release.
 - Upgrades: see [upgrade guides](./beta-v4-migration.mdx).
 - Bootnodes: see [bootnodes](./bootnodes.mdx) if you need to override defaults.
 

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -36,7 +36,7 @@ to Linea-specific features.
     </tr>
     <tr>
       <td>[Erigon](./erigon.mdx)</td>
-      <td>A Go-based Ethereum client focused on performance and saving disk space. Until Erigon `v3.5` is published, build the image from the Linea support merge commit.</td>
+      <td>A Go-based Ethereum client focused on performance and saving disk space. Until an official Erigon release containing the Linea support change is available, build the image from the Linea support merge commit.</td>
       <td>❌</td>
     </tr>
   </tbody>
@@ -60,8 +60,8 @@ Quick steps:
 Next actions:
 - Default compose examples: [Linea Besu](./linea-besu.mdx) and [Maru](./maru.mdx).
 - Alternative EL clients: [Besu](./besu.mdx), [Geth](./geth.mdx), or [Erigon](./erigon.mdx) to follow the chain.
-  Erigon currently requires a locally built image until its Linea support lands in a published
-  `v3.5` or later release.
+  Erigon currently requires a locally built image until an official release containing the Linea
+  support change is available.
 - Upgrades: see [upgrade guides](./beta-v4-migration.mdx).
 - Bootnodes: see [bootnodes](./bootnodes.mdx) if you need to override defaults.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -139,9 +139,9 @@ const sidebars = {
             "network/how-to/run-a-node/maru",
             "network/how-to/run-a-node/besu",
             "network/how-to/run-a-node/geth",
+            "network/how-to/run-a-node/erigon",
             "network/how-to/run-a-node/bootnodes",
             "network/how-to/run-a-node/beta-v4-migration",
-            "network/how-to/run-a-node/erigon",
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Restore the Erigon run-a-node page and add it back under Geth in the sidebar
- Make Docker the primary path and document the temporary build-from-Erigon-PR-20298 flow until v3.5 is released
- Point users to the Linea monorepo compose example and Geth genesis file, with explicit Erigon image/datadir edits

## Verification
- ./node_modules/.bin/docusaurus build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to node setup guides and navigation; no application or protocol code.
> 
> **Overview**
> **Restores the Erigon run-a-node guide** as a listed doc (no longer maintenance/unlisted) and places it **after Geth** in the sidebar, with small **sidebar_position** tweaks on bootnodes and network upgrades.
> 
> The Erigon page is **rewritten around Docker Compose** using the Linea monorepo `docs/getting-started` examples: copy **`geth-genesis.json`** to **`genesis.json`**, override **`erigon-init` / `erigon-node`** images with a **locally built** `erigon-linea:pr-20298` from [erigon#20298](https://github.com/erigontech/erigon/pull/20298) until **Erigon v3.5+** ships, and align **`erigon-init` `--datadir`** with the compose volume. The **binary path** is kept as an alternative with the same build-from-merge-commit flow and monorepo genesis links (replacing old static `/files/erigon` downloads).
> 
> The **run-a-node index** adds Erigon to the client table and “alternative EL clients,” noting the temporary custom image requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b91736009ababbb6cb0a6314c76c8092cb9f6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->