### PR TITLE
Homepage fixes: fonts and contribute link

### DIFF
--- a/src/components/BaseCard/styles.module.css
+++ b/src/components/BaseCard/styles.module.css
@@ -28,7 +28,7 @@
 }
 
 .text {
-  font-family: 'Atyp Display', sans-serif;
+  font-family: AtypDisplay, sans-serif;
   font-size: 18px;
   font-weight: 500;
   line-height: 1.4;

--- a/src/components/CardGrid/styles.module.css
+++ b/src/components/CardGrid/styles.module.css
@@ -13,7 +13,7 @@
 
 .heading {
   text-align: left;
-  font-family: 'Atyp Display', sans-serif;
+  font-family: AtypDisplay, sans-serif;
   font-size: 40px;
   font-weight: 400;
   color: var(--linea-text-primary);
@@ -71,7 +71,7 @@
 }
 
 .cardTitle {
-  font-family: 'Atyp Display', sans-serif;
+  font-family: AtypDisplay, sans-serif;
   font-size: 24px;
   font-weight: 500;
   color: var(--linea-text-primary);
@@ -80,7 +80,7 @@
 }
 
 .description {
-  font-family: 'Atyp Text', sans-serif;
+  font-family: AtypText, sans-serif;
   font-size: 16px;
   font-weight: 400;
   color: var(--linea-text-primary);

--- a/src/components/ContributeBanner/index.tsx
+++ b/src/components/ContributeBanner/index.tsx
@@ -11,15 +11,15 @@ export default function ContributeBanner(): React.ReactNode {
       <div className={styles.bannerContainer}>
         <div className={styles.banner}>
           <div className={styles.content}>
-            <h2 className={styles.title}>Contribute to Linea</h2>
+            <h2 className={styles.title}>Contribute to Lineth</h2>
             <p className={styles.description}>
-              Join the Linea developer community and learn how to contribute.
+              Join the Lineth developer community and learn how to contribute.
             </p>
             <Link
               className={styles.button}
-              to="https://github.com/Consensys/doc.linea">
+              to="https://github.com/LFDT-Lineth/lineth-monorepo">
               <GitHubIcon width="14" height="14" className={styles.icon} />
-              Contribute
+              <span className={styles.buttonText}>Contribute</span>
             </Link>
           </div>
           <div className={styles.illustration}>

--- a/src/components/ContributeBanner/styles.module.css
+++ b/src/components/ContributeBanner/styles.module.css
@@ -67,6 +67,11 @@
   height: 14px;
 }
 
+.buttonText {
+  position: relative;
+  top: 2px;
+}
+
 .illustration {
   position: absolute;
   right: -17px;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -32,7 +32,7 @@
   line-height: 1.2;
   letter-spacing: -1.6px;
   padding-bottom: 16px;
-  font-family: 'Atyp Display', sans-serif;
+  font-family: AtypDisplay, sans-serif;
   text-align: center;
 }
 
@@ -64,7 +64,7 @@
   line-height: 1.4;
   padding: 0 2rem;
   margin-bottom: 0;
-  font-family: 'Atyp Text', sans-serif;
+  font-family: AtypText, sans-serif;
   text-align: center;
 }
 


### PR DESCRIPTION
**Font consistency**
- Homepage hero title/subtitle, card headings/titles, and card descriptions referenced font-family names (`'Atyp Display'`, `'Atyp Text'`) that didn't match the actual `@font-face` declarations (`AtypDisplay`, `AtypText`), causing the browser to silently fall back to the default sans-serif instead of the intended custom fonts. Corrected the family names in:
  - `src/pages/index.module.css`
  - `src/components/CardGrid/styles.module.css`
  - `src/components/BaseCard/styles.module.css`

**Contribute block**
- Updated copy from "Contribute to Linea" to "Contribute to Lineth", and body text to reference the Lineth developer community.
- Updated the CTA link from `https://github.com/Consensys/doc.linea` to `https://github.com/LFDT-Lineth/lineth-monorepo`.
- Wrapped the button label in a `span` and nudged it down `2px` to visually center it against the GitHub icon (custom webfont line-box padding was making the text appear slightly high relative to the icon's tight SVG bounds).

Fixes #1610 

Preview: https://doc-linea-git-1610-homepage-enhancements-consensys-ddffed67.vercel.app/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and marketing copy/link changes with no auth, data, or backend impact.
> 
> **Overview**
> Fixes homepage typography so **custom Atyp fonts actually load** by changing `font-family` from quoted names like `'Atyp Display'` / `'Atyp Text'` to **`AtypDisplay`** and **`AtypText`** in the hero (`index.module.css`), card grid, and base card styles.
> 
> Updates the **Contribute** section for **Lineth**: heading/body copy, CTA URL to `LFDT-Lineth/lineth-monorepo`, and wraps the button label in a `span` with a **2px** offset so it lines up with the GitHub icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fc9c4eeeb8ae7aa855c3dc40b1bed17f063fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->