### PR TITLE
docs(stack): add monorepo README links to Lineth Stack quickstart

### DIFF
--- a/docs/stack/how-to/run-lineth-stack-sepolia.mdx
+++ b/docs/stack/how-to/run-lineth-stack-sepolia.mdx
@@ -56,8 +56,9 @@ rather than public Sepolia.
 Required for all modes. These are quickstart minimums for the monorepo stack:
 
 These requirements are quickstart guidance and may change as the Lineth Stack
-evolves. For the latest values, check the Lineth monorepo documentation before
-running the stack.
+evolves. For the latest values, check the
+[Lineth Stack docs in the monorepo](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/lineth-stack)
+before running the stack.
 
 | Requirement             | Minimum                                               |
 | ----------------------- | ----------------------------------------------------- |
@@ -87,6 +88,10 @@ The Lineth prover image is `linux/amd64` only. On Apple Silicon, keep
 slower on M-series machines.
 
 ## Configure Sepolia mode
+
+For full configuration options and an environment variable reference, see the
+[`docs/getting-started/lineth-stack`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/lineth-stack)
+README in the monorepo.
 
 Clone the [Lineth monorepo](https://github.com/LFDT-Lineth/lineth-monorepo),
 then run:


### PR DESCRIPTION
Adds two links to the `docs/getting-started/lineth-stack` README in the Lineth monorepo from the live quickstart page:

- **Before you start**: the existing "check the Lineth monorepo documentation" sentence now links directly to the folder.
- **Configure Sepolia mode**: new opening sentence points to the README for full configuration options and environment variable reference before the clone steps begin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link additions with no runtime, config, or security impact.
> 
> **Overview**
> The **Run a local Lineth Stack** quickstart (`run-lineth-stack-sepolia.mdx`) now points readers at the canonical monorepo docs instead of vague “check the monorepo” wording.
> 
> In **Before you start**, the sentence about evolving requirements links to the [Lineth Stack docs folder](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/lineth-stack) on GitHub. In **Configure Sepolia mode**, a new lead-in sentence sends operators to the same README for full configuration options and the environment variable reference before the clone/`cp .env.example` steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230fdbc26a963a42f376ae9803e98f5c9bf55095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->