### PR TITLE
docs(stack): add RBAC feature page

### DIFF
--- a/docs/stack/features/index.mdx
+++ b/docs/stack/features/index.mdx
@@ -49,7 +49,7 @@ Using the Linea stack, you can deploy:
 A private validium configuration provides:
 
 - Offchain data availability: transaction data stored privately
-- RBAC: Role-Based Access Control (RBAC) for RPC and API endpoints
+- RBAC: [Role-based access control](./rbac.mdx) for RPC and API endpoints
 - Privacy: transaction details not visible on finalization layer
 - Compliance: Selective data disclosure
 - API portal: controlled access to network functionality

--- a/docs/stack/features/rbac.mdx
+++ b/docs/stack/features/rbac.mdx
@@ -1,0 +1,82 @@
+---
+title: Role-based access control
+description: >-
+  Understand how RBAC controls access to protected Linea Stack RPC, API, and
+  tooling surfaces.
+sidebar_position: 5
+image: /img/socialCards/role-based-access-control.jpg
+---
+
+Role-based access control (RBAC) is an operator-configured access-control layer for Linea Stack
+deployments. It helps operators control who can use protected RPC endpoints, APIs, API portals, and
+related tooling surfaces.
+
+RBAC is especially relevant for [private validium](./validium.mdx) deployments, where operators may
+combine offchain data availability, controlled network membership, and selective disclosure to support
+privacy and compliance requirements.
+
+:::important
+
+RBAC is not cryptographic privacy. It controls access to protected services and data surfaces, but it
+does not make public-chain data private, replace zero-knowledge proofs, or provide data availability.
+
+:::
+
+## What RBAC controls
+
+In a Linea Stack deployment, RBAC can be used around operator-controlled access surfaces, including:
+
+- RPC endpoints that expose blockchain data or accept transactions
+- APIs and API portals used to manage or interact with the deployment
+- Explorer and tooling surfaces that show deployment data
+- Participant access to data in deployments where visibility is intentionally restricted
+
+The operator decides which surfaces are exposed, who can use them, and how access is granted for the
+deployment.
+
+## How RBAC fits with private validium
+
+In a public deployment, transaction data and public RPC access are generally designed for broad
+visibility. In a private validium deployment, transaction data may be kept offchain, and access to
+network functionality may be restricted.
+
+RBAC is one part of that controlled-access model. It can help limit access to RPC endpoints, APIs,
+API portals, and related tooling. It works alongside other deployment choices such as private data
+availability, network isolation, key management, and operator procedures.
+
+RBAC does not change the proof system. Valid state transitions are still proved using
+zero-knowledge proofs and finalized on the selected finalization layer. RBAC affects which protected
+surfaces and data a participant can access.
+
+## Visibility and verification
+
+RBAC affects what a participant can observe through protected interfaces. In validium or RBAC
+deployments, participants can inspect transactions, blocks, state, or data only to the extent that
+the deployment gives them the relevant access and data.
+
+This is a deployment trust boundary. A participant may be able to verify proof validity on the
+finalization layer while still depending on the operator-controlled data access model to inspect
+private transaction data or reconstruct full history.
+
+For the broader trust model, see [Trust model](../how-it-works/trust-model.mdx).
+
+## Limitations
+
+RBAC should be described with these limits:
+
+- RBAC does not encrypt data or hide data that is published to a public chain or finalization layer.
+- RBAC does not replace private data availability, data-retention, or selective-disclosure design.
+- RBAC does not replace zero-knowledge proof verification, governance, admin-key security, key
+  management, monitoring, or incident response.
+- RBAC does not guarantee that every participant can verify full state or history. Verification
+  depends on the deployment model, available data, and participant access.
+
+## Related docs
+
+- [Privacy](./validium.mdx): how private validium deployments use offchain data availability and
+  controlled access.
+- [Security](./security.mdx): how RBAC fits into operational security controls.
+- [Deployment models](../how-it-works/deployment-models.mdx): how access control factors into
+  deployment design.
+- [RPC services](../../protocol/architecture/rpc-services.mdx): how RPC services expose blockchain
+  data and can sit behind access controls.

