### PR TITLE
chore(config): remove ENS resolver announcement banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,14 +111,6 @@ const config = {
   themeConfig:
     /* @type {import('@docusaurus/preset-classic').ThemeConfig} */
     {
-      announcementBar: {
-        id: "announcement_bar_2026_03_ens_resolver_updated",
-        content:
-          '🔔 <strong>ENS resolver contracts updated</strong>: New contract addresses are live as part of the Small Fields upgrade. <a href="/network/how-to/deploy-subdomain#use-ens-contracts">See new addresses →</a>',
-        backgroundColor: "#6119ef",
-        textColor: "#ffffff",
-        isCloseable: true,
-      },
       colorMode: {
         defaultMode: "dark",
         disableSwitch: false,


### PR DESCRIPTION
## Summary
- Removes the now-outdated Small Fields ENS resolver `announcementBar` block from `themeConfig` in `docusaurus.config.js`.
- The previous banner config remains recoverable from git history when the next announcement is needed.

## Test plan
- [x] Run `npm run start` (or `npm run build`) and confirm no announcement bar renders at the top of the site.
- [x] Confirm no other `themeConfig` settings were affected.

Made with [Cursor](https://cursor.com)