### PR TITLE
fix: avoid node size data file race

### DIFF
--- a/scripts/fetchNodeSize.js
+++ b/scripts/fetchNodeSize.js
@@ -128,9 +128,12 @@ const fetchData = async () => {
   const dataFilePath = path.join(__dirname, "../linea-node-size/data.json");
   let existingData = {};
 
-  if (fs.existsSync(dataFilePath)) {
-    const fileContent = fs.readFileSync(dataFilePath, "utf8");
-    existingData = JSON.parse(fileContent);
+  try {
+    existingData = JSON.parse(fs.readFileSync(dataFilePath, "utf8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
   }
 
   const currentDate = new Date();
@@ -144,7 +147,9 @@ const fetchData = async () => {
   existingData[currentYear][currentWeek] = results;
 
   console.log(`Writing results to ${dataFilePath}`);
-  fs.writeFileSync(dataFilePath, JSON.stringify(existingData, null, 2));
+  const tempDataFilePath = `${dataFilePath}.tmp`;
+  fs.writeFileSync(tempDataFilePath, JSON.stringify(existingData, null, 2));
+  fs.renameSync(tempDataFilePath, dataFilePath);
   console.log("Node size data fetched and saved.");
 };
 


### PR DESCRIPTION
Fixes Consensys/Linea-Security-Reports#7.

Changes:
- Removes the existsSync/readFileSync check-then-use pattern.
- Treats only ENOENT as empty prior data.
- Writes through a temporary file and renames into place.

Verification:
- rg "existsSync\\(dataFilePath\\)" scripts/fetchNodeSize.js returned no matches
- npm run lint:js
- npm run typecheck
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to a weekly metrics fetch script’s file I/O; no auth, API, or runtime service behavior changes.
> 
> **Overview**
> Hardens how `scripts/fetchNodeSize.js` loads and saves `linea-node-size/data.json` so concurrent or overlapping runs are less likely to corrupt or lose data.
> 
> **Read path:** Drops `existsSync` plus conditional `readFileSync`. It always attempts to parse the file; only a missing file (`ENOENT`) is treated as “no prior data,” and other read/parse errors still fail the job.
> 
> **Write path:** Persists JSON to `data.json.tmp`, then **`renameSync`** into `data.json` so consumers do not see a half-written file mid-update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476fb30fcc15c4adee5c53b29dd655e24b6adab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->