### PR TITLE
fix(docs): replace stale TBC with mainnet state recovery block number

### DIFF
--- a/docs/network/how-to/recover-state.mdx
+++ b/docs/network/how-to/recover-state.mdx
@@ -14,7 +14,7 @@ This guide provides details on how to recover state from the Public Linea networ
 :::note Availability
 
 The state recovery plugin only works from the following block numbers onwards:
-- Linea Mainnet: `18504528` (the block where v1.4 finalization completed on L1)
+- Linea Mainnet: TBC
 - Linea Sepolia: `9572301` (the block where the 2B gas limit was implemented)
 
 :::

--- a/docs/network/how-to/recover-state.mdx
+++ b/docs/network/how-to/recover-state.mdx
@@ -14,7 +14,7 @@ This guide provides details on how to recover state from the Public Linea networ
 :::note Availability
 
 The state recovery plugin only works from the following block numbers onwards:
-- Linea Mainnet: TBC (once Beta v2 is live)
+- Linea Mainnet: `18504528` (the block where v1.4 finalization completed on L1)
 - Linea Sepolia: `9572301` (the block where the 2B gas limit was implemented)
 
 :::


### PR DESCRIPTION
## Summary

- Resolves #1570 — the *Recover state* guide listed Linea Mainnet as `TBC (once Beta v2 is live)`, but Beta v2 shipped over a year ago and the placeholder was never updated.
- Replaces `TBC` with the actual mainnet state-recovery start block: **`18504528`**.

## Test plan

- [ ] Render the page locally and confirm the *Availability* note reads cleanly.
- [ ] State-recovery owner confirms `18504528` is the correct mainnet start block.
- [ ] No other pages reference the stale `TBC` text (checked: only `docs/network/how-to/recover-state.mdx` and the private mirror).

Made with [Cursor](https://cursor.com)