### PR TITLE
Remove Security Council transactions banner from release notes

### DIFF
--- a/docs/changelog/release-notes.mdx
+++ b/docs/changelog/release-notes.mdx
@@ -132,13 +132,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { ChangelogEntry, ChangelogDate, ChangelogSubtitle } from "@site/src/components/changelog/ChangelogEntry";
 
-<ChangelogSubtitle>Latest network, protocol, and tooling updates for builders.</ChangelogSubtitle>
-
-:::info Linea Security Council transactions
-
-This page maintains a record and brief explanation of [Linea Security Council transactions](./security-council-record.mdx).
-
-:::
+<ChangelogSubtitle>Latest releases, upgrades, and tooling updates across the Lineth stack, protocol, and Linea network.</ChangelogSubtitle>
 
 <div id="v10" className="legacy-anchor" /><div id="beta-v60" className="legacy-anchor" /><div id="forced-transactions" className="legacy-anchor" />
 


### PR DESCRIPTION
Removes the Security Council transactions banner from the release notes page (link to Security Council transactions is clearly visible in the left side navbar); and updates the under-title of the page to fit the Lineth wording as well.