### PR TITLE
chore(docs): add security council L1 nonce 76

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -19,6 +19,22 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
+### July 06, 2026
+#### L1
+- **[Nonce 76](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Change Staking Vault to STRICT Mode via Vault Dashboard.
+    - Change Fee recipient to newly created Payment Splitter.
+    - Fully exit one validator with 1 Wei transfer for the validator exit.
+  - Verification
+    - `PDGPolicyEnacted` event emitted with `0` as the `pdgPolicy`. See [Lido documentation](https://github.com/lidofinance/docs/blob/70fba94e70370247af310d5be870ee2c0aa5f319/docs/contracts/dashboard.md#pdgpolicy).
+    - `FeeRecipientSet` event emitted with `0x4d2504c498bb7e63bcc7bc11f781d30d99b6febb` as the `oldFeeRecipient` and `0x3f6227e81c46f608ff7fc3ace997b955dd345541` as the `newFeeRecipient`.
+    - Event from execution layer withdrawal contract [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) address `0x00000961ef480eb55e80d19ad83579a64c007002` containing concatenated data comprised of 
+      - `0x2df8ccb91c80c9600ea9436b1f940c48cc008ca7` - Staking Vault address
+      - `8ee790c95e5fea2076c2efe0d59f6afae0cc0803406a8584abec5d0392e0b624c2e39cb07308ec85ebfadfd8054a7b30` - Validator Public Key excluding 0x
+      - `0000000000000000` - amount signalling full withdrawal
+    - `ValidatorWithdrawalsTriggered` containing the validator public key `0x8ee790c95e5fea2076c2efe0d59f6afae0cc0803406a8584abec5d0392e0b624c2e39cb07308ec85ebfadfd8054a7b30`, empty `amountsInGwei` array, `0` excess, and the security council `0x892bb7eed71efb060ab90140e7825d8127991dd3` as `refundRecipient`.
+
 ### April 28, 2026
 
 #### L1

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -21,7 +21,7 @@ you can take to verify this information.
 
 ### July 06, 2026
 #### L1
-- **[Nonce 76](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 76](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x08294477fc0fbc2ea7fc8237fd418be368ddd85e0af061350f1a540a46a4bc81)**
   - Actions: 
     - Change Staking Vault to STRICT Mode via Vault Dashboard.
     - Change Fee recipient to newly created Payment Splitter.


### PR DESCRIPTION
Adds the Yield Boost transactions at nonce 76 to the security council transaction log.

Note: Actual link is missing - needs the transaction to be set up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no application or contract code changes.
> 
> **Overview**
> Adds a **July 06, 2026** entry at the top of the Linea Security Council transaction log for **L1 nonce 76**, documenting Yield Boost–related council actions and how to verify them onchain.
> 
> The logged actions are: setting the Staking Vault dashboard to **STRICT** mode (`PDGPolicyEnacted` with `pdgPolicy` `0`), moving the fee recipient to a new Payment Splitter (`FeeRecipientSet`), and triggering a **full validator exit** via EIP-7002 (1 wei) with the expected withdrawal and `ValidatorWithdrawalsTriggered` checks spelled out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07766f87295e4364619fe73112539c44e298d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->