### PR TITLE
Add Linea support page

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -24,8 +24,8 @@ See something missing? Error in our documentation? [Create an issue](https://git
 Alternatively, help us improve our documentation! [Fork our repo](https://github.com/Consensys/doc.linea/fork),
 create a pull request, and tag us for review.
 
-Alternatively, get in touch via the [community forum](https://community.linea.build/) or the
-[support site](https://support.linea.build/) if you have an issue or question.
+Alternatively, get in touch via the [community forum](https://community.linea.build/) or
+[Linea Support](/support) if you have an issue or question.
 
 Please follow these steps if you wish to contribute:
 1. Make an issue describing the change you wish to make _before_ you start working on it, and

--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -617,7 +617,7 @@ limited to one per account and registering requires completion of [Proof of Huma
 As the system leverages CCIP Read, which enables L1 to trustlessly query the Linea Names registry
 through an offchain gateway, Linea Names domains resolve on L1.
 
-Read more about ENS in the user guide [here](https://support.linea.build/general/ens).
+For Linea Names support, see the [Linea support page](/support).
 
 **CCIP Read**
 

--- a/docs/network/build/get-testnet-eth.mdx
+++ b/docs/network/build/get-testnet-eth.mdx
@@ -13,12 +13,12 @@ is to use one of the many available faucets to drip testnet ETH directly to your
 ## MetaMask faucet
 
 The [MetaMask faucet](https://docs.metamask.io/developer-tools/faucet/) supports using Linea Names 
-domains, and using one guarantees you'll receive the full 0.5 ETH daily maximum. [Learn how to get a
-Linea Names domain](https://support.linea.build/explore/ens).
+domains, and using one guarantees you'll receive the full 0.5 ETH daily maximum. For help with
+Linea Names, see the [support page](/support).
 
 :::tip
 
-See our [support guide to getting a Linea Names domain](https://support.linea.build/explore/ens).
+For Linea Names help, see the [support page](/support).
 
 :::
 

--- a/docs/network/build/index.mdx
+++ b/docs/network/build/index.mdx
@@ -7,7 +7,7 @@ image: /img/socialCards/build-on-linea.jpg
 
 Welcome builders!
 
-If you don't find what you need, use the [support site](https://support.linea.build/) or share
+If you don't find what you need, use the [support page](/support) or share
 feedback in the [community forum](https://community.linea.build/c/feedback).
 
 :::important[Status]
@@ -20,4 +20,3 @@ feedback in the [community forum](https://community.linea.build/c/feedback).
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />
-

--- a/docs/network/build/launch-an-app/app.mdx
+++ b/docs/network/build/launch-an-app/app.mdx
@@ -472,7 +472,7 @@ This will allow you to track your changes.
 
 Firstly, run `npm run build` to build the app. This should surface any errors in your code that 
 may prevent it from being deployed. If you need help resolving any, use the
-[support site](https://support.linea.build/).
+[support page](/support).
 
 When you're ready, make sure you've staged your changes with `git add .` and then committed them:
 
@@ -510,7 +510,7 @@ display it in your app.
 ## Help and resources
 
 If you get stuck at any point in this guide, use the
-[support site](https://support.linea.build/).
+[support page](/support).
 
 - [MetaMask Embedded Wallets React SDK documentation](https://docs.metamask.io/embedded-wallets/sdk/react)
 - [Wagmi documentation](https://wagmi.sh/)

--- a/docs/network/build/launch-an-app/deploy.mdx
+++ b/docs/network/build/launch-an-app/deploy.mdx
@@ -270,7 +270,7 @@ interacting with the counter contract.
 ## Help and resources
 
 If you get stuck at any point in this guide, use the
-[support site](https://support.linea.build/).
+[support page](/support).
 
 - [Foundry documentation](https://book.getfoundry.sh/)
   - [Foundry CLI](https://book.getfoundry.sh/forge/)

--- a/docs/network/build/tools/cross-chain/ccip-read.mdx
+++ b/docs/network/build/tools/cross-chain/ccip-read.mdx
@@ -41,7 +41,7 @@ Read more about CCIP in the [Chainlink documentation](https://docs.chain.link/cc
 Linea Names allows Linea users to register human-readable domains for considerably 
 lower fees than on Ethereum Mainnet, it also leverages smart contracts with 
 considerable utility for developers by enabling CCIP Read. See the user guide 
-[here](https://support.linea.build/explore/ens).
+on the [support page](/support).
 
 The [Linea Names repository](https://github.com/Consensys/linea-ens) contains a 
 frontend and associated contracts for ENS to work on Linea, including 

--- a/docs/network/how-to/bridge.mdx
+++ b/docs/network/how-to/bridge.mdx
@@ -35,7 +35,7 @@ with the native bridge, but cost slightly more. In some cases, particularly when
 or bridging [USDC](#bridge-usdc), the native bridge is faster. See the section on [bridging timescales](#how-long-do-bridge-transfers-take) 
 for more information.
 
-For a guide on using the bridge aggregator and FAQs, see our [support guide](https://support.linea.build/bridging/how-to-bridge-to-linea).
+Use the instructions below for the bridge aggregator and native bridge.
 
 ## Native bridge
 
@@ -279,7 +279,7 @@ history will update accordingly:
 </div>
 
 If you encounter any issues, contact us via our
-[support site](https://support.linea.build/).
+[support page](/support).
 
 #### Configure claiming
 

--- a/docs/network/how-to/deploy-subdomain.mdx
+++ b/docs/network/how-to/deploy-subdomain.mdx
@@ -43,7 +43,7 @@ This includes using the Proof of Humanity (PoH) check for registering subdomains
 ### Deploy registrar contracts only 
 
 Deploy only your `Registrar` contracts while using the same `Registry` and `Resolver` contract
-addresses deployed for the `linea.eth` subdomain. Contact [Linea Support](https://support.linea.build/)
+addresses deployed for the `linea.eth` subdomain. Contact [Linea Support](/support)
 to gain ownership of an L1 domain on Linea. This solution allows you to deploy only the registrar contracts.
 
 ### Use ENS contracts 
@@ -63,7 +63,7 @@ The following contract addresses are live on Mainnet:
 | `LineaSparseProofVerifier` | `0x9a4b070A5A6C09C2d0f00309aC1613109A3F6b41` |
 | `L1Resolver` | `0x1507cE9421232FDBd302f5EbE4590F8D77FeBBFF` |
 
-For Sepolia, contact [Linea Support](https://support.linea.build/) for testnet addresses.
+For Sepolia, contact [Linea Support](/support) for testnet addresses.
 
 Modify the [original ENS contracts deployed on Ethereum Mainnet](https://github.com/ensdomains/ens-contracts).
 You must modify the node managed by the Registrar contract to match your domain's node. 

--- a/docs/network/how-to/migrate-dapp.mdx
+++ b/docs/network/how-to/migrate-dapp.mdx
@@ -63,4 +63,4 @@ See the [Lineascan guide](https://info.lineascan.build/how-to-update-token-info/
 
 The Linea site has a zip file of official Linea logos and icons [available for download](https://linea.build/assets),
 available as both PNGs and SVGs for use in your dapp. If you need some assets or media that aren't 
-covered here, please contact us via the [support site](https://support.linea.build/).
+covered here, please contact us via the [support page](/support).

--- a/docs/network/how-to/run-a-node/geth.mdx
+++ b/docs/network/how-to/run-a-node/geth.mdx
@@ -204,7 +204,7 @@ see no incoming blocks to your node, **that doesn't mean that the node is not sy
 **If you don't see any incoming blocks**, check and make sure that you have **at least one peer from
 the bootnodes**; otherwise, you might not be connected to the Linea network.
 
-Contact us via the [support site](https://support.linea.build/) if you have any issues.
+Contact us via the [support page](/support) if you have any issues.
 
 ## Confirm the node is running
 

--- a/docs/network/overview/ethereum-differences.mdx
+++ b/docs/network/overview/ethereum-differences.mdx
@@ -10,7 +10,7 @@ image: /img/socialCards/ethereum-differences.jpg
 This page outlines Ethereum Mainnet functionality that differs on Linea, or is not yet available on 
 Linea. Absence from this page indicates that the functionality is available on Linea and identical to 
 behavior on Ethereum Mainnet; if you're experiencing otherwise, please contact us via the
-[support site](https://support.linea.build/).
+[support page](/support).
 
 :::note 
 

--- a/docs/network/overview/predictable-pricing.mdx
+++ b/docs/network/overview/predictable-pricing.mdx
@@ -58,8 +58,7 @@ and gas used.
 ## Next steps
 
 - Understand how the [gas price is calculated](../how-to/gas-fees#understand-the-gas-price-calculation)
-- Learn more about gas on Linea on our
-[support page](https://support.linea.build/getting-started/what-does-gas-pay-for) 
+- Learn how to [estimate gas costs](../how-to/gas-fees.mdx)
 - See the release notes
 for [Alpha v2](../../changelog/release-notes.mdx#alpha-v2) and
 [Alpha v3](../../changelog/release-notes.mdx#alpha-v30)

--- a/docs/network/tutorials/first-dapp.mdx
+++ b/docs/network/tutorials/first-dapp.mdx
@@ -754,6 +754,6 @@ Find more content about Linea on my X: [https://x.com/Gwenole_M](https://x.com/G
 
 [Solidity by Example](https://solidity-by-example.org/): very useful website when creating smart contracts
 
-[Linea support site](https://support.linea.build/): to contact the team if you need more help
+[Linea support page](/support): to contact the team if you need more help
 
 Also, check the [full codebase on GitHub](https://github.com/Gwen-M/linea-first-dapp)

--- a/docs/protocol/tokenomics.mdx
+++ b/docs/protocol/tokenomics.mdx
@@ -19,7 +19,7 @@ The token's contract address on Linea Mainnet and Ethereum Mainnet is [`0x1789e0
 :::note[Need help?]
 
 This page explains the rationale behind token distribution. If you're looking for help with claiming 
-your airdrop, using the token, or any other common issues, see the [Linea support page](https://support.linea.build/linea-hub/airdrop).
+your airdrop, using the token, or any other common issues, see the [Linea support page](/support).
 
 :::
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -182,10 +182,10 @@ const config = {
             label: "Changelog",
           },
           {
-            href: "https://support.linea.build/",
+            to: "/support",
             label: "Support",
             position: "right",
-            class: "support-link",
+            className: "support-link",
           },
         ],
       },
@@ -241,7 +241,7 @@ const config = {
               },
               {
                 label: "User support",
-                to: "https://support.linea.build/",
+                to: "/support",
               },
               {
                 label: "Give feedback",

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -334,9 +334,11 @@ html[data-theme='dark'] .header-release-notes-link::before {
   font-weight: 400;
   margin-right: 20px;
   color: var(--linea-brand-navy);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+}
+
+.navbar__items .support-link {
+  line-height: 1.4;
+  padding: 8px 12px;
 }
 
 .support-link svg {
@@ -373,6 +375,7 @@ html[data-theme='dark'] .header-release-notes-link::before {
     align-items: center;
     border-radius: 0.25rem;
     display: flex;
+    gap: 6px;
   }
 
   .navbar__items .support-link {
@@ -555,7 +558,8 @@ a.navbar__brand {
 .navbar__link[href="/protocol/quickstart"]::before,
 .navbar__link[href="/stack/quickstart"]::before,
 .navbar__link[href="/api/quickstart"]::before,
-.navbar__link[href="/changelog/release-notes"]::before {
+.navbar__link[href="/changelog/release-notes"]::before,
+.navbar__link[href="/support"]::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -572,7 +576,8 @@ a.navbar__brand {
 [data-theme="dark"] .navbar__link[href="/protocol/quickstart"]::before,
 [data-theme="dark"] .navbar__link[href="/stack/quickstart"]::before,
 [data-theme="dark"] .navbar__link[href="/api/quickstart"]::before,
-[data-theme="dark"] .navbar__link[href="/changelog/release-notes"]::before {
+[data-theme="dark"] .navbar__link[href="/changelog/release-notes"]::before,
+[data-theme="dark"] .navbar__link[href="/support"]::before {
   border-color: white;
 }
 
@@ -581,7 +586,8 @@ a.navbar__brand {
 .navbar__link[href="/protocol/quickstart"].navbar__link--active::before,
 .navbar__link[href="/stack/quickstart"].navbar__link--active::before,
 .navbar__link[href="/api/quickstart"].navbar__link--active::before,
-.navbar__link[href="/changelog/release-notes"].navbar__link--active::before {
+.navbar__link[href="/changelog/release-notes"].navbar__link--active::before,
+.navbar__link[href="/support"].navbar__link--active::before {
   background-color: var(--linea-brand-navy);
 }
 
@@ -589,7 +595,8 @@ a.navbar__brand {
 [data-theme="dark"] .navbar__link[href="/protocol/quickstart"].navbar__link--active::before,
 [data-theme="dark"] .navbar__link[href="/stack/quickstart"].navbar__link--active::before,
 [data-theme="dark"] .navbar__link[href="/api/quickstart"].navbar__link--active::before,
-[data-theme="dark"] .navbar__link[href="/changelog/release-notes"].navbar__link--active::before {
+[data-theme="dark"] .navbar__link[href="/changelog/release-notes"].navbar__link--active::before,
+[data-theme="dark"] .navbar__link[href="/support"].navbar__link--active::before {
   background-color: white;
 }
 
@@ -607,7 +614,8 @@ a.navbar__brand {
 .navbar__link[href="/protocol/quickstart"]:hover::before,
 .navbar__link[href="/stack/quickstart"]:hover::before,
 .navbar__link[href="/api/quickstart"]:hover::before,
-.navbar__link[href="/changelog/release-notes"]:hover::before {
+.navbar__link[href="/changelog/release-notes"]:hover::before,
+.navbar__link[href="/support"]:hover::before {
   background-color: var(--linea-brand-navy);
 }
 
@@ -615,7 +623,8 @@ a.navbar__brand {
 [data-theme="dark"] .navbar__link[href="/protocol/quickstart"]:hover::before,
 [data-theme="dark"] .navbar__link[href="/stack/quickstart"]:hover::before,
 [data-theme="dark"] .navbar__link[href="/api/quickstart"]:hover::before,
-[data-theme="dark"] .navbar__link[href="/changelog/release-notes"]:hover::before {
+[data-theme="dark"] .navbar__link[href="/changelog/release-notes"]:hover::before,
+[data-theme="dark"] .navbar__link[href="/support"]:hover::before {
   background-color: white;
 }
 
@@ -626,7 +635,7 @@ a.navbar__brand {
   .navbar__link[href="/stack/quickstart"]::before,
   .navbar__link[href="/api/quickstart"]::before,
   .navbar__link[href="/changelog/release-notes"]::before,
-  .support-link[href="https://support.linea.build/"]::before {
+  .navbar__link[href="/support"]::before {
     display: none;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,9 +87,9 @@ export default function Home(): React.ReactNode {
   const communityCards = [
     {
       title: "Get support",
-      link: "https://support.linea.build/",
+      link: "/support",
       description: (
-        <>Find help through the Linea support site and builder resources.</>
+        <>Find help through Linea support resources and builder guidance.</>
       ),
     },
     {

--- a/src/pages/support.module.css
+++ b/src/pages/support.module.css
@@ -5,13 +5,13 @@
 .hero {
   background: var(--linea-text-color-1) url('/img/hero_pattern.svg') no-repeat center;
   background-size: cover;
-  color: #f8f7f2;
+  color: var(--linea-white);
   margin: 0 auto;
   min-height: 450px;
   width: calc(100vw - 2.5rem);
   display: flex;
   align-items: center;
-  border-radius: 14px;
+  border-radius: var(--linea-radius-lg);
   overflow: hidden;
 }
 
@@ -28,28 +28,28 @@
 }
 
 .hero h1 {
-  color: #f8f7f2;
-  font-size: 3.5rem;
+  color: var(--linea-white);
+  font-size: var(--font-display-lg);
   line-height: 1.05;
   margin: 0;
 }
 
 .intro {
-  color: #f8f7f2;
-  font-size: 1.15rem;
+  color: var(--linea-white);
+  font-size: var(--font-heading-md);
   line-height: 1.6;
   margin: 20px auto 0;
   max-width: 640px;
 }
 
 .primaryButton {
-  background: white;
+  background: var(--linea-white);
   border: 0;
-  border-radius: 30px;
+  border-radius: var(--linea-radius-pill);
   color: var(--linea-black) !important;
   cursor: pointer;
-  font-family: 'Atyp Display', sans-serif;
-  font-size: 15px;
+  font-family: AtypDisplay, sans-serif;
+  font-size: var(--font-body-sm);
   font-weight: 500;
   margin-top: 32px;
   min-height: 48px;
@@ -65,8 +65,8 @@
 }
 
 .status {
-  color: #f8f7f2;
-  font-size: 0.95rem;
+  color: var(--linea-white);
+  font-size: var(--font-body-md);
   line-height: 1.5;
   margin: 16px auto 0;
   max-width: 520px;
@@ -83,7 +83,7 @@
 
 .resources h2 {
   color: var(--linea-text-primary);
-  font-size: 2rem;
+  font-size: var(--font-display-md);
   margin: 0 0 24px;
 }
 
@@ -95,7 +95,7 @@
 
 .resourceCard {
   border: 1px solid var(--linea-border);
-  border-radius: 8px;
+  border-radius: var(--linea-radius-md);
   color: var(--linea-text-primary) !important;
   min-height: 148px;
   padding: 24px;
@@ -114,7 +114,7 @@
 .resourceCard span {
   display: block;
   font-family: AtypDisplay, sans-serif;
-  font-size: 1.25rem;
+  font-size: var(--font-heading-md);
   font-weight: 500;
   margin-bottom: 12px;
 }
@@ -138,7 +138,7 @@
   }
 
   .hero h1 {
-    font-size: 2.5rem;
+    font-size: var(--font-display-lg);
   }
 
   .resourceGrid {
@@ -152,11 +152,11 @@
   }
 
   .hero h1 {
-    font-size: 2.25rem;
+    font-size: var(--font-display-md);
   }
 
   .intro {
-    font-size: 1rem;
+    font-size: var(--font-body-md);
   }
 
   .primaryButton {

--- a/src/pages/support.module.css
+++ b/src/pages/support.module.css
@@ -1,0 +1,165 @@
+.page {
+  color: var(--linea-text-primary);
+}
+
+.hero {
+  background: var(--linea-text-color-1) url('/img/hero_pattern.svg') no-repeat center;
+  background-size: cover;
+  color: #f8f7f2;
+  margin: 0 auto;
+  min-height: 450px;
+  width: calc(100vw - 2.5rem);
+  display: flex;
+  align-items: center;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+[data-theme="dark"] .hero {
+  background: var(--linea-text-color-1) url('/img/hero_pattern_dark.svg') no-repeat center;
+  background-size: cover;
+}
+
+.heroContent {
+  width: min(760px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 72px 0;
+  text-align: center;
+}
+
+.hero h1 {
+  color: #f8f7f2;
+  font-size: 3.5rem;
+  line-height: 1.05;
+  margin: 0;
+}
+
+.intro {
+  color: #f8f7f2;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  margin: 20px auto 0;
+  max-width: 640px;
+}
+
+.primaryButton {
+  background: white;
+  border: 0;
+  border-radius: 30px;
+  color: var(--linea-black) !important;
+  cursor: pointer;
+  font-family: 'Atyp Display', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  margin-top: 32px;
+  min-height: 48px;
+  padding: 12px 24px;
+  text-align: center;
+  transition: all 0.3s ease;
+}
+
+.primaryButton:hover,
+.primaryButton:focus {
+  background: var(--linea-brand-cyan);
+  color: var(--linea-black) !important;
+}
+
+.status {
+  color: #f8f7f2;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 16px auto 0;
+  max-width: 520px;
+}
+
+.resources {
+  padding: 56px 0 72px;
+}
+
+.resourcesInner {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.resources h2 {
+  color: var(--linea-text-primary);
+  font-size: 2rem;
+  margin: 0 0 24px;
+}
+
+.resourceGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.resourceCard {
+  border: 1px solid var(--linea-border);
+  border-radius: 8px;
+  color: var(--linea-text-primary) !important;
+  min-height: 148px;
+  padding: 24px;
+  text-decoration: none !important;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.resourceCard:hover,
+.resourceCard:focus {
+  border-color: var(--linea-brand-purple);
+  transform: translateY(-2px);
+}
+
+.resourceCard span {
+  display: block;
+  font-family: AtypDisplay, sans-serif;
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.resourceCard p {
+  color: var(--linea-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+@media (max-width: 996px) {
+  .hero {
+    min-height: 360px;
+    width: calc(100vw - 1rem);
+    background-size: 100% auto;
+    background-position: left top;
+  }
+
+  .heroContent {
+    padding: 48px 0;
+  }
+
+  .hero h1 {
+    font-size: 2.5rem;
+  }
+
+  .resourceGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .heroContent {
+    width: min(100% - 28px, 760px);
+  }
+
+  .hero h1 {
+    font-size: 2.25rem;
+  }
+
+  .intro {
+    font-size: 1rem;
+  }
+
+  .primaryButton {
+    width: 100%;
+  }
+}

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+
+import styles from "./support.module.css";
+
+const INTERCOM_APP_ID = "txttgas6";
+const INTERCOM_SCRIPT_SRC = `https://widget.intercom.io/widget/${INTERCOM_APP_ID}`;
+const INTERCOM_LAUNCHER_SELECTOR = "#intercom-button";
+
+type IntercomStatus = "idle" | "loading" | "ready" | "delayed" | "error";
+
+type LayoutProps = {
+  title?: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+type IntercomSettings = {
+  api_base: string;
+  app_id: string;
+  custom_launcher_selector: string;
+};
+
+type IntercomFunction = {
+  (...args: unknown[]): void;
+  q?: unknown[][];
+};
+
+declare global {
+  interface Window {
+    Intercom?: IntercomFunction;
+    intercomSettings?: IntercomSettings;
+  }
+}
+
+const intercomSettings: IntercomSettings = {
+  api_base: "https://api-iam.intercom.io",
+  app_id: INTERCOM_APP_ID,
+  custom_launcher_selector: INTERCOM_LAUNCHER_SELECTOR,
+};
+
+const Layout: React.FC<LayoutProps> = require("@theme/Layout").default;
+
+function installIntercomQueue() {
+  if (typeof window.Intercom === "function") {
+    return;
+  }
+
+  const queuedIntercom: IntercomFunction = (...args: unknown[]) => {
+    queuedIntercom.q?.push(args);
+  };
+
+  queuedIntercom.q = [];
+
+  window.Intercom = queuedIntercom;
+}
+
+export default function Support(): React.ReactNode {
+  const [intercomStatus, setIntercomStatus] = useState<IntercomStatus>("idle");
+  const delayedTimerRef = useRef<number | undefined>(undefined);
+  const hasBootedIntercomRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+
+      if (delayedTimerRef.current !== undefined) {
+        window.clearTimeout(delayedTimerRef.current);
+      }
+
+      if (hasBootedIntercomRef.current) {
+        window.Intercom?.("shutdown");
+      }
+    };
+  }, []);
+
+  const showMessenger = () => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    window.Intercom?.("show");
+  };
+
+  const markScriptReady = (script: HTMLScriptElement) => {
+    script.dataset.loaded = "true";
+    delete script.dataset.failed;
+
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    setIntercomStatus("ready");
+    showMessenger();
+  };
+
+  const markScriptError = (script: HTMLScriptElement) => {
+    script.dataset.failed = "true";
+
+    if (isMountedRef.current) {
+      setIntercomStatus("error");
+    }
+  };
+
+  const bootIntercom = () => {
+    window.intercomSettings = intercomSettings;
+    installIntercomQueue();
+
+    if (!hasBootedIntercomRef.current) {
+      window.Intercom?.("boot", intercomSettings);
+      hasBootedIntercomRef.current = true;
+    }
+  };
+
+  const showIntercom = () => {
+    setIntercomStatus("loading");
+    bootIntercom();
+    showMessenger();
+
+    if (delayedTimerRef.current !== undefined) {
+      window.clearTimeout(delayedTimerRef.current);
+    }
+
+    delayedTimerRef.current = window.setTimeout(() => {
+      setIntercomStatus((status) =>
+        status === "loading" ? "delayed" : status,
+      );
+    }, 2500);
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[src="${INTERCOM_SCRIPT_SRC}"]`,
+    );
+
+    if (existingScript) {
+      if (existingScript.dataset.loaded === "true") {
+        setIntercomStatus("ready");
+        showMessenger();
+        return;
+      }
+
+      if (existingScript.dataset.failed === "true") {
+        existingScript.remove();
+      } else {
+        existingScript.addEventListener(
+          "load",
+          () => markScriptReady(existingScript),
+          { once: true },
+        );
+        existingScript.addEventListener(
+          "error",
+          () => markScriptError(existingScript),
+          { once: true },
+        );
+        return;
+      }
+    }
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = INTERCOM_SCRIPT_SRC;
+    script.onload = () => markScriptReady(script);
+    script.onerror = () => markScriptError(script);
+    document.head.appendChild(script);
+  };
+
+  return (
+    <Layout
+      title="Linea Support"
+      description="Contact Linea support or find docs search, status, and stuck transaction resources.">
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <div className={styles.heroContent}>
+            <h1>Linea Support</h1>
+            <p className={styles.intro}>
+              Need help with Linea? Contact support or use the resources below
+              to find the right next step.
+            </p>
+            <button
+              id="intercom-button"
+              type="button"
+              className={clsx("button", styles.primaryButton)}
+              onClick={showIntercom}>
+              Contact support
+            </button>
+            {intercomStatus === "delayed" && (
+              <p className={styles.status}>
+                Support messenger is still loading. You can also use the
+                resources below.
+              </p>
+            )}
+            {intercomStatus === "error" && (
+              <p className={styles.status}>
+                Support messenger did not load. Use the resources below, then
+                try again.
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section
+          className={styles.resources}
+          aria-labelledby="support-resources">
+          <div className={styles.resourcesInner}>
+            <h2 id="support-resources">Support resources</h2>
+            <div className={styles.resourceGrid}>
+              <Link className={styles.resourceCard} to="/search">
+                <span>Search docs</span>
+                <p>Find public Linea docs, guides, and references.</p>
+              </Link>
+              <Link
+                className={styles.resourceCard}
+                to="https://linea.statuspage.io/">
+                <span>Status</span>
+                <p>Check Linea network and service status.</p>
+              </Link>
+              <Link
+                className={styles.resourceCard}
+                to="https://support.metamask.io/manage-crypto/transactions/how-to-speed-up-or-cancel-a-pending-transaction/#canceling-a-transaction">
+                <span>Stuck transaction</span>
+                <p>Use MetaMask guidance to cancel a stuck transaction.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -50,55 +50,51 @@
       "destination": "/:match*",
       "permanent": true
     },
-    { 
-      "source": "/users", 
-      "destination": "https://support.linea.build/", 
-      "permanent": true 
+    { "source": "/users", "destination": "/support", "permanent": true },
+    {
+      "source": "/users/move-funds",
+      "destination": "/network/how-to/bridge",
+      "permanent": true
     },
-    { 
-      "source": "/users/move-funds", 
-      "destination": "https://support.linea.build/bridging/how-to-bridge-to-linea", 
-      "permanent": true 
+    {
+      "source": "/users/move-funds/bridge",
+      "destination": "/network/how-to/bridge",
+      "permanent": true
     },
-    { 
-      "source": "/users/move-funds/bridge", 
-      "destination": "https://support.linea.build/bridging/how-to-bridge-to-linea", 
-      "permanent": true 
+    {
+      "source": "/users/move-funds/set-up-your-wallet",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/move-funds/set-up-your-wallet", 
-      "destination": "https://support.linea.build/getting-started/can-you-use-linea-with-metamask", 
-      "permanent": true 
+    {
+      "source": "/users/move-funds/fund",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/move-funds/fund", 
-      "destination": "https://support.linea.build/getting-started/how-to-buy-tokens-on-linea-using-metamask-portfolio", 
-      "permanent": true 
+    {
+      "source": "/users/linea-voyage",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/linea-voyage", 
-      "destination": "https://support.linea.build/linea-voyage", 
-      "permanent": true 
+    {
+      "source": "/users/linea-voyage/linea-surge/linea-surge-overview",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/linea-voyage/linea-surge/linea-surge-overview", 
-      "destination": "https://support.linea.build/linea-voyage/linea-surge/linea-surge-overview", 
-      "permanent": true 
+    {
+      "source": "/users/linea-voyage/linea-surge/linea-surge-model",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/linea-voyage/linea-surge/linea-surge-model", 
-      "destination": "https://support.linea.build/linea-voyage/linea-surge/linea-surge-model", 
-      "permanent": true 
+    {
+      "source": "/users/linea-voyage/linea-surge",
+      "destination": "/support",
+      "permanent": true
     },
-    { 
-      "source": "/users/linea-voyage/linea-surge", 
-      "destination": "https://support.linea.build/linea-voyage/linea-surge", 
-      "permanent": true 
-    },
-    { 
-      "source": "/users/linea-voyage/lxp", 
-      "destination": "https://support.linea.build/linea-voyage/lxp", 
-      "permanent": true 
+    {
+      "source": "/users/linea-voyage/lxp",
+      "destination": "/support",
+      "permanent": true
     },
     {
       "source": "/developers/community/hackathons",


### PR DESCRIPTION
## Summary
- Add a /support page with Linea support copy, Intercom launcher wiring, and fallback resource links.
- Update navbar, footer, homepage, docs links, and redirects away from support.linea.build.
- Keep Intercom scoped to the support page and load it only when the Contact support button is clicked.

## Test Plan
- [x] rg -n "support\.linea\.build" .
- [x] git diff --check
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build

## Note
- Intercom production behavior may require the Intercom owner to allow docs.linea.build in the app configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static-site routing only; Intercom is page-scoped and may need domain allowlisting in Intercom for production.
> 
> **Overview**
> Adds a first-party **`/support`** page on the docs site with a **Contact support** button that boots **Intercom** on demand (script load, loading/error fallbacks, shutdown on unmount), plus links to docs search, status, and stuck-transaction help.
> 
> **Navigation and links** now point to `/support` instead of `support.linea.build` in the navbar, footer, homepage community card, and across many doc pages; some copy now defers to the support page rather than deep external support URLs (e.g. bridge aggregator intro, predictable pricing next step).
> 
> **Redirects** in `vercel.json` send legacy `/users/*` paths to `/support` or in-site docs (e.g. move-funds → bridge guide) instead of the old support host.
> 
> **Styling**: navbar Support uses `to` + `className`; support link and `/support` get the same dot-indicator treatment as other top nav items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550e3e388efd8e9c28d630ea5e35f59610b090eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->