### PR TITLE
Remove Grove RPC provider

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -42,11 +42,6 @@ image: /img/socialCards/node-providers.jpg
     <td>:white_check_mark:</td>
   </tr>
   <tr>
-    <td><a href="https://grove.city/">Grove</a></td>
-    <td>:white_check_mark:</td>
-    <td>:x:</td>
-  </tr>
-  <tr>
     <td><a href="https://infura.io/">Infura</a></td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
@@ -137,14 +132,6 @@ Public endpoints are rate limited, and not meant for production systems.
     </td>
     <td>N/A</td>
     <td>:x:</td>
-    <td>:x:</td>
-  </tr>
-  <tr>
-    <td>
-      <code>https://linea.rpc.grove.city/v1/01fdb492</code>
-    </td>
-    <td>N/A</td>
-    <td>:white_check_mark:</td>
     <td>:x:</td>
   </tr>
   <tr>


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no impact on application behavior or infrastructure.
> 
> **Overview**
> Removes **Grove** from the node providers documentation: the provider comparison table row (including its mainnet/testnet support flags) and the public mainnet endpoint `https://linea.rpc.grove.city/v1/01fdb492` from the RPC URL list.
> 
> No runtime or configuration code changes—docs only, aligned with dropping Grove as a supported Linea RPC option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53934896b303eb37fe854862ee6876924c346fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->