### PR TITLE
fix: hotfix support domain redirect routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,15 @@
   "cleanUrls": true,
   "routes": [
     {
+      "src": "^/(.*)$",
+      "has": [{ "type": "host", "value": "support.linea.build" }],
+      "status": 308,
+      "headers": {
+        "Location": "https://docs.linea.build/support"
+      },
+      "dest": "/"
+    },
+    {
       "src": "^/$",
       "has": [
         { "type": "header", "key": "accept", "value": ".*text/markdown.*" }
@@ -36,12 +45,6 @@
     }
   ],
   "redirects": [
-    {
-      "source": "/:match*",
-      "has": [{ "type": "host", "value": "support.linea.build" }],
-      "destination": "https://docs.linea.build/support",
-      "permanent": true
-    },
     { "source": "/en/latest", "destination": "/", "permanent": true },
     { "source": "/en/latest/", "destination": "/", "permanent": true },
     {


### PR DESCRIPTION
## Summary
- replace the ineffective host-matched `redirects` rule from `#1529`
- add a first-match route-level `308` redirect for requests on `support.linea.build`
- keep the fix scoped to `vercel.json` only

## Context
- `#1529` merged and deployed, but production still served the docs app on `support.linea.build` instead of redirecting
- that left the site loading under the wrong host and triggered the Docusaurus runtime/baseUrl warning in production
- this hotfix moves the redirect to the `routes` layer so it can fire before the app is served

## Test Plan
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`

## Post-Deploy Verification
- `curl -I https://support.linea.build`
- confirm `308` with `Location: https://docs.linea.build/support`
- confirm browser lands on `https://docs.linea.build/support`
- only then unpublish GitHub Pages and archive `linea-helpcenter`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-host redirect configuration in `vercel.json` with no auth or data changes; main risk is mis-routing if the host match or status/header syntax is wrong in production.
> 
> **Overview**
> **Hotfixes production behavior for `support.linea.build`** by moving the support-domain redirect out of Vercel’s `redirects` block (which did not take effect after `#1529`) into a **first-match `routes` rule** that runs before the docs app is served.
> 
> For any request whose host is `support.linea.build`, the new rule responds with **HTTP 308** and `Location: https://docs.linea.build/support`, so traffic should no longer load the Docusaurus site on the wrong host or hit the related baseUrl warning.
> 
> No application code changes; scope is **`vercel.json` only**. Existing path-based `redirects` (e.g. `/en/latest`, `/users`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5f1af15df6bece121647aed1fb7d990d1f0be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->