### PR TITLE
feat(api): add interactive RpcPlayground to JSON-RPC reference pages

### DIFF
--- a/docs/api/reference/eth-accounts.mdx
+++ b/docs/api/reference/eth-accounts.mdx
@@ -4,6 +4,8 @@ description: Returns a list of addresses owned by the connected node.
 image: /img/socialCards/ethaccounts.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_accounts`
 
 Returns a list of addresses owned by the node. On the public Linea RPC endpoint the node does not
@@ -19,21 +21,12 @@ Array of 20-byte addresses owned by the node. On `rpc.linea.build` this is alway
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": []
-}
-```
+<RpcPlayground
+  method="eth_accounts"
+  params={[]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: []
+  }}
+/>

--- a/docs/api/reference/eth-blocknumber.mdx
+++ b/docs/api/reference/eth-blocknumber.mdx
@@ -4,6 +4,8 @@ description: Returns the number of the most recent block on Linea.
 image: /img/socialCards/ethblocknumber.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_blockNumber`
 
 Returns the number of the most recent block.
@@ -18,21 +20,12 @@ Hexadecimal integer of the current block number.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x1ce5452"
-}
-```
+<RpcPlayground
+  method="eth_blockNumber"
+  params={[]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x1ce5452"
+  }}
+/>

--- a/docs/api/reference/eth-call.mdx
+++ b/docs/api/reference/eth-call.mdx
@@ -4,6 +4,8 @@ description: Executes a read-only call on Linea without creating a transaction.
 image: /img/socialCards/ethcall.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_call`
 
 Executes a call message without creating a transaction on the blockchain. Commonly used to read
@@ -28,32 +30,18 @@ Hexadecimal return data from the executed contract call.
 
 This example calls `balanceOf(address)` on the USDC contract for a given holder.
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_call",
-    "params": [
-      {
-        "to": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-        "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-      },
-      "latest"
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x000000000000000000000000000000000000000000000000000000000026009c"
-}
-```
+<RpcPlayground
+  method="eth_call"
+  params={[
+    {
+      to: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+      data: "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+    },
+    "latest"
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x000000000000000000000000000000000000000000000000000000000026009c"
+  }}
+/>

--- a/docs/api/reference/eth-chainid.mdx
+++ b/docs/api/reference/eth-chainid.mdx
@@ -4,6 +4,8 @@ description: Returns the chain ID of the connected Linea network.
 image: /img/socialCards/ethchainid.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_chainId`
 
 Returns the chain ID of the connected network. Linea Mainnet is `0xe708` (59144). Linea Sepolia is
@@ -19,21 +21,12 @@ Hexadecimal value of the chain ID.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0xe708"
-}
-```
+<RpcPlayground
+  method="eth_chainId"
+  params={[]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0xe708"
+  }}
+/>

--- a/docs/api/reference/eth-estimategas.mdx
+++ b/docs/api/reference/eth-estimategas.mdx
@@ -4,6 +4,8 @@ description: Estimates the gas required to execute a transaction on Linea.
 image: /img/socialCards/ethestimategas.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_estimateGas`
 
 Returns an estimate of gas needed to execute a transaction. The transaction is not sent.
@@ -27,31 +29,17 @@ Hexadecimal value of the estimated gas.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_estimateGas",
-    "params": [
-      {
-        "to": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-        "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-      }
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x7b17"
-}
-```
+<RpcPlayground
+  method="eth_estimateGas"
+  params={[
+    {
+      to: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+      data: "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+    }
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x7b17"
+  }}
+/>

--- a/docs/api/reference/eth-feehistory.mdx
+++ b/docs/api/reference/eth-feehistory.mdx
@@ -4,6 +4,8 @@ description: Returns historical gas and priority fee data across a range of Line
 image: /img/socialCards/ethfeehistory.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_feeHistory`
 
 Returns historical gas information across a range of blocks, useful for tracking fee trends.
@@ -23,36 +25,22 @@ Returns historical gas information across a range of blocks, useful for tracking
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_feeHistory",
-    "params": ["0x4", "latest", [25, 50, 75]],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "oldestBlock": "0x1ce5452",
-    "baseFeePerGas": ["0x7", "0x7", "0x7", "0x7", "0x7"],
-    "gasUsedRatio": [0.000026867, 0.0000930045, 0.0000379375, 0.0000485935],
-    "reward": [
-      ["0x27f6779", "0x27f6779", "0x27f6779"],
-      ["0x27f6779", "0x27f6779", "0x27f6779"],
-      ["0x27f6779", "0x27f6779", "0x27f6779"],
-      ["0x27f6779", "0x27f6779", "0x27f6779"]
-    ]
-  }
-}
-```
+<RpcPlayground
+  method="eth_feeHistory"
+  params={["0x4", "latest", [25, 50, 75]]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      oldestBlock: "0x1ce5452",
+      baseFeePerGas: ["0x7", "0x7", "0x7", "0x7", "0x7"],
+      gasUsedRatio: [0.000026867, 0.0000930045, 0.0000379375, 0.0000485935],
+      reward: [
+        ["0x27f6779", "0x27f6779", "0x27f6779"],
+        ["0x27f6779", "0x27f6779", "0x27f6779"],
+        ["0x27f6779", "0x27f6779", "0x27f6779"],
+        ["0x27f6779", "0x27f6779", "0x27f6779"]
+      ]
+    }
+  }}
+/>

--- a/docs/api/reference/eth-gasprice.mdx
+++ b/docs/api/reference/eth-gasprice.mdx
@@ -4,6 +4,8 @@ description: 'Returns the current gas price on Linea, in wei.'
 image: /img/socialCards/ethgasprice.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_gasPrice`
 
 Returns the current gas price in wei.
@@ -18,21 +20,12 @@ Hexadecimal value of the current gas price in wei.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x27f6780"
-}
-```
+<RpcPlayground
+  method="eth_gasPrice"
+  params={[]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x27f6780"
+  }}
+/>

--- a/docs/api/reference/eth-getbalance.mdx
+++ b/docs/api/reference/eth-getbalance.mdx
@@ -4,6 +4,8 @@ description: Returns the ETH balance of an address on Linea.
 image: /img/socialCards/ethgetbalance.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBalance`
 
 Returns the ETH balance of an address at a given block.
@@ -19,29 +21,12 @@ Hexadecimal value of the balance in wei.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBalance",
-    "params": [
-      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-      "latest"
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x1805af891ff10a"
-}
-```
+<RpcPlayground
+  method="eth_getBalance"
+  params={["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x1805af891ff10a"
+  }}
+/>

