### PR TITLE
Add agent discovery API catalog

### DIFF
--- a/scripts/agent-docs/discovery.test.js
+++ b/scripts/agent-docs/discovery.test.js
@@ -1,0 +1,102 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.join(__dirname, "../..");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, filePath), "utf8"));
+}
+
+function getHeaderConfig(source) {
+  const vercel = readJson("vercel.json");
+  return vercel.headers.find((header) => header.source === source);
+}
+
+function getRouteConfig(source) {
+  const vercel = readJson("vercel.json");
+  return vercel.routes.find((route) => route.src === source);
+}
+
+function getHeaderValue(source, key) {
+  const headerConfig = getHeaderConfig(source);
+  assert.ok(headerConfig, `${source} header config is missing`);
+  const header = headerConfig.headers.find((item) => item.key === key);
+  assert.ok(header, `${source} is missing ${key}`);
+  return header.value;
+}
+
+test("api catalog is a valid linkset for public Linea APIs", () => {
+  const catalog = readJson("static/.well-known/api-catalog");
+  assert.ok(Array.isArray(catalog.linkset), "catalog.linkset must be an array");
+
+  const entriesByAnchor = new Map(
+    catalog.linkset.map((entry) => [entry.anchor, entry]),
+  );
+
+  for (const anchor of [
+    "https://rpc.linea.build/",
+    "https://rpc.sepolia.linea.build/",
+    "https://token-api.linea.build/tokens",
+  ]) {
+    const entry = entriesByAnchor.get(anchor);
+    assert.ok(entry, `${anchor} is missing from the API catalog`);
+    assert.ok(
+      Array.isArray(entry["service-doc"]) && entry["service-doc"].length > 0,
+      `${anchor} must include at least one service-doc link`,
+    );
+    assert.ok(
+      Array.isArray(entry.status) && entry.status.length > 0,
+      `${anchor} must include a status link`,
+    );
+  }
+
+  const tokenApi = entriesByAnchor.get("https://token-api.linea.build/tokens");
+  assert.deepEqual(tokenApi["service-desc"], [
+    {
+      href: "https://token-api.linea.build/docs-yaml",
+      type: "text/yaml",
+    },
+  ]);
+});
+
+test("vercel advertises agent discovery resources with Link headers", () => {
+  const homepageLink = getHeaderValue("/", "Link");
+  assert.match(homepageLink, /<[^>]*api-catalog>/);
+  assert.match(homepageLink, /rel="api-catalog"/);
+  assert.ok(homepageLink.includes('type="application/linkset+json"'));
+  assert.match(homepageLink, /<[^>]*llms\.txt>/);
+  assert.ok(homepageLink.includes('type="text/plain"'));
+
+  const catalogContentType = getHeaderValue(
+    "/.well-known/api-catalog",
+    "Content-Type",
+  );
+  assert.equal(
+    catalogContentType,
+    'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+  );
+
+  const catalogLink = getHeaderValue("/.well-known/api-catalog", "Link");
+  assert.match(catalogLink, /<[^>]*api-catalog>/);
+  assert.match(catalogLink, /rel="api-catalog"/);
+
+  const homepageMarkdownRoute = getRouteConfig("^/$");
+  assert.ok(homepageMarkdownRoute, "homepage Markdown route is missing");
+  assert.match(homepageMarkdownRoute.headers.Link, /<[^>]*api-catalog>/);
+  assert.match(homepageMarkdownRoute.headers.Link, /<[^>]*llms\.txt>/);
+});
+
+test("markdown negotiation does not rewrite well-known discovery endpoints", () => {
+  const vercel = readJson("vercel.json");
+  const markdownRoute = vercel.routes.find((route) => route.dest === "/$1.md");
+  assert.ok(markdownRoute, "Markdown negotiation route is missing");
+
+  const markdownRoutePattern = new RegExp(markdownRoute.src);
+  assert.equal(
+    markdownRoutePattern.test("/network/overview/public-data"),
+    true,
+  );
+  assert.equal(markdownRoutePattern.test("/.well-known/api-catalog"), false);
+});

--- a/scripts/agent-docs/verify-preview.js
+++ b/scripts/agent-docs/verify-preview.js
@@ -16,6 +16,11 @@ const EXPECTED_NEGOTIATED_MARKDOWN_HEADERS = new Map([
   ["referrer-policy", "strict-origin-when-cross-origin"],
   ["permissions-policy", "camera=(), microphone=(), geolocation=()"],
 ]);
+const EXPECTED_API_CATALOG_ANCHORS = [
+  "https://rpc.linea.build/",
+  "https://rpc.sepolia.linea.build/",
+  "https://token-api.linea.build/tokens",
+];
 
 function buildUrl(pathname) {
   return new URL(pathname, baseUrl).toString();
@@ -66,7 +71,61 @@ function assertExpectedHeaders(label, result, expectedHeaders) {
   }
 }
 
+function assertApiCatalog(label, result) {
+  assert(result.ok, `${label} returned HTTP ${result.status}`);
+  assert(
+    result.contentType.includes("application/linkset+json"),
+    `${label} returned ${result.contentType || "no content-type"}`,
+  );
+
+  let catalog;
+  try {
+    catalog = JSON.parse(result.text);
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${error.message}`);
+  }
+
+  assert(Array.isArray(catalog.linkset), `${label} is missing linkset[]`);
+  const anchors = new Set(catalog.linkset.map((entry) => entry.anchor));
+  for (const anchor of EXPECTED_API_CATALOG_ANCHORS) {
+    assert(anchors.has(anchor), `${label} is missing ${anchor}`);
+  }
+}
+
 async function main() {
+  const homepage = await fetchText("/");
+  assert(homepage.ok, `/ returned HTTP ${homepage.status}`);
+  const homepageLink = homepage.headers.get("link") || "";
+  assert(
+    homepageLink.includes('rel="api-catalog"') &&
+      homepageLink.includes("/.well-known/api-catalog"),
+    "/ is missing the API catalog Link header",
+  );
+  assert(
+    homepageLink.includes("/llms.txt"),
+    "/ is missing the llms.txt Link header",
+  );
+
+  const apiCatalog = await fetchText("/.well-known/api-catalog");
+  assertApiCatalog("API catalog", apiCatalog);
+
+  const apiCatalogViaAccept = await fetchText("/.well-known/api-catalog", {
+    headers: { Accept: "text/markdown" },
+  });
+  assertApiCatalog("Accept: text/markdown API catalog", apiCatalogViaAccept);
+
+  const apiCatalogHead = await fetchText("/.well-known/api-catalog", {
+    method: "HEAD",
+  });
+  assert(
+    apiCatalogHead.ok,
+    `HEAD API catalog returned HTTP ${apiCatalogHead.status}`,
+  );
+  assert(
+    (apiCatalogHead.headers.get("link") || "").includes('rel="api-catalog"'),
+    "HEAD API catalog is missing the API catalog Link header",
+  );
+
   const publicDataViaAccept = await fetchText("/network/overview/public-data", {
     headers: { Accept: "text/markdown" },
   });

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,76 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://rpc.linea.build/",
+      "service-doc": [
+        {
+          "href": "https://docs.linea.build/api/reference",
+          "type": "text/html",
+          "title": "Linea JSON-RPC API reference"
+        },
+        {
+          "href": "https://docs.linea.build/api/reference.md",
+          "type": "text/markdown",
+          "title": "Linea JSON-RPC API reference in Markdown"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://linea.statuspage.io/api/v2/status.json",
+          "type": "application/json",
+          "title": "Linea network status"
+        }
+      ]
+    },
+    {
+      "anchor": "https://rpc.sepolia.linea.build/",
+      "service-doc": [
+        {
+          "href": "https://docs.linea.build/api/reference",
+          "type": "text/html",
+          "title": "Linea Sepolia JSON-RPC API reference"
+        },
+        {
+          "href": "https://docs.linea.build/api/reference.md",
+          "type": "text/markdown",
+          "title": "Linea Sepolia JSON-RPC API reference in Markdown"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://linea.statuspage.io/api/v2/status.json",
+          "type": "application/json",
+          "title": "Linea network status"
+        }
+      ]
+    },
+    {
+      "anchor": "https://token-api.linea.build/tokens",
+      "service-desc": [
+        {
+          "href": "https://token-api.linea.build/docs-yaml",
+          "type": "text/yaml"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://docs.linea.build/api/token-api/reference",
+          "type": "text/html",
+          "title": "Linea Token API reference"
+        },
+        {
+          "href": "https://docs.linea.build/api/token-api/reference.md",
+          "type": "text/markdown",
+          "title": "Linea Token API reference in Markdown"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://linea.statuspage.io/api/v2/status.json",
+          "type": "application/json",
+          "title": "Linea network status"
+        }
+      ]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,7 @@
         "Content-Type": "text/markdown; charset=utf-8",
         "X-Robots-Tag": "noindex",
         "Cache-Control": "public, max-age=300, must-revalidate",
+        "Link": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"; title=\"Linea API catalog\", </llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"Linea llms.txt\"",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "Referrer-Policy": "strict-origin-when-cross-origin",
@@ -18,7 +19,7 @@
       "dest": "/index.md"
     },
     {
-      "src": "^/((?!(?:search|404)/?$)(?!.*\\.(?:abi|css|gif|ico|jpg|jpeg|js|json|md|png|sol|svg|toml|txt|webp|woff|woff2|xml|yml|zip)$).+?)/?$",
+      "src": "^/((?!(?:search|404)/?$)(?!\\.well-known(?:/|$))(?!.*\\.(?:abi|css|gif|ico|jpg|jpeg|js|json|md|png|sol|svg|toml|txt|webp|woff|woff2|xml|yml|zip)$).+?)/?$",
       "has": [
         { "type": "header", "key": "accept", "value": ".*text/markdown.*" }
       ],
@@ -115,6 +116,24 @@
     {
       "source": "/",
       "headers": [
+        {
+          "key": "Link",
+          "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"; title=\"Linea API catalog\", </llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"Linea llms.txt\""
+        },
+        { "key": "Cache-Control", "value": "public, max-age=300, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/.well-known/api-catalog",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\""
+        },
+        {
+          "key": "Link",
+          "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"; title=\"Linea API catalog\""
+        },
         { "key": "Cache-Control", "value": "public, max-age=300, must-revalidate" }
       ]
     },


### PR DESCRIPTION
## Summary

Adds standards-based discovery hints for agents without adding experimental or fake metadata.

- Adds an RFC 9727-style API catalog at `/.well-known/api-catalog`.
- Adds HTTP `Link` response headers on `/` so agents can discover the API catalog and `llms.txt` from headers.
- Adds HTTP headers for `/.well-known/api-catalog`, including `application/linkset+json` content type and cache policy.
- Excludes `/.well-known/*` from `Accept: text/markdown` rewrites so discovery endpoints keep serving their own content.
- Extends local tests and preview verification for the new discovery behavior.

## API catalog contents

The catalog only advertises public, first-party Linea resources that already exist:

- `https://rpc.linea.build/` with links to the JSON-RPC API docs in HTML and Markdown.
- `https://rpc.sepolia.linea.build/` with links to the same JSON-RPC API docs in HTML and Markdown.
- `https://token-api.linea.build/tokens` with the Token API docs plus the existing OpenAPI YAML at `https://token-api.linea.build/docs-yaml`.
- `https://linea.statuspage.io/api/v2/status.json` as the status link for each catalog entry.

## Why

Recent audit flagged two concrete discovery gaps after the previous agent-docs work:

- no homepage HTTP `Link` headers for agent discovery;
- no `/.well-known/api-catalog` endpoint.

This keeps the fix narrow and standards-based. It does not add OAuth, MCP, DNS-AID, WebMCP, `auth.md`, or agent-skills metadata because those would imply products or auth flows we are not actually exposing from the docs site today.

## Test plan

- `npm run agent-docs:test`
- `npm run agent-docs:check`
- `npm run lint`
- `git diff --check`

Preview verification was also extended so Vercel can verify the deployed `Link` headers, API catalog content type, catalog anchors, and that `Accept: text/markdown` does not rewrite `/.well-known/api-catalog`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static discovery metadata and Vercel routing/header tweaks only; no auth, APIs, or application logic changes.
> 
> **Overview**
> Adds **standards-based agent discovery** on the docs site: an RFC 9727-style **`/.well-known/api-catalog`** linkset and **`Link`** headers on **`/`** pointing agents at the catalog and **`llms.txt`**.
> 
> The catalog advertises existing public Linea APIs (mainnet/Sepolia RPC and Token API) with doc links, Token API OpenAPI YAML via **`service-desc`**, and shared status URLs. **`vercel.json`** sets **`application/linkset+json`** (with RFC 9727 profile) and self-referential catalog **`Link`** headers on the catalog route, mirrors discovery **`Link`** on markdown-negotiated homepage responses, and **excludes `/.well-known/*` from `Accept: text/markdown` rewrites** so discovery JSON is not served as Markdown.
> 
> **`discovery.test.js`** locks catalog shape and Vercel header/route config; **`verify-preview.js`** checks deployed homepage/catalog headers, catalog anchors, and that markdown negotiation does not break the catalog endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84faa842fc0f8d62039cae53dd59a929fcde336f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->