### PR TITLE
docs(node-providers): add OpenChainBench as public RPC latency reference

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -184,7 +184,7 @@ Public endpoints are rate limited, and not meant for production systems.
 > API method, or features that require a specific implementation to work on Linea, such as use of
 > the [`finalized` tag](../../../overview/transaction-finality.mdx#use-the-finalized-tag)._
 
-You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/).
+You can also view an overview of public and private RPC endpoints on [linea.chain.love](https://linea.chain.love/), or compare live latency of the public endpoints on [OpenChainBench: Linea RPC](https://openchainbench.com/benchmarks/linea-rpc).
 
 If you're an RPC endpoint provider and would like to be added to the list, reach
 out to our team, or make a PR to the docs.


### PR DESCRIPTION
This resubmits #1591, originally opened by @Flotapponnier, who maintains OpenChainBench.

His personal account was incorrectly caught by GitHub's automated spam detection last week (an appeal is in progress with GitHub Support), which unfortunately made the original PR invisible to reviewers right as the last review feedback had been addressed. We apologize for the confusion and for any extra noise this causes — submitting from the project's account so the change does not go stale.

The change is the same single line as #1591, with the reviewer-requested wording fix already applied (colon instead of em dash in the link label): it adds a link to [OpenChainBench's Linea RPC benchmark](https://openchainbench.com/benchmarks/linea-rpc) next to the existing linea.chain.love reference, so readers can compare live latency of the public endpoints.

Happy to address any further feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation change with no code, security, or runtime impact.
> 
> **Overview**
> Adds a second reference link on the node providers page, alongside the existing **linea.chain.love** overview, pointing readers to **OpenChainBench: Linea RPC** for live latency comparisons of public endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c882bf13267364588be7e434a186fe8e5631af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->