### PR TITLE
Update README links and clarify API section

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -13,11 +13,10 @@ v3 and deployed on Vercel.
 - [Live site: docs.linea.build](https://docs.linea.build/)
 - [Documentation for builders](https://docs.linea.build/)
 - [Lineth monorepo (open-source stack source)](https://github.com/LFDT-Lineth/lineth-monorepo)
-- [Linea vs Lineth explained](https://docs.linea.build/protocol/linea-vs-lineth)
+- [Linea and Lineth explained](https://docs.linea.build/protocol/linea-vs-lineth)
 - [Community forum](https://community.linea.build/)
 - [X](https://x.com/LineaBuild)
 - [Create an issue](https://github.com/Consensys/doc.linea/issues)
-- [Fork repository](https://github.com/Consensys/doc.linea/fork)
 
 ## What is Linea?
 
@@ -55,7 +54,7 @@ mapping to a top-level directory under `docs/`:
 | Public network (Linea Mainnet) | Linea            | Users and app builders transacting on and building for Linea Mainnet and Sepolia                                                           | `docs/network`   |
 | Protocol                       | Lineth           | Readers learning how the Lineth protocol works (zero-knowledge proofs, prover, architecture, contracts)                                    | `docs/protocol`  |
 | Stack                          | Lineth           | Operators deploying and running their own networks on Lineth                                                                               | `docs/stack`     |
-| APIs & SDK                     | Linea            | Developers using the Linea JSON-RPC API, smart contract reference, Linea SDK, and Token API                                                | `docs/api`       |
+| APIs & SDK                     | Linea and Lineth | Developers using the Linea JSON-RPC API, smart contract reference, Linea SDK, and Token API                                                | `docs/api`       |
 | Changelog                      | Linea and Lineth | Releases, upgrades, and tooling updates across the Lineth stack and protocol and the Linea network, plus the Linea Security Council record | `docs/changelog` |
 
 ## Repository structure


### PR DESCRIPTION
Update README links and clarify API section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only wording and link list changes with no runtime or security impact.
> 
> **Overview**
> **README** quick links and the docs tab table are aligned with **Linea and Lineth** naming instead of **Linea vs Lineth**.
> 
> The quick-links list renames the protocol explainer to **Linea and Lineth explained** (same URL) and drops the **Fork repository** entry. In the site map table, the **APIs & SDK** row’s **Documents** column now reads **Linea and Lineth** rather than **Linea** only. A trailing newline is added at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2722a4c70c3c03bd1c6853a317ddbaffc92cf405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->