### PR TITLE
ci: pin GitHub Actions refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build docs
-        uses: Consensys/github-actions/docs-build@main
+        uses: Consensys/github-actions/docs-build@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Case check action
-        uses: ConsenSys/github-actions/docs-case-check@main
+        uses: Consensys/github-actions/docs-case-check@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08
         with:
           DOC_DIR: ${{ matrix.folder }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: LinkCheck
-        uses: Consensys/github-actions/docs-link-check@main
+        uses: Consensys/github-actions/docs-link-check@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08
         with:
           CONFIG_FILE: '.linkspector.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint code
-        uses: Consensys/github-actions/docs-lint-all@main
+        uses: Consensys/github-actions/docs-lint-all@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08
 
       - name: Lint markdown
-        uses: Consensys/github-actions/docs-lint-markdown@main
+        uses: Consensys/github-actions/docs-lint-markdown@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: LinkCheck
-        uses: ConsenSys/github-actions/docs-link-check@main
+        uses: Consensys/github-actions/docs-link-check@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08
         with:
           CONFIG_FILE: .linkspector.yml
 
@@ -31,7 +31,7 @@ jobs:
     permissions: {}   # zero scopes
     steps:
       - name: Slack Notification
-        uses: ConsenSys/github-actions/slack-notify@main
+        uses: Consensys/github-actions/slack-notify@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08
         with:
           SLACK_CHANNEL: doc-ci-alerts
           SLACK_COLOR: danger

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vale
-        uses: Consensys/github-actions/docs-spelling-check@main
+        uses: Consensys/github-actions/docs-spelling-check@8e207ec2ad53d90ab419d39d03084fa93e04d190 # main as of 2026-06-08


### PR DESCRIPTION
## Summary
- Pin docs workflow actions from `Consensys/github-actions` to a full commit SHA.
- Keep the MetaMask security scanner as a pinned reusable workflow.

## Note
The MetaMask security scanner reusable workflow is already pinned at the call site, but the current upstream workflow still contains nested unpinned refs like `actions/checkout@v4`. That needs to be fixed upstream in `MetaMask/action-security-code-scanner`; this PR intentionally does not copy the reusable workflow locally.

## Verification
- `git diff --check origin/main..HEAD`
- Parsed all `.github/workflows/*.yml` files with Ruby YAML.
- Build, link check, lint, spelling, Vercel, Socket, and Cursor checks pass.
- `security-scan / Setup` is still blocked by the upstream reusable workflow.