--- a/docs/api/reference/eth-getblockbyhash.mdx
+++ b/docs/api/reference/eth-getblockbyhash.mdx
@@ -4,6 +4,8 @@ description: Returns block information on Linea by block hash.
 image: /img/socialCards/ethgetblockbyhash.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBlockByHash`
 
 Returns block information by block hash.
@@ -20,40 +22,26 @@ no block is found.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBlockByHash",
-    "params": [
-      "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-      false
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "number": "0x1ce53dd",
-    "hash": "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-    "parentHash": "0x23498a882e8897c7e936846951d66744ba0da6052e23a76c23b8c7d98bc30d14",
-    "timestamp": "0x69e5bc55",
-    "gasUsed": "0x1458e",
-    "gasLimit": "0x77359400",
-    "baseFeePerGas": "0x7",
-    "transactions": [
-      "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
-    ]
-  }
-}
-```
+<RpcPlayground
+  method="eth_getBlockByHash"
+  params={[
+    "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+    false
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      number: "0x1ce53dd",
+      hash: "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+      parentHash: "0x23498a882e8897c7e936846951d66744ba0da6052e23a76c23b8c7d98bc30d14",
+      timestamp: "0x69e5bc55",
+      gasUsed: "0x1458e",
+      gasLimit: "0x77359400",
+      baseFeePerGas: "0x7",
+      transactions: [
+        "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
+      ]
+    }
+  }}
+/>

--- a/docs/api/reference/eth-getblockbynumber.mdx
+++ b/docs/api/reference/eth-getblockbynumber.mdx
@@ -4,6 +4,8 @@ description: Returns block information on Linea by block number.
 image: /img/socialCards/ethgetblockbynumber.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBlockByNumber`
 
 Returns block information by block number.
@@ -20,38 +22,24 @@ A block object, or `null` if no block is found. Key fields include `number`, `ha
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBlockByNumber",
-    "params": ["0x1ce53dd", false],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "number": "0x1ce53dd",
-    "hash": "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-    "parentHash": "0x23498a882e8897c7e936846951d66744ba0da6052e23a76c23b8c7d98bc30d14",
-    "timestamp": "0x69e5bc55",
-    "gasUsed": "0x1458e",
-    "gasLimit": "0x77359400",
-    "baseFeePerGas": "0x7",
-    "miner": "0x8f81e2e3f8b46467523463835f965ffe476e1c9e",
-    "transactions": [
-      "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
-    ]
-  }
-}
-```
+<RpcPlayground
+  method="eth_getBlockByNumber"
+  params={["0x1ce53dd", false]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      number: "0x1ce53dd",
+      hash: "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+      parentHash: "0x23498a882e8897c7e936846951d66744ba0da6052e23a76c23b8c7d98bc30d14",
+      timestamp: "0x69e5bc55",
+      gasUsed: "0x1458e",
+      gasLimit: "0x77359400",
+      baseFeePerGas: "0x7",
+      miner: "0x8f81e2e3f8b46467523463835f965ffe476e1c9e",
+      transactions: [
+        "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
+      ]
+    }
+  }}
+/>

--- a/docs/api/reference/eth-getblockreceipts.mdx
+++ b/docs/api/reference/eth-getblockreceipts.mdx
@@ -4,6 +4,8 @@ description: Returns all transaction receipts for a given block on Linea.
 image: /img/socialCards/ethgetblockreceipts.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBlockReceipts`
 
 Returns all transaction receipts for a given block.
@@ -19,55 +21,41 @@ from [`eth_getTransactionReceipt`](eth-gettransactionreceipt).
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBlockReceipts",
-    "params": ["0x1ce53dd"],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": [
-    {
-      "transactionHash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-      "transactionIndex": "0x0",
-      "blockHash": "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-      "blockNumber": "0x1ce53dd",
-      "from": "0xd26c8000ec8778de5257305c9acdd79f16f87867",
-      "to": "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
-      "gasUsed": "0x1458e",
-      "cumulativeGasUsed": "0x1458e",
-      "effectiveGasPrice": "0x257e36f",
-      "status": "0x1",
-      "type": "0x2",
-      "contractAddress": null,
-      "logs": [
-        {
-          "address": "0xdb3a3929269281f157a58d91289185f21e30a1e0",
-          "topics": [
-            "0x3e393433c9275f1194d1ed44cea161cd2d35166f1906855d6119da515057537d",
-            "0x00000000000000000000000008ede5c20c6cb3b5f84f918322126ab207ac6cd0"
-          ],
-          "data": "0x",
-          "blockNumber": "0x1ce53dd",
-          "transactionHash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-          "logIndex": "0x0",
-          "removed": false
-        }
-      ]
-    }
-  ]
-}
-```
+<RpcPlayground
+  method="eth_getBlockReceipts"
+  params={["0x1ce53dd"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: [
+      {
+        transactionHash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+        transactionIndex: "0x0",
+        blockHash: "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+        blockNumber: "0x1ce53dd",
+        from: "0xd26c8000ec8778de5257305c9acdd79f16f87867",
+        to: "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
+        gasUsed: "0x1458e",
+        cumulativeGasUsed: "0x1458e",
+        effectiveGasPrice: "0x257e36f",
+        status: "0x1",
+        type: "0x2",
+        contractAddress: null,
+        logs: [
+          {
+            address: "0xdb3a3929269281f157a58d91289185f21e30a1e0",
+            topics: [
+              "0x3e393433c9275f1194d1ed44cea161cd2d35166f1906855d6119da515057537d",
+              "0x00000000000000000000000008ede5c20c6cb3b5f84f918322126ab207ac6cd0"
+            ],
+            data: "0x",
+            blockNumber: "0x1ce53dd",
+            transactionHash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+            logIndex: "0x0",
+            removed: false
+          }
+        ]
+      }
+    ]
+  }}
+/>

--- a/docs/api/reference/eth-getblocktransactioncountbyhash.mdx
+++ b/docs/api/reference/eth-getblocktransactioncountbyhash.mdx
@@ -4,6 +4,8 @@ description: 'Returns the number of transactions in a Linea block, given the blo
 image: /img/socialCards/ethgetblocktransactioncountbyhash.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBlockTransactionCountByHash`
 
 Returns the number of transactions in a block, given the block hash.
@@ -18,28 +20,12 @@ Hexadecimal integer of the transaction count, or `null` if no block is found.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBlockTransactionCountByHash",
-    "params": [
-      "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550"
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x1"
-}
-```
+<RpcPlayground
+  method="eth_getBlockTransactionCountByHash"
+  params={["0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x1"
+  }}
+/>

--- a/docs/api/reference/eth-getblocktransactioncountbynumber.mdx
+++ b/docs/api/reference/eth-getblocktransactioncountbynumber.mdx
@@ -4,6 +4,8 @@ description: 'Returns the number of transactions in a Linea block, given the blo
 image: /img/socialCards/ethgetblocktransactioncountbynumber.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getBlockTransactionCountByNumber`
 
 Returns the number of transactions in a block, given the block number.