--- a/docs/stack/features/rbac.mdx
+++ b/docs/stack/features/rbac.mdx
@@ -36,9 +36,9 @@ deployment.
 
 ## How RBAC fits with private validium
 
-In a public deployment, transaction data and public RPC access are generally designed for broad
-visibility. In a private validium deployment, transaction data may be kept offchain, and access to
-network functionality may be restricted.
+In a public deployment, transaction data is designed for broad visibility, and public RPC access is
+designed for broad availability. In a private validium deployment, transaction data may be kept
+offchain, and access to network functionality may be restricted.
 
 RBAC is one part of that controlled-access model. It can help limit access to RPC endpoints, APIs,
 API portals, and related tooling. It works alongside other deployment choices such as private data

--- a/docs/stack/features/rbac.mdx
+++ b/docs/stack/features/rbac.mdx
@@ -44,19 +44,16 @@ RBAC is one part of that controlled-access model. It can help limit access to RP
 API portals, and related tooling. It works alongside other deployment choices such as private data
 availability, network isolation, key management, and operator procedures.
 
-RBAC does not change the proof system. Valid state transitions are still proved using
-zero-knowledge proofs and finalized on the selected finalization layer. RBAC affects which protected
-surfaces and data a participant can access.
+RBAC determines which protected interfaces and data a participant can access. In deployments that
+use RBAC, the operator defines those access rules and can change them as part of operating the
+deployment.
 
 ## Visibility and verification
 
-RBAC affects what a participant can observe through protected interfaces. In validium or RBAC
-deployments, participants can inspect transactions, blocks, state, or data only to the extent that
-the deployment gives them the relevant access and data.
-
-This is a deployment trust boundary. A participant may be able to verify proof validity on the
-finalization layer while still depending on the operator-controlled data access model to inspect
-private transaction data or reconstruct full history.
+Participants can still verify proof validity on the finalization layer. For transactions, blocks,
+or state they are authorized to access, they may also verify that data against posted state roots
+using the deployment's available data. RBAC does not change the proof system; it changes which
+protected data and interfaces a participant can access.
 
 For the broader trust model, see [Trust model](../how-it-works/trust-model.mdx).
 

--- a/docs/stack/features/security.mdx
+++ b/docs/stack/features/security.mdx
@@ -25,6 +25,6 @@ The Linea protocol offers certain security guarantees:
 Operators retain full control over their secure boundaries:
 
 - Infrastructure isolation and network security controls
