### PR TITLE
docs(node-providers): add OpenChainBench as public RPC latency reference

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -184,7 +184,7 @@ Public endpoints are rate limited, and not meant for production systems.
 > API method, or features that require a specific implementation to work on Linea, such as use of
 > the [`finalized` tag](../../../overview/transaction-finality.mdx#use-the-finalized-tag)._
 
-You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/), or compare live latency of the public endpoints on [OpenChainBench — Linea RPC](https://openchainbench.com/benchmarks/linea-rpc).
+You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/), or compare live latency of the public endpoints on [OpenChainBench: Linea RPC](https://openchainbench.com/benchmarks/linea-rpc).
 
 If you're an RPC endpoint provider and would like to be added to the list, reach
 out to our team, or make a PR to the docs.

--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -184,7 +184,7 @@ Public endpoints are rate limited, and not meant for production systems.
 > API method, or features that require a specific implementation to work on Linea, such as use of
 > the [`finalized` tag](../../../overview/transaction-finality.mdx#use-the-finalized-tag)._
 
-You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/).
+You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/), or compare live latency of the public endpoints on [OpenChainBench — Linea RPC](https://openchainbench.com/benchmarks/linea-rpc).
 
 If you're an RPC endpoint provider and would like to be added to the list, reach
 out to our team, or make a PR to the docs.


### PR DESCRIPTION
## Summary

Adds a one-line reference to [OpenChainBench — Linea RPC](https://openchainbench.com/benchmarks/linea-rpc) next to the existing `linea.chain.love` link on the node-providers page, so readers picking between the public no-key endpoints listed in the Public RPC endpoints table can see live latency measurements.

## Why

The page already directs readers to `linea.chain.love` for an overview. OpenChainBench is a neutral third-party benchmark that measures the public endpoints listed on this page (`rpc.linea.build`, `linea.drpc.org`, `linea-mainnet-public.unifra.io`, `linea.rpc.grove.city`, etc.) from three regions every minute. This gives readers a live-data view when choosing an endpoint for their app.

- Open methodology: https://openchainbench.com/methodology
- Data license: CC-BY-4.0
- No affiliation with Consensys / Linea

Happy to reword or drop if this doesn't fit the docs' tone.

## Test plan

- [x] No structural changes, single-line addition inside an existing paragraph
- [x] Preserves surrounding link style (`[label](url)`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only one-line link addition with no code, config, or security impact.
> 
> **Overview**
> **Extends the node-providers RPC guidance** with a second resource link in the paragraph after the public endpoints table.
> 
> Readers who already use [linea.chain.love](https://linea.chain.love/) for endpoint overviews can now also open **[OpenChainBench: Linea RPC](https://openchainbench.com/benchmarks/linea-rpc)** to compare live latency for the public endpoints listed on the page. No table, navigation, or provider list changes—only copy and one URL in an existing sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4342cca62a1b1028dfb147fdddddecb0423e7add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->