### PR TITLE
chore(deps): upgrade concurrently to 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build docs
-        uses: Consensys/github-actions/docs-build@main
+        uses: Consensys/github-actions/docs-build@8e207ec2ad53d90ab419d39d03084fa93e04d190

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
     paths: ['docs/**']
 
+permissions: {}
+
 jobs:
   case:
     name: Check for case being inconsistent

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Case check action
-        uses: ConsenSys/github-actions/docs-case-check@main
+        uses: ConsenSys/github-actions/docs-case-check@8e207ec2ad53d90ab419d39d03084fa93e04d190
         with:
           DOC_DIR: ${{ matrix.folder }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: LinkCheck
-        uses: Consensys/github-actions/docs-link-check@main
+        uses: Consensys/github-actions/docs-link-check@8e207ec2ad53d90ab419d39d03084fa93e04d190
         with:
           CONFIG_FILE: '.linkspector.yml'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   linkCheck:
     name: Link Checking

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint code
-        uses: Consensys/github-actions/docs-lint-all@main
+        uses: Consensys/github-actions/docs-lint-all@8e207ec2ad53d90ab419d39d03084fa93e04d190
 
       - name: Lint markdown
-        uses: Consensys/github-actions/docs-lint-markdown@main
+        uses: Consensys/github-actions/docs-lint-markdown@8e207ec2ad53d90ab419d39d03084fa93e04d190

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint Code Base, Spelling

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: LinkCheck
-        uses: ConsenSys/github-actions/docs-link-check@main
+        uses: ConsenSys/github-actions/docs-link-check@8e207ec2ad53d90ab419d39d03084fa93e04d190
         with:
           CONFIG_FILE: .linkspector.yml
 
@@ -31,7 +31,7 @@ jobs:
     permissions: {}   # zero scopes
     steps:
       - name: Slack Notification
-        uses: ConsenSys/github-actions/slack-notify@main
+        uses: ConsenSys/github-actions/slack-notify@8e207ec2ad53d90ab419d39d03084fa93e04d190
         with:
           SLACK_CHANNEL: doc-ci-alerts
           SLACK_COLOR: danger

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,6 +15,8 @@ on:
         required: false
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   security-scan:
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@0a58c584f25e8c121927884b5e8a86e846090e5c

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
     with:
       repo: ${{ github.repository }}
-      scanner-ref: 'v2'
+      scanner-ref: 0a58c584f25e8c121927884b5e8a86e846090e5c
       paths-ignored: |
         node_modules
         **/node_modules/**

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@0a58c584f25e8c121927884b5e8a86e846090e5c
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   vale:
     name: Spelling

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vale
-        uses: Consensys/github-actions/docs-spelling-check@main
+        uses: Consensys/github-actions/docs-spelling-check@8e207ec2ad53d90ab419d39d03084fa93e04d190

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "browserslist": "4.28.2",
         "cheerio": "1.1.2",
         "clsx": "2.1.1",
-        "concurrently": "9.2.1",
+        "concurrently": "10.0.3",
         "dompurify": "3.4.2",
         "dotenv": "17.4.2",
         "fast-xml-parser": "5.7.1",
@@ -13431,42 +13431,143 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/confbox": {
@@ -17749,7 +17850,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -31423,9 +31523,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "browserslist": "4.28.2",
     "cheerio": "1.1.2",
     "clsx": "2.1.1",
-    "concurrently": "9.2.1",
+    "concurrently": "10.0.3",
     "dompurify": "3.4.2",
     "dotenv": "17.4.2",
     "fast-xml-parser": "5.7.1",


### PR DESCRIPTION
## Summary
- Closes #1520.
- Upgrade `concurrently` from `9.2.1` to `10.0.3`.
- Regenerate `package-lock.json` with npm.

## Validation
- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run agent-docs:test`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and CI workflow pinning only; no application runtime or auth/data-path changes.
> 
> **Overview**
> Upgrades **`concurrently`** from `9.2.1` to **`10.0.3`** in `package.json` and regenerates `package-lock.json`. v10 raises the package engine to **Node ≥22** (aligned with the repo’s `engines.node` `24.14.1`) and pulls newer transitive deps (e.g. chalk 5, yargs 18).
> 
> The same diff **pins several GitHub Actions** from floating `@main` / version tags to commit SHAs: Consensys docs actions (`docs-build`, case/link/lint/spelling, `slack-notify`) and the MetaMask security scanner reusable workflow (new `scanner-ref` SHA). Several workflows also add **workflow-level `permissions: {}`** for least-privilege defaults before job-scoped grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a036640199e79d3b42bda4de58fcd957ecf04eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->