@@ -18,26 +20,12 @@ Hexadecimal integer of the transaction count.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getBlockTransactionCountByNumber",
-    "params": ["0x1ce53dd"],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x1"
-}
-```
+<RpcPlayground
+  method="eth_getBlockTransactionCountByNumber"
+  params={["0x1ce53dd"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x1"
+  }}
+/>

--- a/docs/api/reference/eth-getcode.mdx
+++ b/docs/api/reference/eth-getcode.mdx
@@ -4,6 +4,8 @@ description: Returns the bytecode deployed at a contract address on Linea.
 image: /img/socialCards/ethgetcode.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getCode`
 
 Returns the bytecode at a given contract address. Returns `0x` if the address is not a contract.
@@ -21,29 +23,12 @@ The bytecode at the given address, as a hex string.
 
 This example reads the bytecode of the USDC proxy contract.
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getCode",
-    "params": [
-      "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-      "latest"
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x60806040526004361061005a5760003560e01c80635c60da1b116100435780635c60da1b146101315780638f2839701461016f578063f851a440146101af5761005a565b80633659cfe6146100645780634f1ef286146100a4575b6100626101c4565b..."
-}
-```
+<RpcPlayground
+  method="eth_getCode"
+  params={["0x176211869ca2b568f2a7d4ee941e073a821ee1ff", "latest"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x60806040526004361061005a5760003560e01c80635c60da1b116100435780635c60da1b146101315780638f2839701461016f578063f851a440146101af5761005a565b80633659cfe6146100645780634f1ef286146100a4575b6100626101c4565b..."
+  }}
+/>

--- a/docs/api/reference/eth-getlogs.mdx
+++ b/docs/api/reference/eth-getlogs.mdx
@@ -4,6 +4,8 @@ description: Returns event logs on Linea matching a filter.
 image: /img/socialCards/ethgetlogs.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getLogs`
 
 Returns logs matching a given filter object.
@@ -26,49 +28,35 @@ Array of log objects. Each log includes `address`, `topics`, `data`, `blockNumbe
 
 This example retrieves ERC-20 `Transfer` events from the USDC contract across a range of blocks.
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getLogs",
-    "params": [
-      {
-        "fromBlock": "0x1ce3100",
-        "toBlock": "0x1ce3110",
-        "address": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-        "topics": [
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-        ]
-      }
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": [
+<RpcPlayground
+  method="eth_getLogs"
+  params={[
     {
-      "address": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-      "topics": [
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-        "0x000000000000000000000000...",
-        "0x000000000000000000000000..."
-      ],
-      "data": "0x...",
-      "blockNumber": "0x1ce3105",
-      "transactionHash": "0x...",
-      "logIndex": "0x0",
-      "removed": false
+      fromBlock: "0x1ce3100",
+      toBlock: "0x1ce3110",
+      address: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+      topics: [
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+      ]
     }
-  ]
-}
-```
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: [
+      {
+        address: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+        topics: [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000...",
+          "0x000000000000000000000000..."
+        ],
+        data: "0x...",
+        blockNumber: "0x1ce3105",
+        transactionHash: "0x...",
+        logIndex: "0x0",
+        removed: false
+      }
+    ]
+  }}
+/>

--- a/docs/api/reference/eth-getstorageat.mdx
+++ b/docs/api/reference/eth-getstorageat.mdx
@@ -4,6 +4,8 @@ description: Returns the value stored at a given storage slot of a contract on L
 image: /img/socialCards/ethgetstorageat.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getStorageAt`
 
 Returns the value stored at a given storage slot of a contract address.
@@ -22,30 +24,12 @@ The 32-byte value at the given storage position, as a hex string.
 
 This example reads the 32-byte value at storage position `0x0` of the USDC contract.
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getStorageAt",
-    "params": [
-      "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
-      "0x0",
-      "latest"
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x00000000000000000000000085e54b6659b11b09ece200728bb775332ebcea65"
-}
-```
+<RpcPlayground
+  method="eth_getStorageAt"
+  params={["0x176211869ca2b568f2a7d4ee941e073a821ee1ff", "0x0", "latest"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x00000000000000000000000085e54b6659b11b09ece200728bb775332ebcea65"
+  }}
+/>

--- a/docs/api/reference/eth-gettransactionbyblockhashandindex.mdx
+++ b/docs/api/reference/eth-gettransactionbyblockhashandindex.mdx
@@ -4,6 +4,8 @@ description: Returns a transaction on Linea by block hash and transaction index.
 image: /img/socialCards/ethgettransactionbyblockhashandindex.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getTransactionByBlockHashAndIndex`
 
 Returns transaction data by block hash and transaction index position.
@@ -20,40 +22,26 @@ or `null` if no transaction is found at the given index.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getTransactionByBlockHashAndIndex",
-    "params": [
-      "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-      "0x0"
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "hash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-    "blockNumber": "0x1ce53dd",
-    "transactionIndex": "0x0",
-    "from": "0xd26c8000ec8778de5257305c9acdd79f16f87867",
-    "to": "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
-    "value": "0x0",
-    "gas": "0x2635a",
-    "gasPrice": "0x257e36f",
-    "nonce": "0xc824c",
-    "type": "0x2"
-  }
-}
-```
+<RpcPlayground
+  method="eth_getTransactionByBlockHashAndIndex"
+  params={[
+    "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+    "0x0"
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      hash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+      blockNumber: "0x1ce53dd",
+      transactionIndex: "0x0",
+      from: "0xd26c8000ec8778de5257305c9acdd79f16f87867",
+      to: "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
+      value: "0x0",
+      gas: "0x2635a",
+      gasPrice: "0x257e36f",
+      nonce: "0xc824c",
+      type: "0x2"
+    }
+  }}
+/>

--- a/docs/api/reference/eth-gettransactionbyblocknumberandindex.mdx
+++ b/docs/api/reference/eth-gettransactionbyblocknumberandindex.mdx
@@ -4,6 +4,8 @@ description: Returns a transaction on Linea by block number and transaction inde
 image: /img/socialCards/ethgettransactionbyblocknumberandindex.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getTransactionByBlockNumberAndIndex`
 
 Returns transaction data by block number and transaction index position.
@@ -20,37 +22,23 @@ or `null` if no transaction is found at the given index.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getTransactionByBlockNumberAndIndex",
-    "params": ["0x1ce53dd", "0x0"],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "hash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-    "blockNumber": "0x1ce53dd",
-    "transactionIndex": "0x0",
-    "from": "0xd26c8000ec8778de5257305c9acdd79f16f87867",
-    "to": "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
-    "value": "0x0",
-    "gas": "0x2635a",
-    "gasPrice": "0x257e36f",
-    "nonce": "0xc824c",
-    "type": "0x2"
-  }
-}
-```
+<RpcPlayground
+  method="eth_getTransactionByBlockNumberAndIndex"
+  params={["0x1ce53dd", "0x0"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      hash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+      blockNumber: "0x1ce53dd",
+      transactionIndex: "0x0",
+      from: "0xd26c8000ec8778de5257305c9acdd79f16f87867",
+      to: "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
+      value: "0x0",
+      gas: "0x2635a",
+      gasPrice: "0x257e36f",
+      nonce: "0xc824c",
+      type: "0x2"
+    }
+  }}
+/>

