### PR TITLE
docs: add protocol architecture descriptions

### DIFF
--- a/docs/protocol/architecture/coordinator.mdx
+++ b/docs/protocol/architecture/coordinator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Coordinator
+description: How the Coordinator orchestrates batching, proof generation, and finality submission.
 sidebar_position: 4
 image: /img/socialCards/coordinator.jpg
 ---

--- a/docs/protocol/architecture/coordinator.mdx
+++ b/docs/protocol/architecture/coordinator.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coordinator
-description: How the Coordinator orchestrates batching, proof generation, and finality submission.
+description: How the Lineth Coordinator orchestrates batching, proof generation, and finality submission.
 sidebar_position: 4
 image: /img/socialCards/coordinator.jpg
 ---

--- a/docs/protocol/architecture/interoperability/canonical-message-service.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-message-service.mdx
@@ -1,6 +1,6 @@
 ---
 title: Canonical message service
-description: How the canonical message service passes arbitrary messages between Linea and other networks.
+description: How Lineth's canonical message service passes arbitrary messages between networks.
 sidebar_position: 9
 image: /img/socialCards/canonical-message-service.jpg
 ---

--- a/docs/protocol/architecture/interoperability/canonical-message-service.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-message-service.mdx
@@ -1,5 +1,6 @@
 ---
 title: Canonical message service
+description: How the canonical message service passes arbitrary messages between Linea and other networks.
 sidebar_position: 9
 image: /img/socialCards/canonical-message-service.jpg
 ---

--- a/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
@@ -1,5 +1,6 @@
 ---
 title: Canonical token bridge
+description: How the canonical token bridge uses lock-and-mint contracts and the message service for ERC-20 transfers.
 sidebar_position: 8
 image: /img/socialCards/canonical-token-bridge.jpg
 ---

--- a/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
@@ -1,6 +1,6 @@
 ---
 title: Canonical token bridge
-description: How the canonical token bridge uses lock-and-mint contracts and the message service for ERC-20 transfers.
+description: How Lineth's canonical token bridge uses lock-and-mint contracts and the message service for ERC-20 transfers.
 sidebar_position: 8
 image: /img/socialCards/canonical-token-bridge.jpg
 ---

--- a/docs/protocol/architecture/prover/index.mdx
+++ b/docs/protocol/architecture/prover/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trace expansion and proving
-description: How trace expansion and proving generate zero-knowledge proofs for state transitions.
+description: How trace expansion and proving in Lineth generate zero-knowledge proofs for state transitions.
 sidebar_position: 14
 image: /img/socialCards/trace-expansion-and-proving.jpg
 ---

--- a/docs/protocol/architecture/prover/index.mdx
+++ b/docs/protocol/architecture/prover/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Trace expansion and proving
+description: How trace expansion and proving generate zero-knowledge proofs for state transitions.
 sidebar_position: 14
 image: /img/socialCards/trace-expansion-and-proving.jpg
 ---

--- a/docs/protocol/architecture/prover/proving.mdx
+++ b/docs/protocol/architecture/prover/proving.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Proving: Circuit execution and runtime'
-description: How gnark builds circuits and generates zk-SNARK proofs from expanded traces.
+description: How gnark builds circuits and generates zk-SNARK proofs for Lineth state transitions.
 sidebar_position: 2
 image: /img/socialCards/proving-circuit-execution-and-runtime.jpg
 ---

--- a/docs/protocol/architecture/prover/proving.mdx
+++ b/docs/protocol/architecture/prover/proving.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proving: Circuit execution and runtime'
+description: How gnark builds circuits and generates zk-SNARK proofs from expanded traces.
 sidebar_position: 2
 image: /img/socialCards/proving-circuit-execution-and-runtime.jpg
 ---

--- a/docs/protocol/architecture/prover/trace-expansion.mdx
+++ b/docs/protocol/architecture/prover/trace-expansion.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proving: Circuit building'
+description: How Corset builds constraint systems and expands traces for the proving pipeline.
 sidebar_position: 1
 image: /img/socialCards/proving-circuit-building.jpg
 ---

--- a/docs/protocol/architecture/prover/trace-expansion.mdx
+++ b/docs/protocol/architecture/prover/trace-expansion.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Proving: Circuit building'
-description: How Corset builds constraint systems and expands traces for the proving pipeline.
+description: How Corset builds constraint systems and expands traces for the Lineth proving pipeline.
 sidebar_position: 1
 image: /img/socialCards/proving-circuit-building.jpg
 ---

--- a/docs/protocol/architecture/sequencer/conflation.mdx
+++ b/docs/protocol/architecture/sequencer/conflation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Conflation
-description: How conflation combines blocks into proof-sized data sets for efficient proving.
+description: How conflation in Lineth combines blocks into proof-sized data sets for efficient proving.
 sidebar_position: 2
 image: /img/socialCards/conflation.jpg
 ---

--- a/docs/protocol/architecture/sequencer/conflation.mdx
+++ b/docs/protocol/architecture/sequencer/conflation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Conflation
+description: How conflation combines blocks into proof-sized data sets for efficient proving.
 sidebar_position: 2
 image: /img/socialCards/conflation.jpg
 ---

--- a/docs/protocol/architecture/sequencer/index.mdx
+++ b/docs/protocol/architecture/sequencer/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sequencer
+description: How the Sequencer orders transactions, builds blocks, and prepares execution traces for proving.
 sidebar_position: 11
 image: /img/socialCards/sequencer.jpg
 ---

--- a/docs/protocol/architecture/sequencer/index.mdx
+++ b/docs/protocol/architecture/sequencer/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sequencer
-description: How the Sequencer orders transactions, builds blocks, and prepares execution traces for proving.
+description: How the Lineth Sequencer orders transactions, builds blocks, and prepares execution traces for proving.
 sidebar_position: 11
 image: /img/socialCards/sequencer.jpg
 ---


### PR DESCRIPTION
## Summary
- Add missing `description` frontmatter to Protocol architecture pages for Coordinator, Sequencer, Conflation, Prover, and interoperability pages.
- Improve page-level metadata and generated agent-docs summaries without changing titles, routes, or body copy.

## Test plan
- [x] `npm run agent-docs:test`
- [x] `npx docusaurus build`
- [x] `node scripts/agent-docs/generate.js && npm run agent-docs:check`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)