### PR TITLE
Fix docs review findings for finality and bridge guidance

### DIFF
--- a/docs/network/build/bridge.mdx
+++ b/docs/network/build/bridge.mdx
@@ -25,7 +25,9 @@ bridge be a centralized arbiter and point of failure.
 
 - **Without Permit**
   - User should first allow the bridge to transfer tokens on their behalf
-  - This is done by calling `allowance()` on the TokenBridge.
+  - This is done by calling `approve(address spender, uint256 amount)` on the ERC-20 token contract,
+    setting the TokenBridge as the spender. You can use `allowance(owner, spender)` on the ERC-20
+    token contract to check the approved amount.
   - Then, the user should call the `bridgeToken()` method.
 - **With Permit**
   - User can call `bridgeTokenWithPermit()` to pass permit data in a single transaction

--- a/docs/network/overview/transaction-finality.mdx
+++ b/docs/network/overview/transaction-finality.mdx
@@ -53,8 +53,8 @@ At hard finality:
 
 - The transaction is cryptographically proven on Ethereum and inherits its security guarantees
 - It is anchored to Ethereum's security guarantees
-- The current median time to hard finality is under 1 hour 40 minutes, and is expected to reach
-  approximately 30 minutes as proving performance improves
+- The current median time to hard finality is approximately 2 hours. Planned finality improvements
+  are expected to reduce hard finality to under 30 minutes.
 - Hard finality should never exceed 16 hours under normal operating conditions
 
 Hard finality is required for cross-layer withdrawals, CEX deposit confirmations, and any use case
@@ -82,9 +82,7 @@ curl https://rpc.linea.build \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}'
 ```
 
-The `finalized` tag is supported by all applicable JSON-RPC methods on Linea Mainnet and Linea
-Sepolia, with the exception of `eth_call`. On Linea, `eth_call` does not currently support the
-`finalized` block tag.
+The `finalized` tag is supported by applicable JSON-RPC methods on Linea Mainnet and Linea Sepolia.
 
 ### Query the rollup contract
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -181,9 +181,14 @@ example:
 
 ### Full nodes
 
-Full nodes are composed of the execution layer client such as
-[Besu](../../network/how-to/run-a-node/linea-besu.mdx#run-using-docker) or [Geth](../../network/how-to/run-a-node/geth.mdx),
-and the consensus layer [Maru](../../network/how-to/run-a-node/maru.mdx). The block is proposed by the execution layer, Linea Besu, and the consensus layer, Maru, signs and broadcasts it. Full nodes are often run with both clients in the same container. These clients communicate via the Engine API, an internal service.
+Full nodes are composed of an execution layer client such as
+[Linea Besu](../../network/how-to/run-a-node/linea-besu.mdx#run-using-docker) or [Geth](../../network/how-to/run-a-node/geth.mdx),
+and the consensus layer [Maru](../../network/how-to/run-a-node/maru.mdx). On the public network
+today, block production is handled by Linea-operated sequencer infrastructure using Linea Besu
+paired with Maru. Linea Besu builds the execution payload, while Maru handles consensus, signing,
+and broadcasting. Non-sequencer full nodes follow the chain and can serve RPC. Full nodes are often
+run with both clients in the same container. These clients communicate via the Engine API, an
+internal service.
 
 Full nodes may maintain complete network state and can be configured to participate in consensus, in which case they are referred to as validator nodes:
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -187,9 +187,8 @@ and the consensus layer [Maru](../../network/how-to/run-a-node/maru.mdx). On the
 today, block production is handled by Linea-operated sequencer infrastructure using Linea Besu with
 the Linea sequencer plugin, paired with Maru. Linea Besu builds the execution payload, while the
 sequencer plugin applies Linea-specific block-building rules and Maru handles consensus, signing,
-and broadcasting. Non-sequencer full nodes follow the chain and can serve RPC. Full nodes are often
-run with both clients in the same container. These clients communicate via the Engine API, an internal
-service.
+and broadcasting. Non-sequencer full nodes follow the chain and can serve RPC. The execution and
+consensus clients communicate via the Engine API, an internal service.
 
 Full nodes may maintain complete network state and can be configured to participate in consensus, in which case they are referred to as validator nodes:
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -188,7 +188,7 @@ today, block production is handled by Linea-operated sequencer infrastructure us
 the Linea sequencer plugin, paired with Maru. Linea Besu builds the execution payload, while the
 sequencer plugin applies Linea-specific block-building rules and Maru handles consensus, signing,
 and broadcasting. Non-sequencer full nodes follow the chain and can serve RPC. The execution and
-consensus clients communicate via the Engine API, an internal service.
+consensus clients communicate via the Engine API.
 
 Full nodes may maintain complete network state and can be configured to participate in consensus, in which case they are referred to as validator nodes:
 

--- a/docs/protocol/architecture/index.mdx
+++ b/docs/protocol/architecture/index.mdx
@@ -184,11 +184,12 @@ example:
 Full nodes are composed of an execution layer client such as
 [Linea Besu](../../network/how-to/run-a-node/linea-besu.mdx#run-using-docker) or [Geth](../../network/how-to/run-a-node/geth.mdx),
 and the consensus layer [Maru](../../network/how-to/run-a-node/maru.mdx). On the public network
-today, block production is handled by Linea-operated sequencer infrastructure using Linea Besu
-paired with Maru. Linea Besu builds the execution payload, while Maru handles consensus, signing,
+today, block production is handled by Linea-operated sequencer infrastructure using Linea Besu with
+the Linea sequencer plugin, paired with Maru. Linea Besu builds the execution payload, while the
+sequencer plugin applies Linea-specific block-building rules and Maru handles consensus, signing,
 and broadcasting. Non-sequencer full nodes follow the chain and can serve RPC. Full nodes are often
-run with both clients in the same container. These clients communicate via the Engine API, an
-internal service.
+run with both clients in the same container. These clients communicate via the Engine API, an internal
+service.
 
 Full nodes may maintain complete network state and can be configured to participate in consensus, in which case they are referred to as validator nodes:
 


### PR DESCRIPTION
## Summary

This PR fixes the confirmed docs review findings from #1533 that are safe to update now.

It does four things:

- Aligns the transaction finality page with the current hard-finality baseline: approximately 2 hours today, with planned improvements targeting under 30 minutes.
- Removes the outdated statement that `eth_call` does not support the `finalized` block tag.
- Corrects bridge approval guidance: users approve the TokenBridge as spender by calling `approve()` on the ERC-20 token contract, and can use `allowance()` only to check the approved amount.
- Clarifies full-node and block-production wording: follower full nodes can run Linea Besu or Geth with Maru, while public-network block production is handled by Linea-operated sequencer infrastructure using Linea Besu with the Linea sequencer plugin, paired with Maru.

## Why

The previous wording mixed together current timing metrics, outdated RPC guidance, and block-production language that could make follower full nodes sound like sequencers. The bridge page also pointed developers to a read-only `allowance()` call where the required action is an ERC-20 approval transaction.

## Pages changed

- `docs/network/overview/transaction-finality.mdx`
- `docs/network/build/bridge.mdx`
- `docs/protocol/architecture/index.mdx`

## Not included

These findings from #1533 are intentionally left out:

- Pause authority and upgrade authority: need team confirmation before changing risk disclosures.
- Privacy-policy checklist: not relevant for this PR.
- L1 Message Service naming: not relevant for this PR, especially with possible upcoming contract naming changes.

## Test Plan

- [x] `npm run build`
- [x] `git diff --check`
- [x] `./node_modules/.bin/docusaurus build`