--- a/docs/api/reference/eth-gettransactionbyhash.mdx
+++ b/docs/api/reference/eth-gettransactionbyhash.mdx
@@ -4,6 +4,8 @@ description: Returns transaction data for a given transaction hash on Linea.
 image: /img/socialCards/ethgettransactionbyhash.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getTransactionByHash`
 
 Returns transaction data for a given transaction hash.
@@ -18,44 +20,28 @@ A transaction object, or `null` if no transaction is found.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getTransactionByHash",
-    "params": [
-      "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "hash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-    "blockHash": "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-    "blockNumber": "0x1ce53dd",
-    "transactionIndex": "0x0",
-    "chainId": "0xe708",
-    "from": "0xd26c8000ec8778de5257305c9acdd79f16f87867",
-    "to": "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
-    "value": "0x0",
-    "gas": "0x2635a",
-    "gasPrice": "0x257e36f",
-    "maxFeePerGas": "0x257e371",
-    "maxPriorityFeePerGas": "0x257e368",
-    "nonce": "0xc824c",
-    "type": "0x2",
-    "input": "0x455ee4aa..."
-  }
-}
-```
+<RpcPlayground
+  method="eth_getTransactionByHash"
+  params={["0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      hash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+      blockHash: "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+      blockNumber: "0x1ce53dd",
+      transactionIndex: "0x0",
+      chainId: "0xe708",
+      from: "0xd26c8000ec8778de5257305c9acdd79f16f87867",
+      to: "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
+      value: "0x0",
+      gas: "0x2635a",
+      gasPrice: "0x257e36f",
+      maxFeePerGas: "0x257e371",
+      maxPriorityFeePerGas: "0x257e368",
+      nonce: "0xc824c",
+      type: "0x2",
+      input: "0x455ee4aa..."
+    }
+  }}
+/>

--- a/docs/api/reference/eth-gettransactioncount.mdx
+++ b/docs/api/reference/eth-gettransactioncount.mdx
@@ -6,6 +6,8 @@ description: >-
 image: /img/socialCards/ethgettransactioncount.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getTransactionCount`
 
 Returns the number of transactions sent from an address (the account nonce).
@@ -21,29 +23,12 @@ Hexadecimal integer of the number of transactions sent from the address.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getTransactionCount",
-    "params": [
-      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-      "latest"
-    ],
-    "id": 1
-  }'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x0"
-}
-```
+<RpcPlayground
+  method="eth_getTransactionCount"
+  params={["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x0"
+  }}
+/>

--- a/docs/api/reference/eth-gettransactionreceipt.mdx
+++ b/docs/api/reference/eth-gettransactionreceipt.mdx
@@ -4,6 +4,8 @@ description: 'Returns the receipt of a transaction on Linea, including logs and 
 image: /img/socialCards/ethgettransactionreceipt.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_getTransactionReceipt`
 
 Returns the receipt of a transaction by transaction hash. Receipts are only available for
@@ -21,53 +23,37 @@ include `status` (`0x1` for success, `0x0` for failure), `gasUsed`, `logs`, and 
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "eth_getTransactionReceipt",
-    "params": [
-      "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"
-    ],
-    "id": 1
-  }'
-```
-
-### Response (abbreviated)
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "transactionHash": "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
-    "transactionIndex": "0x0",
-    "blockHash": "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
-    "blockNumber": "0x1ce53dd",
-    "from": "0xd26c8000ec8778de5257305c9acdd79f16f87867",
-    "to": "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
-    "gasUsed": "0x1458e",
-    "cumulativeGasUsed": "0x1458e",
-    "effectiveGasPrice": "0x257e36f",
-    "status": "0x1",
-    "type": "0x2",
-    "contractAddress": null,
-    "logs": [
-      {
-        "address": "0xdb3a3929269281f157a58d91289185f21e30a1e0",
-        "topics": [
-          "0x3e393433c9275f1194d1ed44cea161cd2d35166f1906855d6119da515057537d",
-          "0x00000000000000000000000008ede5c20c6cb3b5f84f918322126ab207ac6cd0"
-        ],
-        "data": "0x",
-        "logIndex": "0x0",
-        "removed": false
-      }
-    ]
-  }
-}
-```
+<RpcPlayground
+  method="eth_getTransactionReceipt"
+  params={["0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259"]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      transactionHash: "0x972fd73b83ee0d567143ebc67509d4fc98fa1b1941c2c145a342d3d10715c259",
+      transactionIndex: "0x0",
+      blockHash: "0x8ebe90fa04dbbf92199c07cbb56c1f908343c69f3dd246a2f7d95272589dc550",
+      blockNumber: "0x1ce53dd",
+      from: "0xd26c8000ec8778de5257305c9acdd79f16f87867",
+      to: "0x6d7ac5d23266c9fea16463b877005bff6de531a7",
+      gasUsed: "0x1458e",
+      cumulativeGasUsed: "0x1458e",
+      effectiveGasPrice: "0x257e36f",
+      status: "0x1",
+      type: "0x2",
+      contractAddress: null,
+      logs: [
+        {
+          address: "0xdb3a3929269281f157a58d91289185f21e30a1e0",
+          topics: [
+            "0x3e393433c9275f1194d1ed44cea161cd2d35166f1906855d6119da515057537d",
+            "0x00000000000000000000000008ede5c20c6cb3b5f84f918322126ab207ac6cd0"
+          ],
+          data: "0x",
+          logIndex: "0x0",
+          removed: false
+        }
+      ]
+    }
+  }}
+/>

--- a/docs/api/reference/eth-maxpriorityfeepergas.mdx
+++ b/docs/api/reference/eth-maxpriorityfeepergas.mdx
@@ -4,6 +4,8 @@ description: 'Returns the current priority fee per gas on Linea, in wei.'
 image: /img/socialCards/ethmaxpriorityfeepergas.jpg
 ---
 
+import RpcPlayground from '@site/src/components/RpcPlayground';
+
 # `eth_maxPriorityFeePerGas`
 
 Returns the current priority fee per gas in wei. This is the tip paid to validators above the base
@@ -19,21 +21,12 @@ Hexadecimal value of the current max priority fee per gas in wei.
 
 ## Example
 
-### Request
-
-```bash
-curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params":[],"id":1}'
-```
-
-### Response
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x396c8ee"
-}
-```
+<RpcPlayground
+  method="eth_maxPriorityFeePerGas"
+  params={[]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "0x396c8ee"
+  }}
+/>

--- a/docs/api/reference/linea-estimategas.mdx
+++ b/docs/api/reference/linea-estimategas.mdx
@@ -1,11 +1,10 @@
 ---
 title: linea_estimateGas
-description: Reference content for the linea_estimateGas method.
+description: Estimates the gas limit, base fee, and priority fee for a Linea transaction using Linea's predictable pricing model.
 image: /img/socialCards/lineaestimategas.jpg
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import RpcPlayground from '@site/src/components/RpcPlayground';
 
 # `linea_estimateGas`
 
