### PR TITLE
Add NodeFlare to node providers

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -57,6 +57,11 @@ image: /img/socialCards/node-providers.jpg
     <td>:x:</td>
   </tr>
   <tr>
+    <td><a href="https://nodeflare.app/chains/linea">NodeFlare</a></td>
+    <td>:x:</td>
+    <td>:x:</td>
+  </tr>
+  <tr>
     <td><a href="https://nownodes.io/nodes">NOWNodes</a></td>
     <td>:white_check_mark:</td>
     <td>:x:</td>


### PR DESCRIPTION
Per the page's invitation for RPC providers to open a PR: adds NodeFlare to the private RPC endpoints table (alphabetical placement).

NodeFlare serves Linea Mainnet from dedicated EU bare-metal with a free public endpoint (`https://rpc.nodeflare.app/linea/public`, no API key) and a free keyed tier including `eth_getLogs` and debug/trace. Flags are conservative/honest: the `finalized` tag works on our endpoint, but `linea_estimateGas` is not currently exposed, so Linea API methods is marked :x:; WebSocket :x: (not wired for Linea yet). Endpoint verifiable via `eth_chainId` → `0xe708`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table row with no runtime, auth, or infrastructure changes.
> 
> **Overview**
> Adds **NodeFlare** to the private RPC endpoints comparison table in `docs/network/build/tools/node-providers/index.mdx`, placed alphabetically between Moralis and NOWNodes.
> 
> The new row links to NodeFlare’s Linea page and marks both **Linea API methods** and **WebSocket** as unsupported (`:x:`), consistent with the provider’s stated capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8bec7620547ff97d6e6f99a1dfee71edb5b5147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->