### PR TITLE
docs: align homepage with Linea/Lineth framing

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -119,6 +119,16 @@
   text-align: center;
 }
 
+.subtitle .subtitleLink {
+  color: var(--linea-brand-cyan);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.subtitle .subtitleLink:hover {
+  color: #f8f7f2;
+}
+
 @media (max-width: 1250px) {
   .logo {
     height: 38px;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,8 +28,7 @@ function HomepageHeader() {
           <Link className={styles.subtitleLink} to="/protocol/linea-vs-lineth">
             Lineth
           </Link>{" "}
-          is the open-source
-          stack that powers it.
+          is the open-source stack that powers it.
         </p>
         <div className={styles.buttons}>
           <Link
@@ -62,9 +61,10 @@ export default function Home(): React.ReactNode {
       title: "Learn about Lineth components",
       link: "/stack/how-it-works",
       description: (
-        <>Explore Lineth's deployment models, data availability, finalization, and trust model.
-
-</>
+        <>
+          Explore Lineth&apos;s deployment models, data availability,
+          finalization, and trust model.
+        </>
       ),
       iconSrc: "/img/card_icon_understand.png",
     },
@@ -80,9 +80,7 @@ export default function Home(): React.ReactNode {
       title: "Build and deploy on Linea",
       link: "/network/quickstart",
       description: (
-        <>
-          Build, launch, and grow your application on the Linea Mainnet.
-        </>
+        <>Build, launch, and grow your application on the Linea Mainnet.</>
       ),
       iconSrc: "/img/card_icon_build.png",
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,14 @@ function HomepageHeader() {
         <p className={clsx("hero__subtitle", styles.subtitle)}>
           Everything you need to build onchain.
         </p>
+        <p className={clsx(styles.subtitle)}>
+          Linea is the public zkEVM network.{" "}
+          <Link className={styles.subtitleLink} to="/protocol/linea-vs-lineth">
+            Lineth
+          </Link>{" "}
+          is the open-source
+          stack that powers it.
+        </p>
         <div className={styles.buttons}>
           <Link
             className={clsx(
@@ -30,8 +38,8 @@ function HomepageHeader() {
               styles.bannerButton,
               styles.bannerButtonPrimary,
             )}
-            to="/stack/quickstart">
-            Launch your chain
+            to="/protocol/overview">
+            Discover Lineth
           </Link>
           <Link
             className={clsx(
@@ -40,7 +48,7 @@ function HomepageHeader() {
               styles.bannerButtonSecondary,
             )}
             to="/network/quickstart">
-            Launch your app
+            Build on Linea
           </Link>
         </div>
       </div>
@@ -51,24 +59,20 @@ function HomepageHeader() {
 export default function Home(): React.ReactNode {
   const startBuildingCards = [
     {
-      title: "Understand how Linea works",
+      title: "Learn about Lineth components",
       link: "/stack/how-it-works",
       description: (
-        <>
-          Learn how the Linea Protocol executes, proves, and finalizes
-          transactions.
-        </>
+        <>Explore Lineth's deployment models, data availability, finalization, and trust model.
+
+</>
       ),
       iconSrc: "/img/card_icon_understand.png",
     },
     {
-      title: "Launch your own Linea chain",
+      title: "Launch your own chain",
       link: "/stack",
       description: (
-        <>
-          Deploy and operate your own Ethereum-compatible network using the
-          Linea Stack.
-        </>
+        <>Deploy your own Ethereum-compatible network using Lineth.</>
       ),
       iconSrc: "/img/card_icon_launch.png",
     },
@@ -77,7 +81,7 @@ export default function Home(): React.ReactNode {
       link: "/network/quickstart",
       description: (
         <>
-          Build, launch, and grow your application on the Linea Public Network.
+          Build, launch, and grow your application on the Linea Mainnet.
         </>
       ),
       iconSrc: "/img/card_icon_build.png",


### PR DESCRIPTION
## Summary

Realigns the docs homepage (`src/pages/index.tsx`) with the new Linea/Lineth split: **Linea** = the public network/brand, **Lineth** = the open-source stack + protocol that powers it. Homepage only; no other pages touched.

### Hero
- Added a framing line under the tagline: *"Linea is the public zkEVM network. Lineth is the open-source stack that powers it."* with **Lineth** linked to the Linea/Lineth explainer (`/protocol/linea-vs-lineth`).
- Relabeled hero buttons to carry the two paths:
  - `Launch your chain` → **Discover Lineth** (now → `/protocol/overview`)
  - `Launch your app` → **Build on Linea** (`/network/quickstart`)

### "Start building" cards
- Card 1: *"Understand how Linea works"* → **"Learn about Lineth components"**; description now covers Lineth's deployment models, data availability, finalization, and trust model. Link points to `/stack/how-it-works` (matches the content).
- Card 2: *"Launch your own Linea chain"* → **"Launch your own chain"**; description updated to "...using Lineth." (link `/stack`).
- Card 3: title unchanged; *"Linea Public Network"* → **"Linea Mainnet"** (link `/network/quickstart`).

### Community cards & meta
- Community cards (support, ecosystem, feedback) left unchanged — all Linea/brand.
- Hero title "Linea Docs" and the page meta description ("powered by Consensys") left unchanged — brand copy.

### Styling
- Added a `.subtitle .subtitleLink` rule so the "Lineth" link uses the brand cyan (`#61dfff`) accent on the navy hero instead of the low-contrast default link purple (fades to near-white on hover, no underline).

## ⚠️ Build dependency
The framing-line link targets `/protocol/linea-vs-lineth`, which lands with the **`docs/lineth-rename-phase2`** branch (merging shortly). Until that merges, `npm run build` fails with a single expected broken-link error:

```
Broken link on source page path = /:
  -> linking to /protocol/linea-vs-lineth
```

Once phase2 is on `main`, the build goes green with no further changes. **Merge after / alongside phase2.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)