@@ -54,112 +53,24 @@ fee per gas.
 
 ## Example
 
-### Request
-
-<Tabs groupId="sdk-lang">
-  <TabItem value="curl">
-
-  ```bash
-  curl https://rpc.linea.build \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0","method": "linea_estimateGas","params": [{"to": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045","value": "0x16345785d8a0000"}],"id": 1}'
-  ```
-
-  </TabItem>
-  <TabItem value="ethers.js">
-
-  ```javascript
-  type LineaEstimateGasResponse = {
-    baseFeePerGas: string;
-    priorityFeePerGas: string;
-    gasLimit: string;
-  };
-
-  const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-
-  const params = {
-    from: "0x...", // Signer address
-    to: "0x...", // Recipient address
-    value: ethers.parseEther("1").toString(), // Value in wei
-    data: "0x...", // Encoded call in case of smart contract interaction
-  };
-
-  const fees: LineaEstimateGasResponse = await provider.send("linea_estimateGas", [params]);
-  console.log(fees);
-  ```
-  </TabItem>
-  <TabItem value="viem">
-
-  ```javascript
-  import { createPublicClient, http, parseEther } from 'viem'
-  import { linea } from 'viem/chains'
-  import { estimateGas } from 'viem/linea'
-
-  async function EstimateGas() {
-    const client = createPublicClient({
-      chain: linea,
-      transport: http(),
-    });
-
-    try {
-      const gasEstimate = await estimateGas(client, {
-        account: '0x...', // Source account's address
-        to: '0x...', // Destination account's address
-        value: parseEther('0.004') // Amount of ETH to transfer
-      });
-      console.log('Gas Estimate:', gasEstimate);
-    } catch (error) {
-      console.error('Error estimating gas:', error);
+<RpcPlayground
+  method="linea_estimateGas"
+  params={[
+    {
+      to: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+      data: "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
     }
-  }
-
-  EstimateGas();
-  ```
-
-  </TabItem>
-</Tabs>
-
-### Response
-
-<Tabs groupId="sdk-lang">
-  <TabItem value="curl">
-
-```JSON
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "baseFeePerGas": "0x7",
-    "gasLimit": "0x5208",
-    "priorityFeePerGas": "0x25d1eb6"
-  }
-}
-```
-
-  </TabItem>
-  <TabItem value="ethers.js">
-
-  ```javascript
-  {
-    baseFeePerGas: "0x7",
-    gasLimit: "0x5208",
-    priorityFeePerGas: "0x25d1eb6"
-  }
-  ```
-  </TabItem>
-  <TabItem value="viem">
-
-  ```javascript
-  {
-    baseFeePerGas: 7n,
-    gasLimit: 21000n,
-    priorityFeePerGas: 39574198n
-  }
-  ```
-
-  </TabItem>
-</Tabs>
+  ]}
+  exampleResponse={{
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      baseFeePerGas: "0x7",
+      gasLimit: "0xcf08",
+      priorityFeePerGas: "0x43a82a4"
+    }
+  }}
+/>
 
 Where:
 - `baseFeePerGas` - Uses the Linea base fee which is set at 7 wei.

--- a/docs/api/reference/linea-getproof.mdx
+++ b/docs/api/reference/linea-getproof.mdx
@@ -1,6 +1,6 @@
 ---
 title: linea_getProof
-description: Reference content for the linea_getProof method.
+description: Returns the account and storage values with Merkle proofs for a finalized L2 block on Linea.
 image: /img/socialCards/lineagetproof.jpg
 ---
 

--- a/docs/api/reference/linea-gettransactionexclusionstatusv1.mdx
+++ b/docs/api/reference/linea-gettransactionexclusionstatusv1.mdx
@@ -1,6 +1,6 @@
 ---
 title: linea_getTransactionExclusionStatusV1
-description: Reference content for the linea_getTransactionExclusionStatusV1 method.
+description: Checks whether a transaction was rejected by the Linea sequencer, RPC, or P2P node for exceeding data line limits.
 image: /img/socialCards/lineagettransactionexclusionstatusv1.jpg
 ---
 

