### PR TITLE
docs(api): refresh SDK reference for the viem-based Lineth SDK

### DIFF
--- a/docs/api/linea-sdk.mdx
+++ b/docs/api/linea-sdk.mdx
@@ -1,320 +1,216 @@
 ---
-title: Linea SDK
+title: Lineth SDK
+description: >-
+  A viem-based TypeScript SDK for bridging ETH and tokens and for sending and
+  claiming messages between Ethereum and Linea.
 sidebar_position: 4
 image: /img/socialCards/linea-sdk.jpg
 ---
 
-The SDK focuses on interacting with smart contracts on both Ethereum and Linea networks and provides 
-custom functions to obtain message information, including claiming bridge messages. You can also use 
-the SDK to get:
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-- Contract instances and addresses
-- Message information, by message hash
-- Messages by transaction hash
-- Getting a message status by message hash
+Bridge ETH and tokens, and send and claim messages between Ethereum (L1) and Linea (L2), using a set of composable TypeScript functions. The Lineth SDK is built on [viem](https://viem.sh/): you create standard viem clients and call SDK actions on them, or extend a client with SDK decorators.
 
-:::info[New features]
+The SDK is published as two packages:
 
-The updated Linea SDK package enhances the L1 contract interaction and adds support for the new L1 claiming system, which is based on a Merkle tree and requires a Merkle proof for claiming.
+- `@lfdt-lineth/sdk-viem`: the actions and decorators most applications use.
+- `@lfdt-lineth/sdk-core`: framework-agnostic utilities (Merkle tree, message types, chain and contract helpers). Most users get it automatically through `@lfdt-lineth/sdk-viem` and do not install it directly.
 
-There are three important things to note:
+It supports Ethereum Mainnet, Linea Mainnet, Sepolia, and Linea Sepolia. You select the network by passing the matching chain from `viem/chains`, and the SDK resolves the correct contract addresses for you.
 
-- The previous L1 claiming and all associated functions are still supported.
-- The L2 claiming remains unaltered, and all SDK features for interacting with L2 will remain unchanged.
-- The previous L1 claiming function and code samples provided here cater to the transition period where pre-transition messages are claimed without the Merkle proof and post-transition with proof. If this SDK is being used after the transition, using the logic that switches between Merkle and non-Merkle proof claiming is suboptimal.
+## Installation
 
-The updated SDK introduces several new features for L1 interactions:
-
-- A new L1ClaimingService class that includes the following functions:
-  - `getMessageProof`: This function retrieves the message Merkle tree proof required for new message claims on L1.
-  - `isClaimingNeedingProof`: This function determines whether a proof is needed to claim a message.
-  - `getMessageStatus`: This function retrieves a message's status, returning the status of both old and new messages.
-  - `estimateClaimMessageGas`: This function provides an estimate of the gas cost for both old and new claim transactions.
-  - `claimMessage`: This function enables a message to be claimed using either the old or new function.
-- Two new functions in the L1 contract:
-  - `estimateClaimWithProofGas`: This function estimates the gas cost for new claim transactions.
-  - `claimWithProof`: This function claims a message using the new claimMessageWithProof function.
-
-:::
-
-## Usage
-
-:::note
-
-The SDK does not currently support sending messages. This feature will be added in a future release.
-
-:::
-
-To install the package, run:
+Install the SDK alongside viem, which is a required peer dependency (version 2.22.0 or later):
 
 ```bash
-npm install @consensys/linea-sdk
+npm install @lfdt-lineth/sdk-viem viem
 ```
 
-Then initialize the SDK: 
+## Set up your clients
 
-```typescript
-const sdk = new LineaSDK({
-  network: 'linea-mainnet', // or 'linea-sepolia' or 'custom'
-  mode: 'read-write',
-  l1RpcUrlOrProvider: 'YOUR_L1_RPC_URL',
-  l2RpcUrlOrProvider: 'YOUR_L2_RPC_URL',
-  l1SignerPrivateKeyOrWallet: 'YOUR_L1_PRIVATE_KEY',
-  l2SignerPrivateKeyOrWallet: 'YOUR_L2_PRIVATE_KEY'
+Most actions take a viem client. Read actions use a public client, and state-changing actions (deposits, withdrawals, claims) use a wallet client. Use `mainnet` and `linea` for production, or `sepolia` and `lineaSepolia` for testing:
+
+```ts
+import { createPublicClient, http } from 'viem';
+import { sepolia, lineaSepolia } from 'viem/chains';
+
+const l1Client = createPublicClient({ chain: sepolia, transport: http() });
+const l2Client = createPublicClient({ chain: lineaSepolia, transport: http() });
+```
+
+## Bridge ETH and tokens
+
+Use `deposit` to bridge from L1 to L2, and `withdraw` to bridge from L2 to L1. Set `token` to `zeroAddress` to bridge native ETH. Both actions take a wallet client and return a transaction hash.
+
+```ts
+import { createWalletClient, createPublicClient, http, zeroAddress } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { sepolia, lineaSepolia } from 'viem/chains';
+import { deposit } from '@lfdt-lineth/sdk-viem';
+
+const client = createWalletClient({ chain: sepolia, transport: http() });
+const l2Client = createPublicClient({ chain: lineaSepolia, transport: http() });
+
+const hash = await deposit(client, {
+  l2Client,
+  account: privateKeyToAccount('0x...'),
+  amount: 1_000_000_000_000n,
+  token: zeroAddress, // Use zeroAddress for ETH
+  to: '0xRecipientAddress',
+  data: '0x', // Optional data
+  fee: 100_000_000n, // Optional fee
 });
-
-// Get L1 and L2 contract instances
-const l1Contract = sdk.getL1Contract();
-const l2Contract = sdk.getL2Contract();
 ```
 
-The SDK supports two `mode`s: 
-- `read-only`: The client operates without the ability to send transactions; it can only read data 
-from the blockchain and does not require private keys.
-- `read-write`: The client can read data and also send transactions, which means you must include
-signing credentials with `l1SignerPrivateKeyOrWallet` and `l2SignerPrivateKeyOrWallet`, depending
-on which layer you need.
+```ts
+import { createWalletClient, http, zeroAddress } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { lineaSepolia } from 'viem/chains';
+import { withdraw } from '@lfdt-lineth/sdk-viem';
 
-See the [SDK README](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/ts-libs/sdk) 
-for a full list of configuration options.
+const client = createWalletClient({ chain: lineaSepolia, transport: http() });
 
-### Claim
+const hash = await withdraw(client, {
+  account: privateKeyToAccount('0x...'),
+  amount: 1_000_000_000_000n,
+  token: zeroAddress, // Use zeroAddress for ETH
+  to: '0xRecipientAddress',
+  data: '0x', // Optional data
+});
+```
 
-Regardless of the layer you need to claim on, you'll need the message hash of the message sent 
-from the origin layer. You can find this in the transaction logs of the message sending transaction
-on the block explorer as a `MessageSent` event.
+## Claim messages
+
+A message sent across the bridge is claimed on the destination layer. Messages to L2 are usually delivered automatically by the Postman service, so manual claiming is mainly needed on L1. Use `claimOnL1` to finalize an L2-to-L1 message, and `claimOnL2` to finalize an L1-to-L2 message.
+
+Claiming on L1 requires a Merkle proof. You can fetch it with [`getMessageProof`](#read-message-data) and pass it in, as shown below.
 
 <Tabs className="my-tabs">
   <TabItem value="L1" label="Claim on L1">
-    The contract function for claiming on L1, `claimMessageWithProof`, is complex and requires a Merkle 
-    proof, Merkle root, and leaf index for the message. The SDK simplifies this by using its [`L1ClaimingService`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/c6550573d3e1840fcfb97c00fc8697933c7b373f/sdk/src/clients/ethereum/L1ClaimingService.ts) 
-    to handle the complex logic, meaning you only need to call `claimMessage`. 
 
-    For example:
+```ts
+import { createWalletClient, http, zeroAddress } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { sepolia } from 'viem/chains';
+import { claimOnL1 } from '@lfdt-lineth/sdk-viem';
 
-    ```typescript
+const client = createWalletClient({ chain: sepolia, transport: http() });
 
-    const message = await l2Contract.getMessageByMessageHash("messageHash");
+const hash = await claimOnL1(client, {
+  account: privateKeyToAccount('0x...'),
+  from: '0xSenderAddress',
+  to: '0xRecipientAddress',
+  fee: 100_000_000n,
+  value: 1_000_000_000_000n,
+  messageNonce: 1n,
+  calldata: '0x',
+  feeRecipient: zeroAddress,
+  messageProof: {
+    root: '0x...',
+    proof: ['0x...'],
+    leafIndex: 0,
+  },
+});
+```
 
-    const messageStatus = await l1ClaimingService.getMessageStatus("messageHash"); 
-
-    if (messageStatus == OnChainMessageStatus.CLAIMABLE) {
-      await l1ClaimingService.claimMessage(message);
-    }
-
-    ```
-
-    This code checks to locate the message from L2, then whether it's claimable yet on L1. If it is,
-    it calls `claimMessage` to claim the message.
   </TabItem>
   <TabItem value="L2" label="Claim on L2">
-    In most situations, messages _to_ L2 will be automatically retrieved by the Postman service, and 
-    manually claiming with the SDK will not be necessary. Most Postman fees are automatically sponsored 
-    by Linea on L2, and therefore do not require a transaction and an accompanying fee to claim,
-    and are claimed automatically.
 
-    Since claiming on L2 requires fewer and less complex parameters, we can use the `claim` function:
+```ts
+import { createWalletClient, http, zeroAddress } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { lineaSepolia } from 'viem/chains';
+import { claimOnL2 } from '@lfdt-lineth/sdk-viem';
 
-    ```typescript
+const client = createWalletClient({ chain: lineaSepolia, transport: http() });
 
-    const message = await l1Contract.getMessageByMessageHash("messageHash");
+const hash = await claimOnL2(client, {
+  account: privateKeyToAccount('0x...'),
+  from: '0xSenderAddress',
+  to: '0xRecipientAddress',
+  fee: 100_000_000n,
+  value: 1_000_000_000_000n,
+  messageNonce: 1n,
+  calldata: '0x',
+  feeRecipient: zeroAddress,
+  // Optional transaction parameters
+  gas: 21000n,
+  maxFeePerGas: 100_000_000n,
+  maxPriorityFeePerGas: 1_000_000n,
+});
+```
 
-    const messageStatus = await l2Contract.getMessageStatus("messageHash");
-
-    if (messageStatus == OnChainMessageStatus.CLAIMABLE) {
-      await l2Contract.claim(message);
-    }
-
-    ```
-
-    This code checks to locate the message from L1, then whether it's claimable yet on L2. If it is,
-    it calls `claim` to claim the message.
-
-    See the [`L2MessageServiceClient`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/c6550573d3e1840fcfb97c00fc8697933c7b373f/sdk/src/clients/linea/L2MessageServiceClient.ts) 
-    for the source code.
   </TabItem>
 </Tabs>
 
-## Examples
+## Read message data
 
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
+These actions run on a public client and read data from the chain. To check whether a message is ready to claim, query its status, and to claim on L1, fetch its proof:
 
-<Tabs className="my-tabs" defaultValue="new" values={[ {label: 'v0.2.0-rc.1', value: 'new'}, {label: 'v0.1.6', value: 'old'}, ] }> 
-  <TabItem value="old">
+```ts
+import { createPublicClient, http } from 'viem';
+import { sepolia, lineaSepolia } from 'viem/chains';
+import { getL2ToL1MessageStatus, getMessageProof } from '@lfdt-lineth/sdk-viem';
 
-  ```typescript
-  import * as dotenv from "dotenv";
-  import { LineaSDK } from "@consensys/linea-sdk";
-  import { BigNumber } from "ethers";
+const l1Client = createPublicClient({ chain: sepolia, transport: http() });
+const l2Client = createPublicClient({ chain: lineaSepolia, transport: http() });
 
-  dotenv.config();
+const status = await getL2ToL1MessageStatus(l1Client, {
+  l2Client,
+  messageHash: '0x...',
+});
 
-  const sdk = new LineaSDK({
-    l1RpcUrl: process.env.L1_RPC_URL ?? "", // L1 rpc url
-    l2RpcUrl: process.env.L2_RPC_URL ?? "", // L2 rpc url
-    l1SignerPrivateKey: process.env.L1_SIGNER_PRIVATE_KEY ?? "", // L1 account private key (optional if you use mode = read-only)
-    l2SignerPrivateKey: process.env.L2_SIGNER_PRIVATE_KEY ?? "", // L2 account private key (optional if you use mode = read-only)
-    network: "linea-mainnet", // network you want to interact with (either linea-mainnet or linea-sepolia)
-    mode: "read-write", // contract wrapper class mode (read-only or read-write), read-only: only read contracts state, read-write: read contracts state and claim messages
-  });
+const messageProof = await getMessageProof(l1Client, {
+  l2Client,
+  messageHash: '0x...',
+});
+```
 
-  const l1Contract = sdk.getL1Contract(); // get the L1 contract wrapper instance
-  const l2Contract = sdk.getL2Contract(); // get the L2 contract wrapper instance
-  const l1ClaimingService = sdk.getL1ClaimingService();
+The full set of read actions:
 
-  console.log(
-    await l2Contract.getMessageStatus(
-      "0x13dd0f5e3611b44c88e80f5206bbe1ce1c6996514cef1e209e9eb06d9f5b9a2d",
-    ),
-  ); //  returns on-chain message status by message hash
-  console.log(
-    await l1Contract.getMessageStatus(
-      "0x28e9e11b53d624500f7610377c97877bb1ecb3127a88f7eba84dd7a146891946",
-    ),
-  ); // returns on-chain message status by message hash
+| Action | Returns |
+| --- | --- |
+| `getL1ToL2MessageStatus` | Whether an L1-to-L2 message is unknown, claimable, or claimed. |
+| `getL2ToL1MessageStatus` | Whether an L2-to-L1 message is unknown, claimable, or claimed, including finalization checks. |
+| `getMessageProof` | The Merkle proof needed to claim an L2-to-L1 message on L1. |
+| `getMessageByMessageHash` | Full message details from on-chain `MessageSent` events. |
+| `getMessagesByTransactionHash` | All messages emitted in a given transaction. |
+| `getTransactionReceiptByMessageHash` | The transaction receipt that contains a specific message. |
+| `getMessageSentEvents` | `MessageSent` logs for a given block range. |
+| `getBlockExtraData` | Decoded Linea block `extraData` (version and fee parameters). |
+| `computeMessageHash` | Deterministically hashes message parameters (utility). |
 
-  console.log(
-    await l2Contract.getMessageByMessageHash(
-      "0x13dd0f5e3611b44c88e80f5206bbe1ce1c6996514cef1e209e9eb06d9f5b9a2d",
-    ),
-  ); // returns message by message hash
-  console.log(await l1Contract.getMessageByMessageHash("")); // returns message by message hash
+## Decorators
 
-  console.log(
-    await l2Contract.getMessagesByTransactionHash(
-      "0x4b72c6abacd3e2372a32e2797c41cab08df8d5e6fb2eb453e896e52fe7b70a27",
-    ),
-  ); // returns message by transaction hash
-  console.log(await l1Contract.getMessagesByTransactionHash("")); // returns message by transaction hash
+Instead of calling actions as standalone functions, you can extend a viem client so the actions become methods on the client. Use `publicActionsL1` and `publicActionsL2` for read actions, and `walletActionsL1` and `walletActionsL2` for write actions:
 
-  console.log(
-    await l2Contract.getTransactionReceiptByMessageHash(
-      "0x13dd0f5e3611b44c88e80f5206bbe1ce1c6996514cef1e209e9eb06d9f5b9a2d",
-    ),
-  ); // returns transaction receipt by message hash
-  console.log(
-    await l1Contract.getTransactionReceiptByMessageHash(
-      "0x13dd0f5e3611b44c88e80f5206bbe1ce1c6996514cef1e209e9eb06d9f5b9a2d",
-    ),
-  ); // returns transaction receipt by message hash
+```ts
+import { createPublicClient, http } from 'viem';
+import { sepolia, lineaSepolia } from 'viem/chains';
+import { publicActionsL1, publicActionsL2 } from '@lfdt-lineth/sdk-viem';
 
-  const claimMessage = await l2Contract.claim({
-    // claims message by message
-    messageSender: "", // address of message sender
-    messageHash: "", // message hash
-    fee: BigNumber.from(1), // fee
-    destination: "", // destination address of message
-    value: BigNumber.from(2), // value of message
-    calldata: "0x", // call data
-    messageNonce: BigNumber.from(1), // message nonce
-    feeRecipient: "0x", // address that will receive fees. by default it is the message sender
-  });
-  ```
+const l1Client = createPublicClient({ chain: sepolia, transport: http() }).extend(publicActionsL1());
+const l2Client = createPublicClient({ chain: lineaSepolia, transport: http() }).extend(publicActionsL2());
+```
 
-  </TabItem> 
-  <TabItem value="new">
+Each decorator accepts optional contract addresses (`lineaRollupAddress`, `l2MessageServiceAddress`, and for wallet decorators the token bridge addresses) for non-standard deployments. On the supported networks you can omit them, and the SDK resolves the correct addresses automatically.
 
-  ```typescript
-  import * as dotenv from "dotenv";
-  import { LineaSDK } from "@consensys/linea-sdk";
-  import { BigNumber } from 'ethers';
+## Core utilities
 
+For advanced or framework-agnostic use, `@lfdt-lineth/sdk-core` exposes the building blocks the viem package is built on: `SparseMerkleTree` for proof generation and verification, `parseBlockExtraData`, `formatMessageStatus`, `getContractsAddressesByChainId`, the `OnChainMessageStatus` enum, chain helpers, and the message types. Install it directly only if you need these without viem:
 
-  dotenv.config();
+```bash
+npm install @lfdt-lineth/sdk-core
+```
 
-  const sdk = new LineaSDK({
-      l1RpcUrl: process.env.L1_RPC_URL ?? "",
-      l2RpcUrl: process.env.L2_RPC_URL ?? "",
-      l1SignerPrivateKey: process.env.L1_SIGNER_PRIVATE_KEY ?? "",
-      l2SignerPrivateKey: process.env.L2_SIGNER_PRIVATE_KEY ?? "",
-      network: "linea-mainnet",
-      mode: "read-write",
-    });
+## Resources
 
-    const l1Contract = sdk.getL1Contract();
-    const l2Contract = sdk.getL2Contract();
-    const l1ClaimingService = sdk.getL1ClaimingService();
+- [`@lfdt-lineth/sdk-viem` README](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/ts-libs/sdk/sdk-viem): the full reference for every action, decorator, and error type.
+- [viem documentation](https://viem.sh/): client setup, transports, and accounts.
 
-    /********************* Three approaches to claim on L1 *********************/
+:::note
 
-    // 1. The L1 Claiming service manages all the necessary logic for you.
-    const message = await l2Contract.getMessageByMessageHash("messageHash");
+This SDK was previously published as `@consensys/linea-sdk`. The package was renamed to `@lfdt-lineth/sdk-viem` and rebuilt on viem. The previous `@consensys/linea-sdk` API (the `LineaSDK` class and `L1ClaimingService`) is no longer the documented interface.
 
-    const messageStatus = await l1ClaimingService.getMessageStatus("messageHash");
-
-    if (messageStatus == OnChainMessageStatus.CLAIMABLE) {
-      const estimatedGas = await l1ClaimingService.estimateClaimMessageGas(message); // Optional
-      await l1ClaimingService.claimMessage(message);
-    }
-
-    // 2. You can handle the logic on your side
-    const message = await l2Contract.getMessageByMessageHash("messageHash");
-
-    const messageStatus = await l1ClaimingService.getMessageStatus("messageHash");
-
-    if (messageStatus == OnChainMessageStatus.CLAIMABLE) {
-      const isProofNeeded = await l1ClaimingService.isClaimingNeedingProof("messageHash");
-      if (!isProofNeeded) {
-        const estimatedGas = await l1Contract.estimateClaimGas(message) // Optional
-        await l1Contract.claim(message);
-      } else {
-        const proofInfo = await l1ClaimingService.getMessageProof("messageHash");
-        const estimatedGas = await l1Contract.estimateClaimWithProofGas({
-          ...message,
-          proof: proofInfo.proof,
-          leafIndex: proofInfo.leafIndex,
-          merkleRoot: proofInfo.root,
-        }); // Optional
-
-        await l1Contract.claimWithProof({
-          ...message,
-          proof: proofInfo.proof,
-          leafIndex: proofInfo.leafIndex,
-          merkleRoot: proofInfo.root,
-        });
-      }
-    }
-
-    // 3. You can implement your own logic to get a merkle proof
-    const message = await l2Contract.getMessageByMessageHash("messageHash");
-
-    const messageStatus = await l1ClaimingService.getMessageStatus("messageHash");
-
-    if (messageStatus == OnChainMessageStatus.CLAIMABLE) {
-      const isProofNeeded = await l1ClaimingService.isClaimingNeedingProof("messageHash");
-      if (!isProofNeeded) {
-        const estimatedGas = await l1Contract.estimateClaimGas(message) // Optional
-        await l1Contract.claim(message);
-      } else {
-        const proofInfo = // Implement your own function to get a merkle proof
-          // The L1ClaimingService exposes some utility functions to assist you: getFinalizationMessagingInfo, getL2MessageHashesInBlockRange, getMessageSiblings
-
-          // Follow these steps:
-          // 1. Retrieve the MessageSent event on L2 by messageHash
-          // 2. Retrieve the L2MessagingBlockAnchored event on L1 using the MessageSent.blockNumber you acquired in step 1. This is used to get the finalization transaction hash where the L2 block number associated with your message has been finalized.
-          // 3. Invoke the getFinalizationMessagingInfo function using the L2MessagingBlockAnchored.transactionHash you obtained in step 2.
-          // This will return all merkle roots anchored during this finalization transaction, the depth of trees, and the first and the last L2 block containing messages finalized on L1 in this transaction.
-          // 4. Invoke the getL2MessageHashesInBlockRange function using the first and last L2 block number that you obtained in step 3. This will return all l2 messages hashes in this L2 block range.
-          // 5. Invoke the getMessageSiblings function to obtain all message siblings
-          // 6. Construct a SparseMerkleTree, add all message siblings you obtained at step 5 to the tree, and return a merkle proof
-
-          // NOTE: You can create your own functions that encompass all steps. Utility functions are merely provided as a helper.
-
-          const estimatedGas = await l1Contract.estimateClaimWithProofGas({
-            ...message,
-            proof: proofInfo.proof,
-            leafIndex: proofInfo.leafIndex,
-            merkleRoot: proofInfo.root,
-          }); // Optional
-          await l1Contract.claimWithProof({
-            ...message,
-            proof: proofInfo.proof,
-            leafIndex: proofInfo.leafIndex,
-            merkleRoot: proofInfo.root,
-          });
-      }
-    }
-
-  ```
-  </TabItem> 
-</Tabs>
+:::

--- a/docs/api/linea-sdk.mdx
+++ b/docs/api/linea-sdk.mdx
@@ -174,7 +174,7 @@ The full set of read actions:
 | `getL1ToL2MessageStatus` | Whether an L1-to-L2 message is unknown, claimable, or claimed. |
 | `getL2ToL1MessageStatus` | Whether an L2-to-L1 message is unknown, claimable, or claimed, including finalization checks. |
 | `getMessageProof` | The Merkle proof needed to claim an L2-to-L1 message on L1. |
-| `getMessageByMessageHash` | Full message details from on-chain `MessageSent` events. |
+| `getMessageByMessageHash` | Full message details from onchain `MessageSent` events. |
 | `getMessagesByTransactionHash` | All messages emitted in a given transaction. |
 | `getTransactionReceiptByMessageHash` | The transaction receipt that contains a specific message. |
 | `getMessageSentEvents` | `MessageSent` logs for a given block range. |

--- a/docs/api/quickstart.mdx
+++ b/docs/api/quickstart.mdx
@@ -3,7 +3,7 @@ title: Get started
 sidebar_label: Get started
 description: >-
   Get started with the Linea APIs and SDK. Explore the JSON-RPC API reference,
-  smart contract reference, Linea SDK, and Token API.
+  smart contract reference, Lineth SDK, and Token API.
 category: Quickstart
 image: /img/socialCards/get-started.jpg
 hide_copy_button: true
@@ -13,7 +13,7 @@ import ActionCards from '@site/src/components/ActionCards';
 import CopyPageButton from '@site/src/components/CopyPageButton';
 
 <div className="intro-with-copy">
-  <p>Get started with the Linea APIs and SDK. Explore the JSON-RPC API reference, smart contract reference, Linea SDK, and Token API.</p>
+  <p>Get started with the Linea APIs and SDK. Explore the JSON-RPC API reference, smart contract reference, Lineth SDK, and Token API.</p>
   <CopyPageButton />
 </div>
 
@@ -28,7 +28,7 @@ import CopyPageButton from '@site/src/components/CopyPageButton';
       href: "/api/linea-smart-contracts/linearollup",
     },
     {
-      text: "Use the Linea SDK",
+      text: "Use the Lineth SDK",
       href: "/api/linea-sdk",
     },
     {

--- a/docs/network/build/send-receive-messages.mdx
+++ b/docs/network/build/send-receive-messages.mdx
@@ -163,34 +163,29 @@ need to call one of these methods using the parameters detailed in the [interfac
     - L2: `claimMessage` 
     - L1: `claimMessageWithProof`
 
-#### Option 2: Use the Linea SDK
+#### Option 2: Use the Lineth SDK
 
-The [Linea SDK](../../api/linea-sdk.mdx) (view the [npm package](https://npmjs.com/package/@consensys/linea-sdk?activeTab=readme))
-simplifies the execution of messages on the destination layer.
+The [Lineth SDK](../../api/linea-sdk.mdx) (view the [npm package](https://npmjs.com/package/@lfdt-lineth/sdk-viem))
+simplifies claiming messages on the destination layer.
 
-Install the SDK using the package manager of your choice. For example:
+Install the SDK alongside viem, which is a required peer dependency:
 
 ```bash
-npm install @consensys/linea-sdk
+npm install @lfdt-lineth/sdk-viem viem
 ```
 
-Refer to the [SDK README](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/ts-libs/sdk) for 
-directions on initializing the SDK and enabling read-write mode. 
+Refer to the [SDK documentation](../../api/linea-sdk.mdx) for 
+client setup. To claim a message, use `claimOnL2` for an L1 to L2 message, or `claimOnL1` (with a
+Merkle proof) for an L2 to L1 message.
 
-Now you can use the `claim()` function on the destination layer to claim messages, passing the 
-message hash as an argument:
-
-```js
-const tx = await l2Contract.claim(message);
-```
-
-You can call `claim()` either on the `l1Contract` or `l2Contract` depending on which you need.
+See [Claim messages](../../api/linea-sdk.mdx#claim-messages) in the SDK reference for the full
+parameters and code examples.
 
 ## Claim old messages
 
 The Linea native bridge app only retains unclaimed message for 90 days; if your bridge transfer is
 older than this, you'll need to claim it outside of the native bridge app using a block explorer or 
-the Linea SDK. We recommend you use the SDK, particularly if you're claiming on L1.
+the Lineth SDK. We recommend you use the SDK, particularly if you're claiming on L1.
 
 :::note
 
@@ -271,8 +266,8 @@ for more information.
     We don't recommend manually claiming messages on L1 with `claimMessageWithProof`, as gathering
     the parameters is complex and involves querying for various events to reconstruct the proof.
 
-    Instead, we recommend using the Linea SDK, which abstracts away most of this complexity. See 
-    the [SDK documentation](../../api/linea-sdk.mdx#claim) for guidance on claiming on L1.
+    Instead, we recommend using the Lineth SDK, which abstracts away most of this complexity. See 
+    the [SDK documentation](../../api/linea-sdk.mdx#claim-messages) for guidance on claiming on L1.
   </TabItem>
 </Tabs>
 

--- a/docs/protocol/linea-vs-lineth.mdx
+++ b/docs/protocol/linea-vs-lineth.mdx
@@ -13,13 +13,13 @@ image: /img/socialCards/linea-and-lineth.jpg
 **Linea** is the public, permissionless zkEVM Layer 2 network that scales Ethereum, along with its brand, token, tokenomics, and governance:
 
 - **Linea Mainnet** and **Linea Sepolia**: the public network and its testnet.
-- The **Linea** brand, the **Linea Consortium** that governs the **Linea Protocol**, and user- and developer-facing products such as the **Linea SDK**.
+- The **Linea** brand, the **Linea Consortium** that governs the **Linea Protocol**, and the public network and its user-facing apps.
 
 When the documentation means the network you transact on, the product, or its governance, it says **Linea**.
 
 ## What is Lineth
 
-**Lineth (formerly the Linea Stack)** is the open-source ZK-rollup stack, codebase, and technical protocol: the protocol components, onchain contracts, and operational tooling that operators deploy. It applies to all chains built on it. It is an incubating project at [LF Decentralized Trust (LFDT)](https://www.lfdecentralizedtrust.org/), where the open-source Linea Stack was contributed and renamed Lineth.
+**Lineth (formerly the Linea Stack)** is the open-source ZK-rollup stack, codebase, and technical protocol: the protocol components, onchain contracts, developer SDKs, and operational tooling that operators deploy. It applies to all chains built on it. It is an incubating project at [LF Decentralized Trust (LFDT)](https://www.lfdecentralizedtrust.org/), where the open-source Linea Stack was contributed and renamed Lineth.
 
 When the documentation means the technical stack, protocol, codebase, deployable components, or the LFDT project, it says **Lineth**.
 
@@ -42,8 +42,8 @@ This mirrors the [LFDT naming model](https://github.com/LF-Decentralized-Trust/w
 
 ## When each name applies
 
-- **Linea**: Linea Mainnet-specific brand, token, tokenomics, Linea Consortium, Linea Mainnet, Linea Sepolia, Linea SDK.
-- **Lineth**: the technical stack and protocol, including the open-source rollup stack, codebase, components, clients, contracts, tooling, LFDT project, and all chains built on it.
+- **Linea**: Linea Mainnet-specific brand, token, tokenomics, Linea Consortium, Linea Mainnet, and Linea Sepolia.
+- **Lineth**: the technical stack and protocol, including the open-source rollup stack, codebase, components, clients, contracts, developer SDKs, tooling, LFDT project, and all chains built on it.
 
 On first reference within a page, the stack is introduced as **"Lineth (formerly the Linea Stack)"**, then **Lineth** thereafter.
 


### PR DESCRIPTION
## What and why
tackle #1554
The public SDK page documented `@consensys/linea-sdk` (the ethers `LineaSDK` class and `L1ClaimingService`), which was replaced on 2026-06-10 by `@lfdt-lineth/sdk-viem@1.0.0`. The old install command and every code sample were broken. This rewrites the page for the new viem-based SDK and rebrands it to "Lineth SDK" to match the `@lfdt-lineth` package scope.

## Changes

- **`docs/api/linea-sdk.mdx`** — full rewrite: install (`@lfdt-lineth/sdk-viem` + `viem` peer dep), client setup, `deposit`/`withdraw`, `claimOnL1`/`claimOnL2` (tabs), read-actions table, decorators, `sdk-core` note, and a "previously published as `@consensys/linea-sdk`" note. Code samples taken from the package README.
- **`docs/network/build/send-receive-messages.mdx`** — fixed the stale install command and npm link, removed the dead `l2Contract.claim()` snippet, repointed the SDK anchor, renamed to Lineth SDK.
- **`docs/api/quickstart.mdx`** — renamed the APIs & SDK landing references to Lineth SDK (URL unchanged).
- **`docs/protocol/linea-vs-lineth.mdx`** — moved the SDK from the Linea list to the Lineth list so the naming page stays consistent with the new brand.

The `/api/linea-sdk` slug is intentionally kept (no redirect/SEO churn). Historical release-notes mentions are left as point-in-time record.

## Validation

- `npm run build` passes, no broken links or anchors.
- All code samples verified against the `@lfdt-lineth/sdk-viem` README and `src/index.ts` (both at `1.0.0` on monorepo `main`).

## Open follow-ups (not in this PR)

- Migration guide for existing `@consensys/linea-sdk` users (needs SDK eng confirmation it is wanted).
- Optional later: move the slug to `/api/lineth-sdk` with a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or contract behavior; main risk is readers following wrong install/API guidance if samples drift from the published package.
> 
> **Overview**
> **Replaces outdated `@consensys/linea-sdk` documentation** with the current **`@lfdt-lineth/sdk-viem`** (viem peer dependency) workflow: install, public/wallet clients, `deposit`/`withdraw`, L1/L2 claiming tabs (`claimOnL1` with Merkle proof, `claimOnL2`), read-actions table, decorators, and a short `sdk-core` note. The page is rebranded **Lineth SDK** and notes the old package/API is no longer the documented interface.
> 
> **Cross-links are updated** so quickstart, message bridging (`send-receive-messages`), and **Linea vs Lineth** naming stay consistent: npm links, install commands, claim anchor (`#claim-messages`), and SDK listed under **Lineth** rather than **Linea**. The `/api/linea-sdk` URL is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c9341ff95caed9c4e2ca83b3d0cd72c7e40964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->