### PR TITLE
docs(repos): update archived Consensys repo links to current Lineth homes

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -429,7 +429,7 @@ the hub's consistency arguments.
 
 <ChangelogEntry tag="upgrade">
 
-- New arithmetization, with selected modules activated from the [Linea specification](https://github.com/Consensys/linea-specification).
+- New arithmetization, with selected modules activated from the [Linea specification](https://github.com/LFDT-Lineth/lineth-monorepo).
 - The transition to generating traces with Besu.
 
 </ChangelogEntry>

--- a/docs/protocol/reference/repos.mdx
+++ b/docs/protocol/reference/repos.mdx
@@ -21,7 +21,7 @@ The principal Linea repository. This includes the:
 - Sequencer: responsible for ordering, building, and executing blocks
 - Smart contracts: covering Linea's core functions
 
-## [`linea-specification`](https://github.com/Consensys/linea-specification)
+## [`linea-specification`](https://github.com/LFDT-Lineth/lineth-monorepo)
 
 Specification of the constraint system underlying Linea's zkEVM.
 
@@ -30,7 +30,7 @@ Linea's constraint system aims to capture the logic of valid EVM executions.
 
 The constraints specified here are implemented in the `linea-constraints` repo.
 
-## [`linea-constraints`](https://github.com/Consensys/linea-constraints)
+## [`linea-constraints`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/tracer-constraints)
 
 Implementation of the constraint system specified in the `linea-specification` repo.
 
@@ -40,7 +40,7 @@ of the EVM execution). The production of such traces is the job of the `linea-tr
 
 Constraints and traces are two of the inputs to the prover.
 
-## [`linea-tracer`](https://github.com/Consensys/linea-tracer)
+## [`linea-tracer`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/tracer)
 
 Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover.
 
@@ -48,7 +48,7 @@ Tracing refers to the process of extracting data from the execution of an EVM cl
 construct large matrices known as execution traces. Execution traces are subject to the constraint 
 system specified in the `linea-specification` repo and implemented in the `linea-constraints` repo.
 
-## [`linea-besu-upstream`](https://github.com/Consensys/linea-besu-upstream)
+## [`linea-besu-upstream`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/linea-besu)
 
 A Besu build configured for Linea.
 


### PR DESCRIPTION
## Summary

Follow-up to #1516. Four component repos referenced on `protocol/reference/repos.mdx` are now **archived** on GitHub; their content was consolidated into the monorepo (`Consensys/linea-monorepo`, which now redirects to `LFDT-Lineth/lineth-monorepo`). This points each link to its current home and fixes the same archived `linea-specification` link in the Beta v1.1 changelog entry.

This is **Phase 1** (internal-consistency / dead-link fixes only). No brand-term renames, page-title changes, or code identifiers touched — those are deferred to Phase 2.

## Repo link changes

| Repo | GitHub status (verified via API) | New target |
|---|---|---|
| `linea-tracer` | archived | `lineth-monorepo/tree/main/tracer` (subdir confirmed by folder README) |
| `linea-constraints` | archived | `lineth-monorepo/tree/main/tracer-constraints` (subdir confirmed by folder README) |
| `linea-besu-upstream` | archived | `lineth-monorepo/tree/main/linea-besu` (dir confirmed; archive notice → monorepo besu package) |
| `linea-specification` | archived | `lineth-monorepo` (root — no dedicated subdir; see notes) |
| `shomei` | **not archived** | unchanged — still canonical at `Consensys/shomei` |
| `gnark` | **not archived** | unchanged — general-purpose Consensys crypto lib, still canonical |

Also updated the same archived `linea-specification` link in `docs/changelog/release-notes.mdx` (Beta v1.1 entry); link text unchanged.

## Verification

- Repo status confirmed via GitHub API: `linea-specification`, `linea-constraints`, `linea-tracer`, `linea-besu-upstream` are **archived**; `shomei` and `gnark` are **not** archived.
- New destinations confirmed live (monorepo root + `tracer`, `tracer-constraints`, `linea-besu` subdirs exist; `Consensys/linea-monorepo` redirects to `LFDT-Lineth/lineth-monorepo`).
- Re-grep of `docs/` for the archived URLs → none remaining.
- **Anchors unaffected:** only the URL target of each heading link changed, not the displayed repo-name text, so inbound anchors (`#linea-tracer`, `#linea-besu-upstream`, `#shomei`, `#gnark`, `#maru`) still resolve. No page slugs changed → no `redirects.json` entry needed.

## Notes / follow-ups

- ⚠️ **`linea-specification` has no dedicated subdir** in `lineth-monorepo`, so it points to the monorepo root (per its own archive banner). `rollup_spec/` is a *different* doc (Type-1 RISC-V migration spec), not the constraint-system specification. Confirm intended home if a more specific link is wanted.
- ⚠️ **Monorepo READMEs are internally stale:** `lineth-monorepo`'s `tracer/` and `tracer-constraints/` READMEs still cross-reference the archived `Consensys/linea-specification` repo — an upstream issue for the Lineth team, not fixable here.
- Out of scope for this PR (Phase 2): page title "Linea repositories", "Linea-Besu plugins" / "Linea's core functions" prose, "Linea Stack" → Lineth renames, and "Linea Besu" client-naming disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates documentation links from **archived** Consensys component repos to their current homes under **`LFDT-Lineth/lineth-monorepo`**.
> 
> On **`protocol/reference/repos.mdx`**, **`linea-specification`** now points at the monorepo root; **`linea-constraints`**, **`linea-tracer`**, and **`linea-besu-upstream`** point at **`tracer-constraints`**, **`tracer`**, and **`linea-besu`** respectively. Heading link text and anchors are unchanged; **`gnark`** and **`shomei`** links are untouched.
> 
> The Beta v1.1 changelog entry in **`release-notes.mdx`** uses the same **`linea-specification`** URL fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb489efa5ee54d638d356734fbb2399ba7a06605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->