--- a/src/components/RpcPlayground/index.tsx
+++ b/src/components/RpcPlayground/index.tsx
@@ -35,6 +35,8 @@ export default function RpcPlayground({
   const prismLang = LANGUAGES.find((l) => l.id === language)?.prism ?? "bash";
 
   const isCurl = language === "curl";
+  const isRunning = isCurl && status === "loading";
+  const isRunDisabled = !isCurl || isRunning;
   // The playground only runs raw fetch (curl-equivalent) calls, so the live
   // response is only meaningful while Curl is selected. Switching to
   // ethers.js / viem hides the live state and falls back to the static
@@ -109,25 +111,28 @@ export default function RpcPlayground({
             </button>
             <button
               type="button"
-              className={styles.runBtn}
+              className={clsx(
+                styles.runBtn,
+                isRunning && styles.runBtnLoading,
+                !isCurl && styles.runBtnUnavailable,
+              )}
               onClick={run}
-              disabled={status === "loading" || language !== "curl"}
+              disabled={isRunDisabled}
               title={
-                language !== "curl"
-                  ? "Switch to Curl to run the request live"
-                  : undefined
+                !isCurl ? "Switch to Curl to run the request live" : undefined
               }
+              aria-describedby={!isCurl ? "rpc-playground-run-note" : undefined}
               aria-label={
-                language !== "curl"
+                !isCurl
                   ? "Run request (Curl only)"
-                  : status === "loading"
+                  : isRunning
                     ? "Running request"
                     : "Run request"
               }>
-              {status === "loading" ? (
+              {isRunning ? (
                 <>
                   <span className={styles.spinner} aria-hidden="true" />
-                  <span>Running…</span>
+                  <span>Running...</span>
                 </>
               ) : (
                 <>
@@ -138,6 +143,12 @@ export default function RpcPlayground({
             </button>
           </div>
         </div>
+        {!isCurl && (
+          <p id="rpc-playground-run-note" className={styles.runNote}>
+            Live requests are available for Curl only. Copy this SDK example to
+            run it in your app.
+          </p>
+        )}
         <div className={styles.codeWrap}>
           <CodeBlock language={prismLang}>{code}</CodeBlock>
         </div>
@@ -164,8 +175,9 @@ export default function RpcPlayground({
         </div>
         {language !== "curl" && (
           <p className={styles.responseNote}>
-            ethers.js and viem unwrap this envelope and convert hex values to
-            BigNumber/BigInt. See the SDK docs for the exact return shape.
+            ethers.js and viem return the JSON-RPC method result instead of the
+            raw envelope shown here. Convert hex quantities explicitly when you
+            need typed numeric values.
           </p>
         )}
       </div>

--- a/src/components/RpcPlayground/index.tsx
+++ b/src/components/RpcPlayground/index.tsx
@@ -1,0 +1,174 @@
+import React, { useMemo, useState } from "react";
+import CodeBlock from "@theme/CodeBlock";
+import clsx from "clsx";
+
+import { CheckIcon, CopyIcon, PlayIcon } from "../icons";
+import { LANGUAGES, Language, renderCode } from "./languages";
+import { useRpcCall } from "./useRpcCall";
+import styles from "./styles.module.css";
+
+const DEFAULT_ENDPOINT = "https://rpc.linea.build";
+const COPY_FEEDBACK_MS = 1500;
+
+export interface RpcPlaygroundProps {
+  method: string;
+  params: unknown[];
+  exampleResponse: unknown;
+  endpoint?: string;
+}
+
+export default function RpcPlayground({
+  method,
+  params,
+  exampleResponse,
+  endpoint = DEFAULT_ENDPOINT,
+}: RpcPlaygroundProps): React.ReactNode {
+  const [language, setLanguage] = useState<Language>("curl");
+  const [copied, setCopied] = useState(false);
+  const { status, response, error, run } = useRpcCall(endpoint, method, params);
+
+  const code = useMemo(
+    () => renderCode(language, method, params, endpoint),
+    [language, method, params, endpoint],
+  );
+
+  const prismLang = LANGUAGES.find((l) => l.id === language)?.prism ?? "bash";
+
+  const isCurl = language === "curl";
+  // The playground only runs raw fetch (curl-equivalent) calls, so the live
+  // response is only meaningful while Curl is selected. Switching to
+  // ethers.js / viem hides the live state and falls back to the static
+  // example so the LIVE badge never appears next to SDK code.
+  const showLive = isCurl && (status === "success" || status === "error");
+  // While a re-run is in flight (Curl only), keep the previous response body
+  // visible instead of flashing back to the static example — but don't badge
+  // it as "Live" since the data is stale until the new call resolves.
+  const hasStaleResponse = isCurl && status === "loading" && response != null;
+  const responseTitle =
+    status === "error" && isCurl
+      ? "Error"
+      : showLive
+        ? "Raw JSON-RPC response"
+        : hasStaleResponse
+          ? "Previous response"
+          : "Example response";
+
+  const responseBody: string = (() => {
+    if (status === "error" && isCurl) {
+      return error ?? "Request failed.";
+    }
+    const value = showLive || hasStaleResponse ? response : exampleResponse;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  })();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // Clipboard API may fail in insecure contexts — silently no-op.
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <span className={styles.panelLabel}>Request</span>
+          <div className={styles.toolbar}>
+            <label className={styles.langSelect}>
+              <span className={styles.srOnly}>Language</span>
+              <select
+                value={language}
+                onChange={(e) => setLanguage(e.target.value as Language)}>
+                {LANGUAGES.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {l.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={handleCopy}
+              aria-label={copied ? "Copied" : "Copy code"}>
+              {copied ? (
+                <CheckIcon aria-hidden="true" />
+              ) : (
+                <CopyIcon aria-hidden="true" />
+              )}
+              <span className={styles.iconBtnLabel}>
+                {copied ? "Copied!" : "Copy"}
+              </span>
+            </button>
+            <button
+              type="button"
+              className={styles.runBtn}
+              onClick={run}
+              disabled={status === "loading" || language !== "curl"}
+              title={
+                language !== "curl"
+                  ? "Switch to Curl to run the request live"
+                  : undefined
+              }
+              aria-label={
+                language !== "curl"
+                  ? "Run request (Curl only)"
+                  : status === "loading"
+                    ? "Running request"
+                    : "Run request"
+              }>
+              {status === "loading" ? (
+                <>
+                  <span className={styles.spinner} aria-hidden="true" />
+                  <span>Running…</span>
+                </>
+              ) : (
+                <>
+                  <PlayIcon className={styles.runIcon} aria-hidden="true" />
+                  <span>Run</span>
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+        <div className={styles.codeWrap}>
+          <CodeBlock language={prismLang}>{code}</CodeBlock>
+        </div>
+      </div>
+
+      <div className={clsx(styles.panel, styles.responsePanel)}>
+        <div className={styles.header}>
+          <span className={styles.panelLabel}>{responseTitle}</span>
+          {showLive && (
+            <span
+              className={clsx(
+                styles.badge,
+                status === "error" && styles.badgeError,
+                status === "success" && styles.badgeLive,
+              )}>
+              {status === "error" ? "Error" : "Live"}
+            </span>
+          )}
+        </div>
+        <div className={styles.codeWrap}>
+          <CodeBlock language={status === "error" && isCurl ? "text" : "json"}>
+            {responseBody}
+          </CodeBlock>
+        </div>
+        {language !== "curl" && (
+          <p className={styles.responseNote}>
+            ethers.js and viem unwrap this envelope and convert hex values to
+            BigNumber/BigInt. See the SDK docs for the exact return shape.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RpcPlayground/languages.ts
+++ b/src/components/RpcPlayground/languages.ts
@@ -1,0 +1,54 @@
+export type Language = "curl" | "ethers" | "viem";
+
+export const LANGUAGES: { id: Language; label: string; prism: string }[] = [
+  { id: "curl", label: "Curl", prism: "bash" },
+  { id: "ethers", label: "Ethers.js", prism: "javascript" },
+  { id: "viem", label: "Viem", prism: "javascript" },
+];
+
+type Renderer = (method: string, params: unknown[], endpoint: string) => string;
+
+const RENDERERS: Record<Language, Renderer> = {
+  curl: (method, params, endpoint) => {
+    const body = JSON.stringify(
+      { jsonrpc: "2.0", method, params, id: 1 },
+      null,
+      2,
+    );
+    // Escape single quotes for shell so an apostrophe inside a param value
+    // can't break out of the `-d '...'` quoting.
+    const shellBody = body.replace(/'/g, "'\\''");
+    return `curl ${endpoint} \\
+  -X POST \\
+  -H "Content-Type: application/json" \\
+  -d '${shellBody}'`;
+  },
+
+  ethers: (method, params, endpoint) =>
+    `import { JsonRpcProvider } from 'ethers';
+
+const provider = new JsonRpcProvider('${endpoint}');
+const result = await provider.send('${method}', ${JSON.stringify(params, null, 2)});
+console.log(result);`,
+
+  viem: (method, params, endpoint) =>
+    `import { createPublicClient, http } from 'viem';
+import { linea } from 'viem/chains';
+
+const client = createPublicClient({
+  chain: linea,
+  transport: http('${endpoint}'),
+});
+const result = await client.request({
+  method: '${method}',
+  params: ${JSON.stringify(params, null, 2)},
+});
+console.log(result);`,
+};
+
+export const renderCode = (
+  lang: Language,
+  method: string,
+  params: unknown[],
+  endpoint: string,
+): string => RENDERERS[lang](method, params, endpoint);

--- a/src/components/RpcPlayground/styles.module.css
+++ b/src/components/RpcPlayground/styles.module.css
@@ -158,8 +158,15 @@
 }
 
 .runBtn:disabled {
-  cursor: wait;
   opacity: 0.75;
+}
+
+.runBtnLoading:disabled {
+  cursor: wait;
+}
+
+.runBtnUnavailable:disabled {
+  cursor: not-allowed;
 }
 
 .runIcon {
@@ -174,6 +181,12 @@
   border-top-color: #fff;
   border-radius: 50%;
   animation: rpc-playground-spin 0.7s linear infinite;
+}
+
+.runNote {
+  margin: 6px 0 0;
+  font-size: var(--font-body-xs);
+  color: var(--linea-text-muted);
 }
 
 @keyframes rpc-playground-spin {

--- a/src/components/RpcPlayground/styles.module.css
+++ b/src/components/RpcPlayground/styles.module.css
@@ -1,0 +1,244 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  margin: 24px 0;
+}
+
+/* Panel: structural wrapper around each code block. No visible border or
+   background — the nested @theme/CodeBlock provides the visual surface.
+   No overflow:hidden so focus-visible outlines on the toolbar buttons
+   are not clipped. */
+.panel {
+  margin: 0;
+}
+
+/* Response panel: base class. The live/error state is communicated by
+   the badge in the header; no left-border accent. */
+.responsePanel {
+  /* no visual accent — badge owns the state signal */
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  flex-wrap: wrap;
+}
+
+/* Wrapper around the @theme/CodeBlock child. Resets site-wide code-block
+   margins so the block sits flush inside the panel. */
+.codeWrap {
+  margin: 0;
+}
+
+/* Match the site's article h3 typography so the label looks like the
+   ### Request / ### Response headings on static method pages. */
+.panelLabel {
+  font-family: AtypDisplay, sans-serif;
+  font-size: var(--font-heading-lg);
+  font-weight: 500;
+  color: var(--linea-text-primary);
+  line-height: 1.3;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.langSelect {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.langSelect select {
+  appearance: none;
+  font-family: inherit;
+  font-size: var(--font-body-sm);
+  font-weight: 500;
+  color: var(--linea-text-primary);
+  background: var(--page-background);
+  border: 1px solid var(--linea-border);
+  border-radius: var(--linea-radius-sm);
+  padding: 4px 26px 4px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.langSelect select:hover {
+  border-color: var(--linea-text-muted);
+  background: var(--linea-hover-bg);
+}
+
+.langSelect select:focus-visible {
+  outline: 2px solid var(--linea-active-color);
+  outline-offset: 1px;
+}
+
+.langSelect::after {
+  content: "";
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid var(--linea-text-secondary);
+  border-bottom: 1.5px solid var(--linea-text-secondary);
+  transform: translateY(-70%) rotate(45deg);
+  pointer-events: none;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+  font-size: var(--font-body-sm);
+  font-weight: 500;
+  color: var(--linea-text-secondary);
+  background: var(--page-background);
+  border: 1px solid var(--linea-border);
+  border-radius: var(--linea-radius-sm);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.iconBtn:hover {
+  background: var(--linea-hover-bg);
+  border-color: var(--linea-text-muted);
+  color: var(--linea-text-primary);
+}
+
+.iconBtn:focus-visible {
+  outline: 2px solid var(--linea-active-color);
+  outline-offset: 1px;
+}
+
+.iconBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Text label ("Copy" / "Copied!") next to the copy icon. Inherits font
+   sizing from .iconBtn; no extra rules needed to start. */
+.iconBtnLabel {
+  /* inherits from .iconBtn */
+}
+
+.runBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+  font-size: var(--font-body-sm);
+  font-weight: 600;
+  color: #fff;
+  background: var(--linea-brand-purple);
+  border: 1px solid var(--linea-brand-purple);
+  border-radius: var(--linea-radius-sm);
+  padding: 4px 14px;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.runBtn:hover:not(:disabled) {
+  background: var(--linea-purple-hover);
+  border-color: var(--linea-purple-hover);
+}
+
+.runBtn:focus-visible {
+  outline: 2px solid var(--linea-brand-cyan);
+  outline-offset: 2px;
+}
+
+.runBtn:disabled {
+  cursor: wait;
+  opacity: 0.75;
+}
+
+.runIcon {
+  margin-left: 1px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgb(255 255 255 / 35%);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: rpc-playground-spin 0.7s linear infinite;
+}
+
+@keyframes rpc-playground-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Hide the built-in copy button on the request code block only. The
+   toolbar above already owns Copy. The response block keeps its built-in
+   copy so users can grab JSON responses. */
+.panel:not(.responsePanel) .codeWrap :global([class*="buttonGroup"]) {
+  display: none;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: inherit;
+  font-size: var(--font-body-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 10px;
+  border-radius: var(--linea-radius-pill);
+  border: 1px solid transparent;
+  line-height: 1.4;
+}
+
+.badgeLive {
+  color: var(--linea-success-accent);
+  border-color: var(--linea-success-accent);
+  background: rgb(16 185 129 / 10%);
+}
+
+.badgeError {
+  color: var(--linea-error-accent);
+  border-color: var(--linea-error-accent);
+  background: rgb(239 68 68 / 10%);
+}
+
+/* Helper note shown under the response panel when a non-curl language is
+   selected, explaining that the SDK return shape differs from the raw
+   JSON-RPC envelope. */
+.responseNote {
+  margin: 8px 12px;
+  font-size: var(--font-body-xs);
+  color: var(--linea-text-muted);
+  font-style: italic;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .toolbar {
+    gap: 4px;
+  }
+}

--- a/src/components/RpcPlayground/useRpcCall.ts
+++ b/src/components/RpcPlayground/useRpcCall.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type CallStatus = "idle" | "loading" | "success" | "error";
+
+export interface UseRpcCallResult {
+  status: CallStatus;
+  response: unknown;
+  error: string | null;
+  run: () => Promise<void>;
+}
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export function useRpcCall(
+  endpoint: string,
+  method: string,
+  params: unknown[],
+): UseRpcCallResult {
+  const [status, setStatus] = useState<CallStatus>("idle");
+  const [response, setResponse] = useState<unknown>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const run = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const mine = controller;
+
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, REQUEST_TIMEOUT_MS);
+
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method,
+          params,
+          id: 1,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        let detail = `HTTP ${res.status} ${res.statusText}`;
+        try {
+          const body = await res.json();
+          if (body?.error?.message) {
+            detail = body.error.message;
+          }
+        } catch {
+          // body wasn't JSON, stick with the HTTP status line
+        }
+        throw new Error(detail);
+      }
+
+      const data = await res.json();
+      if (abortRef.current !== mine) return;
+      if (data?.error) {
+        setError(
+          data.error.message ?? `JSON-RPC error ${data.error.code ?? ""}`,
+        );
+        setResponse(null);
+        setStatus("error");
+        return;
+      }
+      setResponse(data);
+      setStatus("success");
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") {
+        if (timedOut && abortRef.current === mine) {
+          setError(
+            `Request timed out after ${REQUEST_TIMEOUT_MS / 1000} seconds.`,
+          );
+          setResponse(null);
+          setStatus("error");
+        }
+        // Superseded, unmounted, or timed out after a newer run started —
+        // the active controller owns the state. Silently ignore.
+        return;
+      }
+      if (abortRef.current !== mine) return;
+      setError(e instanceof Error ? e.message : "Request failed.");
+      setResponse(null);
+      setStatus("error");
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }, [endpoint, method, params]);
+
+  return { status, response, error, run };
+}

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -53,6 +53,34 @@ export function CopyIcon(props: IconProps) {
   );
 }
 
+export function CheckIcon(props: IconProps) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" {...props}>
+      <path
+        d="M3 8.5L6.5 12L13 5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function PlayIcon(props: IconProps) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" {...props}>
+      <path
+        d="M2.5 1.5L10 6L2.5 10.5V1.5Z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function MoonIcon(props: IconProps) {
   return (
     <svg

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -160,6 +160,8 @@
   --linea-active-bg: rgb(161 107 250 / 15%);
   --linea-hover-bg: rgb(255 255 255 / 8%);
   --linea-code-text: #d1d1d1;
+  --linea-success-accent: #10b981;
+  --linea-error-accent: #f87171;
 }
 
 /* ── Light theme ── */
@@ -267,4 +269,6 @@
   --linea-active-bg: rgb(97 25 239 / 10%);
   --linea-hover-bg: #EFEFEB;
   --linea-code-text: #d1d1d1;
+  --linea-success-accent: #0f9d6f;
+  --linea-error-accent: #dc2626;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "paths": {
       "@site/*": ["./*"]
     },
-    "types": ["@docusaurus/module-type-aliases", "node"],
+    "types": ["@docusaurus/module-type-aliases", "@docusaurus/theme-classic", "node"],
     "allowJs": true,
     "checkJs": false
   },


### PR DESCRIPTION
## Summary

Replaces the static `### Request` / `### Response` curl+JSON blocks on 23 JSON-RPC method pages with an interactive `<RpcPlayground>` component that fires live calls against `https://rpc.linea.build` and renders the response in-page. Users can switch between curl, ethers.js, and viem renderings, copy the request, and run it to see a live result.

Builds on top of #1449, which added the static per-method reference pages. This PR keeps all of main's wording and links intact and only swaps the example blocks.

### Component

New component in `src/components/RpcPlayground/`:
- `index.tsx` — view layer (request panel, response panel, toolbar with language selector, copy, run)
- `languages.ts` — pure per-language code generators (curl / ethers.js / viem)
- `useRpcCall.ts` — fetch hook with `AbortController` + 15s timeout + supersession
- `styles.module.css` — scoped styles

Supporting changes:
- `CheckIcon` and `PlayIcon` added to `src/components/icons/index.tsx`
- `--linea-success-accent` and `--linea-error-accent` tokens added to `src/css/tokens.css`
- `@docusaurus/theme-classic` added to `tsconfig.json` types

### Migrated pages (23)

`eth_accounts`, `eth_blockNumber`, `eth_call`, `eth_chainId`, `eth_estimateGas`, `eth_feeHistory`, `eth_gasPrice`, `eth_getBalance`, `eth_getBlockByHash`, `eth_getBlockByNumber`, `eth_getBlockReceipts`, `eth_getBlockTransactionCountByHash`, `eth_getBlockTransactionCountByNumber`, `eth_getCode`, `eth_getLogs`, `eth_getStorageAt`, `eth_getTransactionByBlockHashAndIndex`, `eth_getTransactionByBlockNumberAndIndex`, `eth_getTransactionByHash`, `eth_getTransactionCount`, `eth_getTransactionReceipt`, `eth_maxPriorityFeePerGas`, `linea_estimateGas`.

### Intentionally not migrated

Filter methods, debug/trace methods, `eth_sendRawTransaction`, `eth_sendBundle`, `linea_getProof`, and `linea_getTransactionExclusionStatusV1` are kept as static examples — they're stateful, tracer-required, or rely on non-public-endpoint behavior.

### Review-driven fixes folded in

- **JSON-RPC error detection**: a JSON-RPC error returned over HTTP 200 (`{error: {code, message}}`) now routes to the red Error state instead of showing a green "Live" badge.
- **Missing CSS classes**: defined `.panel`, `.responsePanel`, `.responseLive`, `.responseError`, `.codeWrap`, `.iconBtnLabel` — these were referenced by the component but never authored, so the panels were rendering unstyled.
- **Response panel labeling**: the live response title now reads "Raw JSON-RPC response" (the playground runs one raw `fetch` regardless of selected language). A helper note appears under the response panel when ethers.js or viem is selected, explaining that the SDK return shape differs from the raw envelope.
- **Accessibility**: dropped a redundant `aria-label` on the language `<select>` (the wrapping `<label>` already provides the accessible name).
- **Consistency**: fixed `id: 53` to `id: 1` in the `linea_estimateGas` exampleResponse.
- Replaced placeholder descriptions on `linea_estimateGas`, `linea_getProof`, and `linea_getTransactionExclusionStatusV1` with real one-line summaries.

## Test plan

- [x] `npm run lint` passes (eslint + stylelint)
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds (production build)
- [ ] Spot-check a few migrated pages in `npm run start` — confirm the language selector switches code, Copy works, Run returns a live response (or a clear error on rate-limit / JSON-RPC error)
- [ ] Confirm `linea_estimateGas` page still renders the "Override state values" section correctly (it's preserved below the playground)
- [ ] Confirm panels have borders/containment (B2 fix) and live/error states show the correct left-border accent
- [ ] Confirm the ethers.js / viem helper note appears under the response panel when those languages are selected

## Known CI state

The **Spelling (vale)** check is expected to fail — camelCase JSON field names inside `exampleResponse` JSX objects are flagged as misspelled prose. The vale config lives in `Consensys/github-actions`, not this repo, and the fix is deferred to a separate effort.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site and client-side RPC playground only; no backend or auth changes. Live calls hit the public RPC endpoint from the browser.
> 
> **Overview**
> Adds an interactive **`RpcPlayground`** on 23 JSON-RPC reference pages, replacing static curl request/response examples.
> 
> Readers get curl, ethers.js, and viem snippets, copy, and **Run** (curl only) against `https://rpc.linea.build`, with static example JSON when idle and **Live** / **Error** badges when a call completes. **`linea_estimateGas`** drops the old Tabs-based multi-SDK example for the same playground pattern; a few **`linea_*`** frontmatter descriptions are tightened where those pages stay static.
> 
> Supporting work: new `RpcPlayground` module (`useRpcCall` with abort/timeout and JSON-RPC error handling), **Check** / **Play** icons, success/error theme tokens, and `@docusaurus/theme-classic` in `tsconfig` for `CodeBlock` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ccf7c4758c6752aa1429e682c8c6b2db6fc9d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->