### PR TITLE
ci: lock nightly.yml workflow-level permissions to zero scopes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   linkCheck:


### PR DESCRIPTION
## Summary

- Follow-up to #1596: locks `nightly.yml`'s workflow-level `permissions` to `{}` instead of `contents: read`, matching the least-privilege pattern used elsewhere in that PR (zero scopes by default, per-job grants).
- No behavioral change — the `linkCheck` job already declares its own `contents: read`.

## Test plan

- [ ] Confirm the nightly workflow still runs successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tightening with per-job grants unchanged for link check; no application or runtime impact.
> 
> **Overview**
> Aligns **nightly** workflow defaults with the repo’s least-privilege CI pattern by setting workflow-level `permissions` to `{}` instead of `contents: read`.
> 
> **linkCheck** still grants `contents: read` at the job level, so checkout and link checking behavior should be unchanged; only the default token scope for jobs that don’t declare permissions is tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61366ea3c20d8b3e2ca96fa3e6469bfe000bf4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->