### PR TITLE
Audit documentation UI: links, breadcrumbs, homepage, code

### DIFF
--- a/docs/api/quickstart.mdx
+++ b/docs/api/quickstart.mdx
@@ -4,19 +4,12 @@ sidebar_label: API overview
 description: Explore Linea's JSON-RPC methods and Token API.
 category: Reference
 image: /img/socialCards/rpc-and-api-overview.jpg
-hide_copy_button: true
 ---
 
 import ActionCards from "@site/src/components/ActionCards";
-import CopyPageButton from "@site/src/components/CopyPageButton";
 
-<div className="intro-with-copy">
-  <p>
-    Use Linea's JSON-RPC interface to read and write blockchain data, or use the
-    Token API to retrieve token metadata and balances.
-  </p>
-  <CopyPageButton />
-</div>
+Use Linea's JSON-RPC interface to read and write blockchain data, or use the
+Token API to retrieve token metadata and balances.
 
 <ActionCards
   cards={[

--- a/docs/network/overview/index.mdx
+++ b/docs/network/overview/index.mdx
@@ -3,16 +3,9 @@ title: Overview
 description: 'Overview of Linea Mainnet, the public zkEVM L2 network built on Lineth.'
 sidebar_position: 0
 image: /img/socialCards/overview.jpg
-hide_copy_button: true
 ---
 
 import ActionCards from '@site/src/components/ActionCards';
-import CopyPageButton from '@site/src/components/CopyPageButton';
-
-<div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginTop: '-30px' }}>
-  <div style={{ flex: 1 }} />
-  <CopyPageButton />
-</div>
 
 Linea Mainnet is the public, permissionless zkEVM layer 2 network built on
 [Lineth](../../protocol/linea-vs-lineth.mdx). It processes Ethereum-compatible transactions,

--- a/docs/network/quickstart/index.mdx
+++ b/docs/network/quickstart/index.mdx
@@ -7,16 +7,11 @@ description: >-
   smart contracts on Linea.
 category: Quickstart
 image: /img/socialCards/get-started.jpg
-hide_copy_button: true
 ---
 
 import ActionCards from '@site/src/components/ActionCards';
-import CopyPageButton from '@site/src/components/CopyPageButton';
 
-<div style={{display: 'flex', alignItems: 'center', gap: '16px'}}>
-  <p style={{margin: 0, flex: 1}}>Get started building on Linea. From overviews to step-by-step guides, the following articles will walk you through deploying and managing your apps and smart contracts on Linea.</p>
-  <CopyPageButton />
-</div>
+Get started building on Linea. From overviews to step-by-step guides, the following articles will walk you through deploying and managing your apps and smart contracts on Linea.
 
 <ActionCards
   cards={[

--- a/docs/protocol/overview.mdx
+++ b/docs/protocol/overview.mdx
@@ -3,15 +3,7 @@ title: Overview
 description: 'A high-level overview of how the Lineth protocol processes transactions, generates proofs, and finalizes state.'
 sidebar_position: 1
 image: /img/socialCards/overview.jpg
-hide_copy_button: true
 ---
-
-import CopyPageButton from '@site/src/components/CopyPageButton';
-
-<div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginTop: '-30px' }}>
-  <div style={{ flex: 1 }} />
-  <CopyPageButton />
-</div>
 
 ## How the Lineth protocol works
 

--- a/docs/protocol/quickstart.mdx
+++ b/docs/protocol/quickstart.mdx
@@ -6,17 +6,12 @@ description: >-
   its architecture.
 category: Quickstart
 sidebar_position: 0
-hide_copy_button: true
 image: /img/socialCards/get-started.jpg
 ---
 
 import ActionCards from '@site/src/components/ActionCards';
-import CopyPageButton from '@site/src/components/CopyPageButton';
 
