### PR TITLE
fix: redirect support.linea.build to docs support page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,12 @@
     }
   ],
   "redirects": [
+    {
+      "source": "/:match*",
+      "has": [{ "type": "host", "value": "support.linea.build" }],
+      "destination": "https://docs.linea.build/support",
+      "permanent": true
+    },
     { "source": "/en/latest", "destination": "/", "permanent": true },
     { "source": "/en/latest/", "destination": "/", "permanent": true },
     {


### PR DESCRIPTION
## Summary
- add a host-based permanent redirect in `vercel.json` for requests arriving on `support.linea.build`
- send the retired support hostname to the canonical support page at `https://docs.linea.build/support`
- keep the change scoped to Vercel config only, with no docs content or route changes

## Context
- `support.linea.build` is now attached to the `doc.linea` Vercel project as a normal production domain
- the Vercel domain settings UI can only redirect host to host, so it cannot send `support.linea.build` directly to `https://docs.linea.build/support`
- without this repo change, the old hostname serves the docs site under `support.linea.build`, which is not the intended final state

## Implementation
- add a `host`-matched redirect at the top of the `redirects` array in `vercel.json`
- match any request whose host is `support.linea.build`
- permanently redirect all of that traffic to `https://docs.linea.build/support`
- do not preserve the incoming path; the goal is to retire the old hostname and collapse it to the single canonical support URL

## Test Plan
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`

## Post-Deploy Verification
- visit `https://support.linea.build`
- confirm the browser lands on `https://docs.linea.build/support`
- confirm the old hostname no longer serves the docs site directly
- once verified, unpublish GitHub Pages for `Consensys/linea-helpcenter`
- archive `Consensys/linea-helpcenter`
