### PR TITLE
fix: unescape dot in eligible-actions validation regex

### DIFF
--- a/.agents/skills/linea-dependency-maintenance/references/github-actions.md
+++ b/.agents/skills/linea-dependency-maintenance/references/github-actions.md
@@ -58,7 +58,7 @@ grep -rnE 'uses:\s+[^./]' .github/workflows .github/actions
   (` # vX.Y.Z` or ` # X.Y.Z`, space before `#`):
   ```bash
   grep -rnE 'uses:\s+[^./][^@]+@[^ ]+' .github/workflows .github/actions \
-    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\\.[0-9]+\\.[0-9]+'
+    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\.[0-9]+\.[0-9]+'
   ```
   The command should print nothing. Any line it prints is an unpinned action, a tag/branch ref, or a non-standard
   version comment (for example `#v7.2.0` without a leading space).


### PR DESCRIPTION
## Summary
- Fix the validation regex example in `.agents/skills/linea-dependency-maintenance/references/github-actions.md`

The example was double-escaping the dot (`\\.`) inside a single-quoted shell string. `grep -E` reads that as a literal backslash followed by any character, so the pattern never matched a real version comment like `# v6.0.2` — the validation command would flag every correctly pinned action instead of printing nothing.

Same fix as raised by @eloi010 on https://github.com/Consensys/linea-hub/pull/2253#pullrequestreview-4634307662, ported here since this repo carries the same skill doc.

## Test plan
- [x] Verified `grep -vE '@[0-9a-f]{40} +# v?[0-9]+\.[0-9]+\.[0-9]+'` correctly filters a properly pinned `uses:` line and still flags an unpinned one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill reference; no workflow or runtime code is modified.
> 
> **Overview**
> Fixes the **Validation** `grep -vE` example in `github-actions.md` so the documented pin check matches real version comments.
> 
> The pattern used `\\.` inside a single-quoted shell string, which `grep -E` treats as a literal backslash plus any character—not a dot between semver segments. Correctly pinned `uses:` lines (e.g. `# v6.0.2`) would not be filtered out, so the command would falsely report every pin as invalid instead of printing nothing on success.
> 
> The example now uses unescaped `\.` in the regex (`[0-9]+\.[0-9]+\.[0-9]+`), aligning the doc with the intended validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3d5bd911f334338fee291ab6f96f034be3360d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->