-<div style={{display: 'flex', alignItems: 'center', gap: '16px'}}>
-  <p style={{margin: 0, flex: 1}}>Learn more about the Lineth protocol, including the components that make up its architecture. Use this section as your general reference for how the Lineth protocol is composed and run.</p>
-  <CopyPageButton />
-</div>
+Learn more about the Lineth protocol, including the components that make up its architecture. Use this section as your general reference for how the Lineth protocol is composed and run.
 
 <ActionCards
   cards={[

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -5,19 +5,12 @@ description: >-
   Reference documentation for Linea RPC APIs, SDKs, component configuration, and
   smart contracts.
 image: /img/socialCards/reference.jpg
-hide_copy_button: true
 ---
 
 import ActionCards from "@site/src/components/ActionCards";
-import CopyPageButton from "@site/src/components/CopyPageButton";
 
-<div className="intro-with-copy">
-  <p>
-    Find the technical references for integrating with Linea and configuring
-    Lineth components.
-  </p>
-  <CopyPageButton />
-</div>
+Find the technical references for integrating with Linea and configuring
+Lineth components.
 
 <!-- vale Consensys.CaseSensitive-Substitution = NO -->
 

--- a/docs/stack/index.mdx
+++ b/docs/stack/index.mdx
@@ -3,16 +3,7 @@ title: Overview
 description: Overview of Lineth for enterprise network operators
 sidebar_position: 1
 image: /img/socialCards/overview.jpg
-hide_copy_button: true
 ---
-
-
-import CopyPageButton from "@site/src/components/CopyPageButton";
-
-<div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginTop: '-30px' }}>
-  <div style={{ flex: 1 }} />
-  <CopyPageButton />
-</div>
 
 ## Lineth
 

--- a/docs/stack/quickstart.mdx
+++ b/docs/stack/quickstart.mdx
@@ -7,16 +7,11 @@ description: >-
   models, data availability, and more.
 category: Quickstart
 image: /img/socialCards/get-started.jpg
-hide_copy_button: true
 ---
 
 import ActionCards from '@site/src/components/ActionCards';
-import CopyPageButton from '@site/src/components/CopyPageButton';
 
