### PR TITLE
Fix link to Erigon software prerequisites

### DIFF
--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -152,7 +152,7 @@ node.
 Until an official Erigon `v3.5` or later release is published, use a binary built from the
 [#20298 merge commit](https://github.com/erigontech/erigon/pull/20298) rather than a published
 release binary. Ensure you review
-[Erigon's software prerequisites](https://erigon.gitbook.io/erigon/basic-usage/getting-started#software-prerequisites)
+[Erigon's software prerequisites](https://docs.erigon.tech/get-started/hardware-requirements)
 before building the Erigon client.
 
 If you're not comfortable with installing the binary distribution, use [Docker](#run-using-docker)


### PR DESCRIPTION
Updated link to Erigon's software prerequisites in documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fix with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **Erigon binary install** callout in `erigon.mdx` so the “software prerequisites” link points to Erigon’s current docs site (`docs.erigon.tech` hardware requirements) instead of the retired GitBook “getting started” prerequisites URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7518a6849fb507f4725cd56f4da4b293c9e28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->