### PR TITLE
docs: fix homepage Lineth link color (design-system compliant)

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -126,6 +126,7 @@
    always-navy hero in both themes (no !important needed). */
 .subtitle .subtitleLink {
   --linea-link-highlight-color: var(--linea-brand-cyan);
+  font-weight: 700;
   transition: color 0.3s ease;
 }
 

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -119,14 +119,18 @@
   text-align: center;
 }
 
+/* The global `a:not(...)` reset in base.css colors links via
+   --linea-link-highlight-color, and PostCSS expands its :not() list into a
+   chained selector whose specificity can't be beaten naturally. Override the
+   token locally instead so the global rule resolves to cyan on the
+   always-navy hero in both themes (no !important needed). */
 .subtitle .subtitleLink {
-  color: var(--linea-brand-cyan);
-  text-decoration: none;
+  --linea-link-highlight-color: var(--linea-brand-cyan);
   transition: color 0.3s ease;
 }
 
 .subtitle .subtitleLink:hover {
-  color: #f8f7f2;
+  --linea-link-highlight-color: var(--linea-white);
 }
 
 @media (max-width: 1250px) {


### PR DESCRIPTION
## Summary

Follow-up to #1539. The hero **Lineth** link rendered in the default link color (theme-flipped purple/cyan) instead of the intended brand cyan on the navy hero.

## Root cause

The global reset in `base.css` colors links via a design token:

```css
a:not(.navbar__link, .footer__link-item, .menu__link, .support-link, .table-of-contents__link) {
  color: var(--linea-link-highlight-color);
}
```

PostCSS expands that single `:not(list)` into **chained** `:not()` calls in the compiled output, so the real specificity is **(0,5,1)**, not the (0,1,1) the source implies. A plain `.subtitle .subtitleLink` rule (0,2,0) loses, so the color never changed.

## Fix (per AGENTS.md design system)

Rather than fight specificity with `!important` (forbidden unless commented) or hardcoded hex, **override the token locally**:

```css
.subtitle .subtitleLink {
  --linea-link-highlight-color: var(--linea-brand-cyan);
}
.subtitle .subtitleLink:hover {
  --linea-link-highlight-color: var(--linea-white);
}
```

A directly-set custom property always beats the inherited `:root`/`[data-theme]` value (cascade of custom properties, not a specificity contest), so the global rule itself resolves to cyan on the link in both themes. No `!important`, no hardcoded values, only `--linea-brand-cyan` / `--linea-white` tokens.

## Verification

- `npm run lint` passes (lint:js + lint:style).
- `npm run build` passes (`[SUCCESS]`, no broken links).
- Compiled CSS confirms the override: `.subtitleLink_*{--linea-link-highlight-color:var(--linea-brand-cyan)}`.
- The only rule coloring `<a>` is the global reset that reads this token; the only other `a` color rule (`.theme-announcement-bar a`) is scoped and does not match.

Note: verified via compiled-CSS + cascade analysis; no headless browser is installed locally for a live screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)