### PR TITLE
adding renovatebot to maintain deps

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,0 +1,60 @@
+name: renovatebot
+
+on:
+  schedule:
+    - cron: "15 3 14,28 * *"
+
+  # push:
+    # branches:
+    #   - main
+    # paths:
+    #   - '.github/workflows/**'
+  workflow_dispatch:
+    inputs:
+      minimum_release_age:
+        description: 'Override minimumReleaseAge in days (leave empty for config default; 0 requires protocol-galileo membership)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  renovatebot-check:
+    runs-on: ubuntu-24.04
+    environment: security
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check protocol-galileo membership
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.minimum_release_age == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.teams.getMembershipForUserInOrg({
+              org: context.repo.owner,
+              team_slug: 'protocol-galileo',
+              username: context.actor,
+            });
+            if (data.state !== 'active') {
+              core.setFailed(`${context.actor} must be an active member of protocol-galileo to set minimumReleaseAge to 0`);
+            }
+
+      - name: Set minimum release age override
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.minimum_release_age != ''
+        env:
+          MINIMUM_RELEASE_AGE: ${{ github.event.inputs.minimum_release_age }}
+        run: |
+          if ! [[ "$MINIMUM_RELEASE_AGE" =~ ^[0-9]+$ ]]; then
+            echo "Invalid minimumReleaseAge: must be a non-negative integer"
+            exit 1
+          fi
+          echo "RENOVATE_MINIMUM_RELEASE_AGE=$MINIMUM_RELEASE_AGE days" >> $GITHUB_ENV
+
+      - name: Run renovatebot
+        uses: ConsenSys/github-actions/renovatebot@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        with:
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
+          GH_REPOSITORY: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": ["github-actions", "npm"],
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "description": "Pin all GitHub Actions to SHA digests",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "minimumReleaseAge": "7 days",
+      "groupName": "Renovatebot GHA Updates"
+    },
+    {
+      "description": "Allow immediate updates for ConsenSys/github-actions",
+      "matchManagers": ["github-actions"],
+      "matchPackagePrefixes": ["ConsenSys/github-actions"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Group npm dependency updates",
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "7 days",
+      "groupName": "npm dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces automation that can open dependency PRs using GitHub App secrets in a security environment; misconfiguration or bypass of the team gate for immediate updates could increase supply-chain exposure.
> 
> **Overview**
> Introduces **automated dependency maintenance** via Renovate: a new scheduled GitHub Actions workflow and a root `renovate.json` policy.
> 
> The **`.github/workflows/renovatebot.yml`** workflow runs on the 14th and 28th of each month (and via `workflow_dispatch`), uses the `security` environment, and invokes `ConsenSys/github-actions/renovatebot` with GitHub App credentials. Manual runs can override `minimumReleaseAge`; setting it to **0** is gated on active **protocol-galileo** team membership, and non-empty overrides are validated as non-negative integers before being passed as `RENOVATE_MINIMUM_RELEASE_AGE`.
> 
> **`renovate.json`** enables **github-actions** and **npm** only, turns off the dependency dashboard, pins GitHub Actions to **SHA digests** (7-day minimum release age, grouped), allows immediate updates for **ConsenSys/github-actions**, and groups npm updates with a 7-day release age.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd256c2f3e2e237147baea0c940245b608f2f6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->