-- Role-Based Access Control (RBAC) for APIs and services
+- [Role-based access control (RBAC)](./rbac.mdx) for APIs and services
 - Secure key management via KMS-backed signing and remote signing through [Web3Signer](../../protocol/architecture#web3signer)
 - Monitoring and incident response tooling

--- a/docs/stack/features/validium.mdx
+++ b/docs/stack/features/validium.mdx
@@ -33,7 +33,7 @@ privacy while maintaining cryptographic guarantees.
 
 ### Role-based access control
 
-Role-Based Access Control (RBAC) controls access to network functionality:
+[Role-based access control (RBAC)](./rbac.mdx) controls access to network functionality:
 
 - RPC endpoints: Access controlled by API keys and permissions
 - API portal: Institution-level access controls

--- a/docs/stack/how-it-works/deployment-models.mdx
+++ b/docs/stack/how-it-works/deployment-models.mdx
@@ -31,7 +31,7 @@ Consider these factors when configuring your deployment model design:
 - Regulatory compliance: Do you need KYC/KYT controls and selective disclosure?
 - Data availability guarantees: How important are onchain data availability guarantees?
 - Network topology: Do you need a private network with controlled membership?
-- Access control: Do you need RBAC on RPC endpoints and APIs?
+- Access control: Do you need [RBAC](../features/rbac.mdx) on RPC endpoints and APIs?
 
 ## Compare deployment models
 
@@ -57,7 +57,7 @@ Public deployments such as Linea Mainnet are fully public networks with onchain 
 ### Security considerations
 
 - Minimum node count: 4 nodes for Quorum-Based Byzantine Fault Tolerance (QBFT) fault tolerance
-- Access controls: Whether or not to implement RBAC on RPC endpoints
+- Access controls: Whether or not to implement [RBAC](../features/rbac.mdx) on RPC endpoints
 - [Key management](../../protocol/architecture/index.mdx#web3signer): remote signing backed by a hardware
   security module (HSM) or key management service (KMS)
 
@@ -71,7 +71,7 @@ financial institutions requiring privacy.
 
 - Data availability: Transaction data can be stored offchain in a private node set
 - Privacy: Transaction details not visible on the finalization layer
-- Access control: RPC endpoints protected by Role-Based Access Control (RBAC); only authorized
+- Access control: RPC endpoints protected by Role-Based Access Control ([RBAC](../features/rbac.mdx)); only authorized
   participants can view data
 - [Finalization](../../network/overview/transaction-finality.mdx): State commitments and proofs
   posted to the finalization layer
@@ -90,7 +90,7 @@ privacy, compliance, and access control features:
 ### Security considerations
 
 - Minimum node count: 4 Maru nodes for QBFT fault tolerance
-- Access controls: RBAC on RPC endpoints and API portal
+- Access controls: [RBAC](../features/rbac.mdx) on RPC endpoints and API portal
 - [Key management](../../protocol/architecture/index.mdx#web3signer): remote signing backed by a
   hardware security module (HSM) or key management service (KMS)
 - Network isolation: Private network topology with controlled peering

--- a/docs/stack/how-it-works/trust-model.mdx
+++ b/docs/stack/how-it-works/trust-model.mdx
@@ -19,7 +19,7 @@ In this page, **operator** means the entity or consortium responsible for deploy
 
 | Component | Operated by | Can do unilaterally | Cannot do | Independently verifiable by participants |
 | --- | --- | --- | --- | --- |
-| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state, since invalid blocks fail proof verification | Public rollup block contents and ordering by running a full or archive node; in validium or RBAC deployments, transactions or blocks only to the extent participants have the relevant data and access |
+| Sequencer | Operator | Order, delay, or omit transactions within a block | Forge state, since invalid blocks fail proof verification | Public rollup block contents and ordering by running a full or archive node; in validium or [RBAC](../features/rbac.mdx) deployments, transactions or blocks only to the extent participants have the relevant data and access |
 | Prover | Operator | Stall proof generation, halting finalization | Produce a valid proof for an invalid state transition | Proof verification by reading the verifier contract on the finalization layer |
 | Coordinator | Operator | Stall the pipeline that conflates blocks, requests proofs, and submits them to the finalization layer | Modify state independently of the sequencer or prover | Submission events on the finalization layer |
 | Data availability (rollup) | Ethereum | N/A | Withhold data, since DA is on L1 as EIP-4844 blobs | State reconstruction from L1 blobs |
@@ -27,7 +27,7 @@ In this page, **operator** means the entity or consortium responsible for deploy
 | Canonical bridge (to Ethereum / Linea-anchored chain) | Operator (admin keys) + protocol (proofs) | Pause bridging via pause roles; upgrade contracts through the proxy upgrade path | In the normal protocol path, process unproved messages, since messages are tied to verified state transitions | Bridge events, proof verification, role assignments, proxy admin, and implementation addresses on the finalization layer |
 | Trusted bridge (to private or non-anchored chain) | Operator (admin keys) + trusted relayer | Pause bridging; relayer can withhold or delay messages | In the normal relayer path, process messages that are not signed over source-chain events | Bridge events on each side; no shared proof, so verifiability depends on trust in the relayer, its keys, and the bridge upgrade/admin model |
 | System contracts | Operator (role holders) + proxy upgrade authority | Pause, change verifier address, change rate limits, and upgrade contracts through the proxy upgrade path | Bypass role gating in the deployed implementation, since privileged functions are role-gated | Role assignments, contract state, proxy admin, and implementation addresses on the finalization layer |
-| Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, subject to the deployment's data access model; not every participant in a validium or RBAC deployment necessarily runs a full or archive node |
+| Participant nodes | Each participant | Read state visible to them, broadcast transactions | Modify network state | Their own observed state, subject to the deployment's data access model; not every participant in a validium or [RBAC](../features/rbac.mdx) deployment necessarily runs a full or archive node |
 
 ## Admin keys and upgrade authority
 
@@ -71,7 +71,7 @@ A private validium on Linea Mainnet inherits Linea Mainnet's trust assumptions i
 | Sequencer halt | Block production stops; pending transactions not included | Operator restart or failover to redundant sequencer infrastructure. In distributed sequencing or validator consensus deployments, recovery follows the configured QBFT or validator process. |
 | Prover stall | Proofs not generated; finalization stops; soft-finalized blocks remain on L2 but not finalized to the finalization layer | Operator restart or failover to an alternate prover instance where deployed |
 | Coordinator stall | Submission to the finalization layer stops; same effect as prover stall downstream | Operator restart or failover to an alternate coordinator instance where deployed |
-| DA withhold (validium) | Participants without the required DA or RBAC access cannot reconstruct or verify affected private data | Operator-defined wind-down procedure; depends on consortium agreement and is not protocol-enforced |
+| DA withhold (validium) | Participants without the required DA or [RBAC](../features/rbac.mdx) access cannot reconstruct or verify affected private data | Operator-defined wind-down procedure; depends on consortium agreement and is not protocol-enforced |
 | Finality layer reorg | Affects depth of finality on the selected finalization layer | Wait for the required finality depth on the selected finalization layer |
 | Admin key compromise | Compromised role can act within its scope until revoked; `DEFAULT_ADMIN_ROLE` compromise affects all roles | Revoke or rotate compromised authority through the deployment's governance or multisig process; use emergency pause roles where available |
 
@@ -93,12 +93,12 @@ The set of guarantees a participant can verify *without* trusting the operator d
 - Transactions or blocks they are authorized to access, using the relevant data and [Merkle proofs](/protocol/architecture/state-manager#merkle-trees) against posted state roots. This does not by itself establish global transaction ordering for participants who do not have access to the full ordered data set.
 - Bridge events on L1.
 - Their own observed state, by running a node or using an authorized interface where the deployment grants access.
-- They cannot reconstruct full state or history without the required operator DA access. This is the validium trade-off, and RBAC settings may further limit which data each participant can observe.
+- They cannot reconstruct full state or history without the required operator DA access. This is the validium trade-off, and [RBAC](../features/rbac.mdx) settings may further limit which data each participant can observe.
 
 **Private validium on Linea Mainnet**
 
 - Proof validity and state-transition correctness, by reading the verifier contract on Linea Mainnet. A valid proof means the operator cannot finalize an invalid state transition through the normal proof path.
-- Same validium and RBAC caveats as private validium on Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
+- Same validium and [RBAC](../features/rbac.mdx) caveats as private validium on Ethereum, but proofs are verified on Linea Mainnet (which is itself proved to Ethereum).
 - Verifying the chain end-to-end requires verifying both the private validium proof on Linea Mainnet and Linea Mainnet's proofs on Ethereum.
 
 ## See also

--- a/sidebars.js
+++ b/sidebars.js
@@ -448,6 +448,7 @@ const sidebars = {
           label: "Instant finality",
         },
         "stack/features/security",
+        "stack/features/rbac",
         {
           type: "doc",
           id: "stack/features/validium",


### PR DESCRIPTION
## Summary
- Added a dedicated Linea Stack RBAC feature page covering protected RPC, API, portal, and tooling access surfaces.
- Clarified how RBAC fits private validium deployments, visibility, verification, and operator trust boundaries.
- Linked existing Stack feature pages to the new RBAC page and added it to the Stack sidebar.

## Test Plan
- [x] npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds a dedicated **Role-based access control** feature doc for Linea Stack and wires it into navigation and cross-links.
> 
> The new `rbac.mdx` page explains operator-controlled access to protected RPC, APIs, portals, and tooling; how that fits **private validium** and visibility/trust boundaries; and explicit **limitations** (not cryptographic privacy, not a substitute for DA or ZK verification). **Features index**, **Security**, and **Privacy (validium)** now link to `./rbac.mdx` instead of inline RBAC text, and `sidebars.js` lists `stack/features/rbac` under Stack → Features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09813f7fcde30584313dbb1565f43d12d5acd083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->