### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -1,5 +1,11 @@
 # Linea documentation
 
+[![Build](https://github.com/Consensys/doc.linea/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Consensys/doc.linea/actions/workflows/build.yml)
+[![Security scan](https://github.com/Consensys/doc.linea/actions/workflows/security-code-scanner.yml/badge.svg?branch=main)](https://github.com/Consensys/doc.linea/actions/workflows/security-code-scanner.yml)
+[![License](https://img.shields.io/github/license/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/blob/main/LICENSE)
+[![Open issues](https://img.shields.io/github/issues/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/issues)
+[![Open PRs](https://img.shields.io/github/issues-pr/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/pulls)
+
 Source for [`docs.linea.build`](https://docs.linea.build/), the official Linea
 documentation site. The site is built with [Docusaurus](https://docusaurus.io/)
 v3 and deployed on Vercel.

--- a/README.mdx
+++ b/README.mdx
@@ -3,8 +3,6 @@
 [![Build](https://github.com/Consensys/doc.linea/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Consensys/doc.linea/actions/workflows/build.yml)
 [![Security scan](https://github.com/Consensys/doc.linea/actions/workflows/security-code-scanner.yml/badge.svg?branch=main)](https://github.com/Consensys/doc.linea/actions/workflows/security-code-scanner.yml)
 [![License](https://img.shields.io/github/license/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/blob/main/LICENSE)
-[![Open issues](https://img.shields.io/github/issues/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/issues)
-[![Open PRs](https://img.shields.io/github/issues-pr/Consensys/doc.linea)](https://github.com/Consensys/doc.linea/pulls)
 
 Source for [`docs.linea.build`](https://docs.linea.build/), the official Linea
 documentation site. The site is built with [Docusaurus](https://docusaurus.io/)


### PR DESCRIPTION
## Summary

Adds a small, accurate badge row directly under the README title. Every badge maps to something the repo genuinely supports — no fake CI/Codecov/npm badges — and conveys info the GitHub UI doesn't already surface in its tab chrome.

| Badge | Why |
|-------|-----|
| **Build** | `build.yml` runs on push to `main`; primary "is the docs site building" signal (`?branch=main`). Not shown anywhere in GitHub's tabs. |
| **Security scan** | `security-code-scanner.yml` runs on push to `main`; shows the repo is security-scanned. |
| **License** | `LICENSE` exists (GitHub detects Apache-2.0); standard README convention. |

## Intentionally excluded

- **Open issues / Open PRs** — already shown in GitHub's Issues/Pull requests tabs; redundant for a repo that isn't published outside GitHub.
- **Codecov** — no `codecov.yml` / coverage tooling in this repo.
- **npm / package** — `package.json` is `private: true`.
- **Deploy** — deployment is via Vercel, not a GitHub Action, so there's no workflow to badge.
- **lint / links / spelling / case / nightly** — these run on PRs only (or schedule), so `?branch=main` would show no/misleading status.
- **GitHub stars / social** — omitted to avoid a marketing feel on a docs repo.

Diff is scoped strictly to the badge row; no other README content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime, CI, or application code impact.
> 
> **Overview**
> Adds a **badge row** under the main `# Linea documentation` heading in `README.mdx`, with blank lines separating it from the intro paragraph.
> 
> The three badges link to real repo signals: **Build** (`build.yml` on `main`), **Security scan** (`security-code-scanner.yml` on `main`), and **License** (shields.io → `LICENSE` on `main`). No other README sections or content are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22275e5b77fbb0107a37f790e49a014f8090a465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->