-<div style={{display: 'flex', alignItems: 'center', gap: '16px'}}>
-  <p style={{margin: 0, flex: 1}}>Learn how to operate your own Ethereum-compatible network using Lineth (formerly the Linea Stack). Discover how the stack works and read about key features such as deployment models, data availability, and more.</p>
-  <CopyPageButton />
-</div>
+Learn how to operate your own Ethereum-compatible network using Lineth (formerly the Linea Stack). Discover how the stack works and read about key features such as deployment models, data availability, and more.
 
 <ActionCards
   cards={[

--- a/src/components/CardGrid/index.tsx
+++ b/src/components/CardGrid/index.tsx
@@ -5,7 +5,7 @@ import { ArrowIcon } from "@site/src/components/icons";
 import styles from "./styles.module.css";
 
 type CardItem = {
-  title: string;
+  title: React.ReactNode;
   link: string;
   description: React.ReactNode;
   iconSrc?: string;
@@ -37,7 +37,7 @@ function Card({ title, link, description, iconSrc }: CardItem) {
 }
 
 type Props = {
-  heading: string;
+  heading?: string;
   cards: CardItem[];
   equalizeHeights?: boolean;
 };
@@ -85,7 +85,7 @@ export default function CardGrid({
     <section
       className={clsx("margin-top--lg", "margin-bottom--lg", styles.section)}>
       <div className={styles.cardContainer}>
-        <h2 className={styles.heading}>{heading}</h2>
+        {heading && <h2 className={styles.heading}>{heading}</h2>}
         <div className="row" ref={rowRef}>
           {cards.map((props, idx) => (
             <Card key={idx} {...props} />

--- a/src/components/CardGrid/styles.module.css
+++ b/src/components/CardGrid/styles.module.css
@@ -1,7 +1,12 @@
 /* main background handled globally in custom.css */
 
+.section {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+
 .cardContainer {
-  padding: 60px 67px;
+  padding: 24px 67px;
   margin: 0 auto;
   max-width: 1444px;
 }
@@ -12,7 +17,7 @@
   font-size: 40px;
   font-weight: 400;
   color: var(--linea-text-primary);
-  margin-bottom: 40px;
+  margin-bottom: 16px;
   line-height: 1.4;
 }
 
@@ -107,12 +112,12 @@
 
 @media (max-width: 996px) {
   .cardContainer {
-    padding: 40px 24px;
+    padding: 16px 24px;
   }
 
   .heading {
     font-size: 28px;
-    margin-bottom: 32px;
+    margin-bottom: 12px;
   }
 
   .card {
@@ -130,12 +135,12 @@
 
 @media (max-width: 768px) {
   .section {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin-top: 0.75rem !important;
+    margin-bottom: 0.75rem !important;
   }
 
   .cardContainer {
-    padding: 40px 24px 0;
+    padding: 16px 24px 0;
   }
 
   .heading {

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -917,17 +917,23 @@ html[data-theme="dark"] .navbar {
   font-size: 14px;
 }
 
-/* Breadcrumbs styling per Figma */
+/* Breadcrumbs styling per Figma (bottom spacing lives on .docItemHeader) */
 nav[aria-label="Breadcrumbs"] {
   font-family: 'Atyp Text', sans-serif;
   font-size: 12px;
   font-weight: 500;
   line-height: 1.4;
-  margin-bottom: 24px;
+  margin-bottom: 0;
 }
 
-nav[aria-label="Breadcrumbs"] a {
-  color: var(--linea-text-muted);
+/*
+ * Breadcrumb labels: !important needed to beat `article a` link color,
+ * which otherwise makes linked crumbs purple/cyan while unlinked category
+ * spans stay muted/gray.
+ */
+nav[aria-label="Breadcrumbs"] a,
+nav[aria-label="Breadcrumbs"] .breadcrumbs__link {
+  color: var(--linea-text-primary) !important;
   text-decoration: none !important;
   padding: 5px 10px;
   border-radius: var(--linea-radius-round);
@@ -940,34 +946,13 @@ nav[aria-label="Breadcrumbs"] a:hover {
   text-decoration: none !important;
 }
 
-nav[aria-label="Breadcrumbs"] .breadcrumbs__item--active a {
-  color: var(--linea-text-primary);
-}
-
-[data-theme="dark"] nav[aria-label="Breadcrumbs"] a {
-  color: var(--linea-text-subtle) !important;
-  text-decoration: none !important;
-}
-
 [data-theme="dark"] nav[aria-label="Breadcrumbs"] a:hover {
   color: var(--linea-purple-hover) !important;
-  background-color: transparent !important;
-  text-decoration: none !important;
-}
-
-[data-theme="dark"] nav[aria-label="Breadcrumbs"] .breadcrumbs__item--active a {
-  color: var(--linea-text-primary);
 }
 
 /* Remove background from active breadcrumb item */
 nav[aria-label="Breadcrumbs"] .breadcrumbs__item--active .breadcrumbs__link {
   background-color: transparent !important;
-}
-
-/* Hide non-collapsible section header items (Introduction, Features, etc.)
-   They render as <span> not <a>, and are not the active item */
-.breadcrumbs__item:not(.breadcrumbs__item--active):has(> span.breadcrumbs__link) {
-  display: none;
 }
 
 /* ============================================================
@@ -1546,7 +1531,7 @@ button.clean-btn.menu__caret {
 
 /* Mobile TOC ("On this page") - collapsed and expanded states */
 @media (max-width: 996px) {
-  /* Reorder: TOC above the purple category title */
+  /* Reorder: breadcrumbs/header, then mobile TOC, then content */
   article {
     display: flex;
     flex-direction: column;
@@ -1554,10 +1539,9 @@ button.clean-btn.menu__caret {
 
   article > .article-breadcrumbs-wrapper   { order: 1; }
   article > .article-mobile-toc-wrapper     { order: 2; }
-  article > [class*="titleRow"]             { order: 3; }
-  article > .theme-doc-markdown              { order: 4; }
-  article > *                                { order: 5; }
-  article > .article-footer-wrapper          { order: 6; }
+  article > .theme-doc-markdown              { order: 3; }
+  article > *                                { order: 4; }
+  article > .article-footer-wrapper          { order: 5; }
 
   .theme-doc-toc-mobile {
     background: var(--ifm-background-color) !important;
@@ -1925,12 +1909,12 @@ details > div {
 }
 
 .theme-admonition-content a {
-  text-decoration: underline;
-  font-weight: 500;
+  text-decoration: none;
+  font-weight: 400;
 }
 
 .theme-admonition-content a:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 /* Admonition inline code per Figma */
@@ -2133,11 +2117,10 @@ details > div {
 
 article a,
 .theme-doc-markdown a {
-  color: var(--linea-text-primary) !important;
-  text-decoration: underline;
-  text-decoration-style: solid;
+  color: var(--linea-inline-link-color) !important;
+  text-decoration: none;
   font-family: 'Atyp Text', sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   font-size: inherit;
   transition: color 0.2s ease;
 }
@@ -2157,13 +2140,8 @@ article a.submission-button:hover,
 
 article a:hover,
 .theme-doc-markdown a:hover {
-  color: var(--linea-brand-purple) !important;
+  color: var(--linea-inline-link-hover) !important;
   opacity: 1;
-}
-
-[data-theme="dark"] article a:hover,
-[data-theme="dark"] .theme-doc-markdown a:hover {
-  color: var(--linea-purple-hover) !important;
 }
 
 /* Headings styling per Figma - EXACT specs */
@@ -2347,14 +2325,21 @@ code {
   letter-spacing: 0.28px;
 }
 
-/* Inline code (pills) per Figma */
+/* Inline code (pills): relative size so it scales in headings */
 :not(pre) > code {
-  font-size: var(--font-body-xs);
-  letter-spacing: 0.24px;
+  font-size: 0.875em; /* 14px at body-md (16px); scales with parent */
+  letter-spacing: 0.2px;
   background-color: var(--linea-surface-elevated);
   color: var(--linea-text-primary);
   padding: 0 5px;
   border-radius: var(--linea-radius-sm);
+  position: relative;
+  top: -0.08em; /* optical align with surrounding text */
+}
+
+/* Keep pill styling in headings, sized just under the heading text */
+article :is(h2, h3, h4, h5, h6) code {
+  font-size: 0.85em;
 }
 
 [data-theme="dark"] :not(pre) > code {

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -917,7 +917,7 @@ html[data-theme="dark"] .navbar {
   font-size: 14px;
 }
 
-/* Breadcrumbs styling per Figma (bottom spacing lives on .docItemHeader) */
+/* Breadcrumbs styling per Figma */
 nav[aria-label="Breadcrumbs"] {
   font-family: 'Atyp Text', sans-serif;
   font-size: 12px;
@@ -926,14 +926,10 @@ nav[aria-label="Breadcrumbs"] {
   margin-bottom: 0;
 }
 
-/*
- * Breadcrumb labels: !important needed to beat `article a` link color,
- * which otherwise makes linked crumbs purple/cyan while unlinked category
- * spans stay muted/gray.
- */
 nav[aria-label="Breadcrumbs"] a,
 nav[aria-label="Breadcrumbs"] .breadcrumbs__link {
   color: var(--linea-text-primary) !important;
+  font-weight: 400 !important;
   text-decoration: none !important;
   padding: 5px 10px;
   border-radius: var(--linea-radius-round);
@@ -2325,19 +2321,18 @@ code {
   letter-spacing: 0.28px;
 }
 
-/* Inline code (pills): relative size so it scales in headings */
+/* Inline code (pills) per Figma */
 :not(pre) > code {
-  font-size: 0.875em; /* 14px at body-md (16px); scales with parent */
+  font-size: 0.875em;
   letter-spacing: 0.2px;
   background-color: var(--linea-surface-elevated);
   color: var(--linea-text-primary);
   padding: 0 5px;
   border-radius: var(--linea-radius-sm);
   position: relative;
-  top: -0.08em; /* optical align with surrounding text */
+  top: -0.08em;
 }
 
-/* Keep pill styling in headings, sized just under the heading text */
 article :is(h2, h3, h4, h5, h6) code {
   font-size: 0.85em;
 }

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -162,7 +162,6 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #10b981;
   --linea-error-accent: #f87171;
-  /* Inline body links: closer to text than brand accent colors */
   --linea-inline-link-color: #7edff5;
   --linea-inline-link-hover: #2eb9dc;
 }
@@ -274,7 +273,6 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #0f9d6f;
   --linea-error-accent: #dc2626;
-  /* Inline body links: closer to text than brand accent colors */
   --linea-inline-link-color: #4f24c4;
   --linea-inline-link-hover: #8e5dff;
 }

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -162,6 +162,9 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #10b981;
   --linea-error-accent: #f87171;
+  /* Inline body links: closer to text than brand accent colors */
+  --linea-inline-link-color: #7edff5;
+  --linea-inline-link-hover: #2eb9dc;
 }
 
 /* ── Light theme ── */
@@ -271,4 +274,7 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #0f9d6f;
   --linea-error-accent: #dc2626;
+  /* Inline body links: closer to text than brand accent colors */
+  --linea-inline-link-color: #4f24c4;
+  --linea-inline-link-hover: #8e5dff;
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -9,57 +9,6 @@
   transition: color 0.3s ease;
 }
 
-.bannerButton {
-  border: none;
-  padding: 12px 14px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-family: 'Atyp Display', sans-serif;
-  font-size: 15px;
-  font-weight: 500;
-  margin: 0 8px;
-  cursor: pointer;
-  border-radius: 30px;
-  transition: all 0.3s ease;
-}
-
-.bannerButtonPrimary {
-  background-color: white;
-  color: var(--linea-black) !important;
-}
-
-.bannerButtonPrimary:hover {
-  background-color: var(--linea-brand-cyan);
-}
-
-.bannerButtonSecondary {
-  background-color: white;
-  color: var(--linea-black) !important;
-  border: none;
-}
-
-.bannerButtonSecondary:hover {
-  background-color: var(--linea-brand-cyan);
-}
-
-@media (max-width: 320px) {
-  .bannerButton {
-    font-size: 14px;
-    padding: 12px 24px;
-    margin: 4px;
-  }
-}
-
-.buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  flex-wrap: wrap;
-  margin-top: 0;
-}
-
 .logo {
   color: var(--linea-banner-color-1);
   padding-right: 15px;
@@ -114,9 +63,13 @@
   font-weight: 400;
   line-height: 1.4;
   padding: 0 2rem;
-  margin-bottom: 40px;
+  margin-bottom: 0;
   font-family: 'Atyp Text', sans-serif;
   text-align: center;
+}
+
+.subtitle + .subtitle {
+  margin-top: 12px;
 }
 
 /* The global `a:not(...)` reset in base.css colors links via
@@ -154,10 +107,6 @@
     font-size: 24px;
     padding-left: 20px;
     padding-right: 20px;
-  }
-
-  .bannerButton {
-    padding: 20px 40px;
   }
 }
 
@@ -198,10 +147,10 @@
 .introductionBlock {
   background: var(--linea-text-color-1) url('/img/hero_pattern.svg') no-repeat center;
   background-size: cover;
-  padding: 6rem;
+  padding: 4rem;
   text-align: center;
-  height: 50vh;
-  min-height: 450px;
+  height: auto;
+  min-height: 340px;
   width: calc(100vw - 2.5rem) !important;
   border-radius: 14px;
   margin: 0 auto;
@@ -217,51 +166,29 @@
   z-index: 1;
 }
 
-@media (max-width: 1380px) {
-  .introductionBlock {
-    height: 60vh;
-  }
-}
-
 @media (max-width: 768px) {
   .introductionBlock {
     padding: 3rem 2rem;
-    height: 344px;
-    min-height: 344px;
+    min-height: 280px;
     background-size: 100% auto;
     background-position: left top;
   }
 
   .title {
     font-size: 40px;
-    margin-bottom: 24px;
+    margin-bottom: 16px;
+    padding-bottom: 0;
   }
 
   .subtitle {
     font-size: 14px;
-    margin-bottom: 24px;
-  }
-
-  .buttons {
-    flex-direction: column;
-    gap: 16px;
-    margin-top: 0;
-    width: 248px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .bannerButton {
-    width: 100%;
-    padding: 12px 20px;
   }
 }
 
 @media (max-width: 530px) {
   .introductionBlock {
-    padding: 2rem 1rem;
-    height: 344px;
-    min-height: 344px;
+    padding: 2.5rem 1rem;
+    min-height: 260px;
   }
 
   .title {
@@ -271,8 +198,8 @@
 
 @media (max-width: 320px) {
   .introductionBlock {
-    padding: 0;
-    height: 75vh;
+    padding: 2rem 0.75rem;
+    min-height: 240px;
   }
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,26 +30,6 @@ function HomepageHeader() {
           </Link>{" "}
           is the open-source stack that powers it.
         </p>
-        <div className={styles.buttons}>
-          <Link
-            className={clsx(
-              "button button--secondary button--lg",
-              styles.bannerButton,
-              styles.bannerButtonPrimary,
-            )}
-            to="/protocol/overview">
-            Discover Lineth
-          </Link>
-          <Link
-            className={clsx(
-              "button button--secondary button--lg",
-              styles.bannerButton,
-              styles.bannerButtonSecondary,
-            )}
-            to="/network/quickstart">
-            Build on Linea
-          </Link>
-        </div>
       </div>
     </header>
   );
@@ -58,31 +38,43 @@ function HomepageHeader() {
 export default function Home(): React.ReactNode {
   const startBuildingCards = [
     {
-      title: "Learn about Lineth components",
-      link: "/stack/how-it-works",
-      description: (
+      title: (
         <>
-          Explore Lineth&apos;s deployment models, data availability,
-          finalization, and trust model.
+          Build on <strong>Linea</strong>
         </>
       ),
-      iconSrc: "/img/card_icon_understand.png",
+      link: "/network/quickstart",
+      description: (
+        <>Build, launch, and grow your application on Linea Mainnet.</>
+      ),
+      iconSrc: "/img/card_icon_build.png",
     },
     {
-      title: "Launch your own chain",
-      link: "/stack",
+      title: (
+        <>
+          Launch your own <strong>Lineth</strong> chain
+        </>
+      ),
+      link: "/stack/quickstart",
       description: (
         <>Deploy your own Ethereum-compatible network using Lineth.</>
       ),
       iconSrc: "/img/card_icon_launch.png",
     },
     {
-      title: "Build and deploy on Linea",
-      link: "/network/quickstart",
-      description: (
-        <>Build, launch, and grow your application on the Linea Mainnet.</>
+      title: (
+        <>
+          Learn about the <strong>protocol</strong>
+        </>
       ),
-      iconSrc: "/img/card_icon_build.png",
+      link: "/protocol/quickstart",
+      description: (
+        <>
+          Explore how Lineth processes transactions, generates proofs, and
+          finalizes state.
+        </>
+      ),
+      iconSrc: "/img/card_icon_understand.png",
     },
   ];
 
@@ -117,7 +109,7 @@ export default function Home(): React.ReactNode {
         description="Documentation for Linea Mainnet, the public zkEVM network, and Lineth, the open-source rollup stack that powers it.">
         <HomepageHeader />
         <main>
-          <CardGrid heading="Start building" cards={startBuildingCards} />
+          <CardGrid cards={startBuildingCards} />
           <CardGrid
             heading="Join the community"
             cards={communityCards}

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -1,0 +1,141 @@
+import React from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import {
+  useDocsSidebar,
+  useSidebarBreadcrumbs,
+} from "@docusaurus/plugin-content-docs/client";
+import { useHomePageRoute } from "@docusaurus/theme-common/internal";
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
+import DocBreadcrumbsStructuredData from "@theme/DocBreadcrumbs/StructuredData";
+import styles from "./styles.module.css";
+
+/** Map each docs sidebar to its top-level navbar section. */
+const SIDEBAR_SECTIONS = {
+  networkSidebar: {
+    label: "Linea Mainnet",
+    href: "/network/quickstart",
+  },
+  stackSidebar: {
+    label: "Lineth Stack",
+    href: "/stack/quickstart",
+  },
+  protocolSidebar: {
+    label: "Protocol",
+    href: "/protocol/quickstart",
+  },
+  referenceSidebar: {
+    label: "Reference",
+    href: "/reference",
+  },
+  changelogSidebar: {
+    label: "Changelog",
+    href: "/changelog/release-notes",
+  },
+};
+
+function getSectionItem(sidebarName) {
+  if (!sidebarName) {
+    return null;
+  }
+  return SIDEBAR_SECTIONS[sidebarName] ?? null;
+}
+
+function normalizeHref(href) {
+  if (!href || href === "/") {
+    return href;
+  }
+  return href.replace(/\/+$/, "");
+}
+
+function BreadcrumbsItemLink({ children, href, isLast }) {
+  const className = "breadcrumbs__link";
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({ children, active }) {
+  return (
+    <li
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}
+    >
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs() {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  const sidebar = useDocsSidebar();
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  const sectionItem = getSectionItem(sidebar?.name);
+
+  // Always include the top-level section. On section landing pages the first
+  // crumb is the same route (e.g. Get started → /stack/quickstart); replace it
+  // with the section label so we show "Lineth Stack" instead of omitting it.
+  let allItems = breadcrumbs;
+  if (sectionItem) {
+    const sectionHref = normalizeHref(sectionItem.href);
+    const rest = breadcrumbs.filter(
+      (item, idx) =>
+        !(idx === 0 && normalizeHref(item.href) === sectionHref),
+    );
+    allItems = [
+      { label: sectionItem.label, href: sectionItem.href, _isSection: true },
+      ...rest,
+    ];
+  }
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={allItems} />
+      <nav
+        className={clsx(
+          ThemeClassNames.docs.docBreadcrumbs,
+          styles.breadcrumbsContainer,
+        )}
+        aria-label={translate({
+          id: "theme.docs.breadcrumbs.navAriaLabel",
+          message: "Breadcrumbs",
+          description: "The ARIA label for the breadcrumbs",
+        })}
+      >
+        <ul className="breadcrumbs">
+          {homePageRoute && <HomeBreadcrumbItem />}
+          {allItems.map((item, idx) => {
+            const isLast = idx === allItems.length - 1;
+            const href = item._isSection
+              ? item.href
+              : item.type === "category" && item.linkUnlisted
+                ? undefined
+                : item.href;
+            return (
+              <BreadcrumbsItem key={idx} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {item.label}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -69,8 +69,7 @@ function BreadcrumbsItem({ children, active }) {
     <li
       className={clsx("breadcrumbs__item", {
         "breadcrumbs__item--active": active,
-      })}
-    >
+      })}>
       {children}
     </li>
   );
@@ -94,8 +93,7 @@ export default function DocBreadcrumbs() {
   if (sectionItem) {
     const sectionHref = normalizeHref(sectionItem.href);
     const rest = breadcrumbs.filter(
-      (item, idx) =>
-        !(idx === 0 && normalizeHref(item.href) === sectionHref),
+      (item, idx) => !(idx === 0 && normalizeHref(item.href) === sectionHref),
     );
     allItems = [
       { label: sectionItem.label, href: sectionItem.href, _isSection: true },
@@ -115,8 +113,7 @@ export default function DocBreadcrumbs() {
           id: "theme.docs.breadcrumbs.navAriaLabel",
           message: "Breadcrumbs",
           description: "The ARIA label for the breadcrumbs",
-        })}
-      >
+        })}>
         <ul className="breadcrumbs">
           {homePageRoute && <HomeBreadcrumbItem />}
           {allItems.map((item, idx) => {

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,4 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0;
+}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -147,8 +147,7 @@ export default function DocItemLayout({ children }) {
               className={clsx(
                 styles.docItemHeader,
                 "article-breadcrumbs-wrapper",
-              )}
-            >
+              )}>
               <DocBreadcrumbs />
               <div className={styles.docItemHeaderActions}>
                 <DocVersionBadge />

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,10 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import { ThemeClassNames, useWindowSize } from "@docusaurus/theme-common";
-import {
-  useDoc,
-  useSidebarBreadcrumbs,
-} from "@docusaurus/plugin-content-docs/client";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import DocItemPaginator from "@theme/DocItem/Paginator";
 import DocVersionBanner from "@theme/DocVersionBanner";
 import DocVersionBadge from "@theme/DocVersionBadge";
@@ -136,15 +133,6 @@ function useDocTOC() {
 export default function DocItemLayout({ children }) {
   const docTOC = useDocTOC();
   const { metadata } = useDoc();
-  const breadcrumbs = useSidebarBreadcrumbs();
-
-  // Get parent category label from breadcrumbs
-  // Find the last category-type breadcrumb (parent category)
-  const categoryLabel = breadcrumbs
-    ?.slice()
-    .reverse()
-    .find((item) => item.type === "category")?.label;
-
   const hideCopyButton = metadata.frontMatter?.hide_copy_button;
 
   return (
@@ -154,14 +142,15 @@ export default function DocItemLayout({ children }) {
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
           <article>
-            <div data-markdown-ignore className="article-breadcrumbs-wrapper">
-              <DocBreadcrumbs />
-            </div>
-            <div className={styles.titleRow} data-markdown-ignore>
-              {categoryLabel && (
-                <span className={styles.categoryLabel}>{categoryLabel}</span>
+            <div
+              data-markdown-ignore
+              className={clsx(
+                styles.docItemHeader,
+                "article-breadcrumbs-wrapper",
               )}
-              <div className={styles.titleRowRight}>
+            >
+              <DocBreadcrumbs />
+              <div className={styles.docItemHeaderActions}>
                 <DocVersionBadge />
                 {!hideCopyButton && <CopyPageButton />}
               </div>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -4,7 +4,7 @@
 
 .docItemContainer header + *,
 .docItemContainer article > *:first-child {
-  margin-top: 35px;
+  margin-top: 0;
 }
 
 @media (min-width: 1200px) {
@@ -25,35 +25,35 @@
   }
 }
 
-/* adjusts Y position of the main article section in the layout */
-nav[aria-label="Breadcrumbs"] {
-  margin-top: 0 !important;
-}
-
-/* Title row: category label left, copy button right */
-.titleRow {
+/* Breadcrumbs + copy page button on one row */
+.docItemHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 24px;
-  margin-bottom: 16px;
+  gap: 1rem;
+  margin-bottom: 24px;
 }
 
-.categoryLabel {
-  color: var(--linea-highlight-color-2);
-  font-family: 'Atyp Text', sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.4;
+.docItemHeader > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-[data-theme="dark"] .categoryLabel {
-  color: var(--linea-purple-light);
-}
-
-.titleRowRight {
+.docItemHeaderActions {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* adjusts Y position of the main article section in the layout */
+nav[aria-label="Breadcrumbs"] {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+@media (max-width: 996px) {
+  .docItemHeader {
+    flex-wrap: wrap;
+  }
 }


### PR DESCRIPTION
- Update link styles to use standard font-weight + different color
- Improve page header/breadcrumbs:
  - Add top-level section (Linea Mainnet, Lineth Stack, etc) to breadcrumbs
  - Remove category label (Features, How it works, etc) from separate heading line and integrate into breadcrumbs
  - Align copy page button with breadcrumbs
- Increase size of inline code and ensure it scales up when used in headings
- Make homepage UI more intuitive:
  - Remove redundant buttons in hero
  - Make the main CTA cards consistent with top level sections (Linea, Lineth, protocol)
  - Adjust spacing to ensure cards are visible without scrolling

Preview: https://doc-linea-git-ui-improvements-consensys-ddffed67.vercel.app/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to the Docusaurus theme, CSS, and MDX intros; no runtime APIs, auth, or data handling.
> 
> **Overview**
> **Documentation UI polish** across doc pages and the homepage: navigation context, typography, and layout spacing.
> 
> **Breadcrumbs and doc header** — A custom `DocBreadcrumbs` theme adds a **top-level section crumb** (Linea Mainnet, Lineth Stack, Protocol, Reference, Changelog) from the active sidebar. The separate **purple category label** row is removed; category context stays in the breadcrumb trail. **Copy page** sits on the **same row** as breadcrumbs (layout header), and several overview/quickstart MDX files drop inline copy-button wrappers and `hide_copy_button` front matter.
> 
> **Links and inline code** — Body and admonition links use new `--linea-inline-link-color` / hover tokens (no underline, regular weight). **Inline `code`** is slightly larger, with relative sizing inside headings.
> 
> **Homepage** — Hero **CTA buttons** are removed; primary paths are the three cards aligned to **Linea**, **Lineth**, and **protocol** quickstarts (rich card titles). Hero and `CardGrid` padding are tightened so cards show with less scrolling; the first card grid no longer has a "Start building" heading.
> 
> **Misc** — `CardGrid` supports optional `heading` and `React.ReactNode` titles; mobile article flex order drops the old title row in favor of breadcrumbs → TOC → content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fffab1587a4372ae846c03c89ccc649564efca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->