### PR TITLE
fix: avoid regex backtracking in feedback sanitization

### DIFF
--- a/api/feedback-sanitize.test.js
+++ b/api/feedback-sanitize.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("removes HTML tags without regex backtracking", async () => {
+  const { sanitizeFeedbackText } = await import("./feedback-sanitize.ts");
+  const input = `${"<".repeat(5000)}>slow</b>`;
+
+  const result = sanitizeFeedbackText(input);
+
+  assert.equal(result.includes("<"), false);
+  assert.equal(result.includes(">"), false);
+  assert.ok(result.length <= 1000);
+});
+
+test("keeps existing markdown and mention sanitization", async () => {
+  const { sanitizeFeedbackText } = await import("./feedback-sanitize.ts");
+  const result = sanitizeFeedbackText(
+    "See [docs](https://docs.linea.build) ![alt](https://example.com/a.png) @team #123",
+  );
+
+  assert.equal(result, "See docs alt @\u200Bteam #\u200B123");
+});

--- a/api/feedback-sanitize.test.js
+++ b/api/feedback-sanitize.test.js
@@ -1,15 +1,21 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-test("removes HTML tags without regex backtracking", async () => {
+test("removes complete HTML tags", async () => {
   const { sanitizeFeedbackText } = await import("./feedback-sanitize.ts");
-  const input = `${"<".repeat(5000)}>slow</b>`;
+
+  const result = sanitizeFeedbackText("Hello <strong>docs</strong> team");
+
+  assert.equal(result, "Hello docs team");
+});
+
+test("caps pathological angle bracket input without regex backtracking", async () => {
+  const { sanitizeFeedbackText } = await import("./feedback-sanitize.ts");
+  const input = "<".repeat(5000);
 
   const result = sanitizeFeedbackText(input);
 
-  assert.equal(result.includes("<"), false);
-  assert.equal(result.includes(">"), false);
-  assert.ok(result.length <= 1000);
+  assert.equal(result, "<".repeat(1000));
 });
 
 test("keeps existing markdown and mention sanitization", async () => {
@@ -19,4 +25,12 @@ test("keeps existing markdown and mention sanitization", async () => {
   );
 
   assert.equal(result, "See docs alt @\u200Bteam #\u200B123");
+});
+
+test("preserves feedback after an unclosed angle bracket", async () => {
+  const { sanitizeFeedbackText } = await import("./feedback-sanitize.ts");
+
+  const result = sanitizeFeedbackText("<Sidebar breaks on mobile");
+
+  assert.equal(result, "<Sidebar breaks on mobile");
 });

--- a/api/feedback-sanitize.ts
+++ b/api/feedback-sanitize.ts
@@ -1,0 +1,36 @@
+const MAX_REASON_LENGTH = 1000;
+
+function stripHtmlTags(text: string): string {
+  let result = "";
+  let insideTag = false;
+
+  for (const char of text) {
+    if (char === "<") {
+      insideTag = true;
+      continue;
+    }
+
+    if (char === ">") {
+      insideTag = false;
+      continue;
+    }
+
+    if (!insideTag) {
+      result += char;
+    }
+  }
+
+  return result;
+}
+
+export function sanitizeFeedbackText(text: string): string {
+  const cappedText = text.slice(0, MAX_REASON_LENGTH);
+
+  return stripHtmlTags(cappedText)
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // strip markdown images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // strip markdown links
+    .replace(/@/g, "@\u200B") // break GitHub @mentions
+    .replace(/#(\d)/g, "#\u200B$1") // break GitHub #issue references
+    .slice(0, MAX_REASON_LENGTH)
+    .trim();
+}

--- a/api/feedback-sanitize.ts
+++ b/api/feedback-sanitize.ts
@@ -2,22 +2,21 @@ const MAX_REASON_LENGTH = 1000;
 
 function stripHtmlTags(text: string): string {
   let result = "";
-  let insideTag = false;
+  let cursor = 0;
 
-  for (const char of text) {
-    if (char === "<") {
-      insideTag = true;
-      continue;
+  while (cursor < text.length) {
+    const tagStart = text.indexOf("<", cursor);
+    if (tagStart === -1) {
+      return result + text.slice(cursor);
     }
 
-    if (char === ">") {
-      insideTag = false;
-      continue;
+    const tagEnd = text.indexOf(">", tagStart + 1);
+    if (tagEnd === -1) {
+      return result + text.slice(cursor);
     }
 
-    if (!insideTag) {
-      result += char;
-    }
+    result += text.slice(cursor, tagStart);
+    cursor = tagEnd + 1;
   }
 
   return result;

--- a/api/feedback.ts
+++ b/api/feedback.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { sheets } from "@googleapis/sheets";
 import { GoogleAuth } from "google-auth-library";
+import { sanitizeFeedbackText } from "./feedback-sanitize";
 
 // ---------- Types ----------
 
@@ -9,28 +10,6 @@ interface FeedbackBody {
   rating: "yes" | "no";
   reason?: string;
   timestamp?: string;
-}
-
-// ---------- Sanitize ----------
-
-function stripHtml(text: string): string {
-  let prev = text;
-  // Loop to handle nested tags like <<script>script>
-  while (true) {
-    const next = prev.replace(/<[^>]*>/g, "");
-    if (next === prev) return next;
-    prev = next;
-  }
-}
-
-function sanitize(text: string): string {
-  return stripHtml(text)
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // strip markdown images
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // strip markdown links
-    .replace(/@/g, "@\u200B") // break GitHub @mentions
-    .replace(/#(\d)/g, "#\u200B$1") // break GitHub #issue references
-    .slice(0, 1000)
-    .trim();
 }
 
 function isValidPageUrl(url: string): boolean {
@@ -160,7 +139,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: "invalid page_url" });
   }
 
-  const cleanReason = reason ? sanitize(reason) : "";
+  const cleanReason = reason ? sanitizeFeedbackText(reason) : "";
 
   if (rating === "no" && !cleanReason) {
     return res


### PR DESCRIPTION
Fixes Consensys/Linea-Security-Reports#24.

Changes:
- Moves feedback reason sanitization into a small helper.
- Caps input before sanitization.
- Replaces the polynomial HTML-stripping regex with deterministic tag stripping.

Verification:
- node --test api/feedback-sanitize.test.js
- npm run lint:js
- npm run typecheck
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to feedback text sanitization with tests; reduces DoS risk from regex backtracking without altering auth or storage flows.
> 
> **Overview**
> Refactors docs feedback **reason** sanitization into `sanitizeFeedbackText` in `api/feedback-sanitize.ts` and wires the feedback API handler to use it instead of inline helpers.
> 
> The main behavioral change is **HTML removal**: nested-tag stripping via a repeating `/<[^>]*>/g` regex is replaced with a linear scan that drops only balanced `<...>` segments and leaves text after an unclosed `<` intact. Input is **capped at 1000 characters before** sanitization (and again after), which limits work on pathological angle-bracket input. Existing markdown link/image stripping and GitHub `@` / `#` mention breaking are unchanged.
> 
> Adds `api/feedback-sanitize.test.js` covering tag removal, long `<` runs, markdown/mentions, and unclosed brackets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e5c3cd40fbf85edc46d52779e5919c6fbf45f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->