### PR TITLE
docs: remove stale Linea Besu image tags

### DIFF
--- a/docs/network/how-to/run-a-node/beta-v4-migration.mdx
+++ b/docs/network/how-to/run-a-node/beta-v4-migration.mdx
@@ -240,7 +240,7 @@ Supported EL clients include:
   - Post-Shanghai: v1.16.x  
 - Erigon: Latest release
 - Nethermind: Latest release
-- Linea-specific: A new `linea-besu-package` release is available via Docker: `consensys/linea-besu-package:beta-v4.0-rc17-20251024131506-d32162b`
+- Linea-specific: Use the `linea-besu-package` release referenced in the canonical [Mainnet `docker-compose.yml`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet) in the Linea monorepo, or pick the latest tag from the [releases page](https://github.com/LFDT-Lineth/lineth-monorepo/releases).
 
 ## Upgrade to Cancun and Prague
 
@@ -265,17 +265,13 @@ requires a genesis file:
 ### Step 2: Update `docker-compose.yml`
 
 Retrieve the [updated `docker-compose.yml`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet) 
-file from the Linea monorepo. 
+file from the Linea monorepo. This canonical compose file pins the supported `linea-besu-package`
+image tag for Mainnet and is kept up to date as new releases ship; using it avoids pinning a
+tag in your own config that will go stale.
 
-Alternatively, update your existing `docker-compose.yml` file manually with the new `linea-besu-package` 
-image (`rc17`):
-
-```yaml
-  besu-node:
-      hostname: el-client
-      container_name: linea-besu
-      image: consensys/linea-besu-package:beta-v4.0-rc17-20251024131506-d32162b 
-```
+If you need to update an existing `docker-compose.yml` manually, copy the `besu-node` service
+definition (including the `image:` line) from the canonical compose file linked above rather
+than pinning a specific tag here.
 
 ### Step 3: Reinitialize your node
 

--- a/docs/network/how-to/run-a-node/linea-besu.mdx
+++ b/docs/network/how-to/run-a-node/linea-besu.mdx
@@ -101,15 +101,12 @@ You can use [this page](https://whatismyip.com/) to find your public IP address.
       docker compose -f ./your-file-path/docker-compose-advanced-sepolia.yaml up
       ```
 
-      Alternatively, you can run a node without downloading a `.yaml` file with a `docker run`
-      command. For example:
+      Use the canonical Sepolia compose file from the [Linea Besu package `docker`
+      directory](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/linea-besu/package/docker)
+      as the source of truth for the supported `linea-besu-package` image tag. That file is kept up
+      to date as new releases ship, so you do not have to pin a specific tag in your own config.
 
-      ```bash
-      docker run -e BESU_PROFILE=advanced-sepolia consensys/linea-besu-package:latest
-      ```
-
-      Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1, and replace the image
-      name with a more recent version from the releases page.
+      Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1.
 
     </TabItem>
 </Tabs>

--- a/docs/network/how-to/run-a-node/linea-besu.mdx
+++ b/docs/network/how-to/run-a-node/linea-besu.mdx
@@ -105,7 +105,7 @@ You can use [this page](https://whatismyip.com/) to find your public IP address.
       command. For example:
 
       ```bash
-      docker run -e BESU_PROFILE=advanced-sepolia consensys/linea-besu-package:beta-v4.0-rc11-20251004063519-a5c4c31
+      docker run -e BESU_PROFILE=advanced-sepolia consensys/linea-besu-package:latest
       ```
 
       Adjust the `BESU_PROFILE` to match one of the profiles listed in step 1, and replace the image


### PR DESCRIPTION
Removes stale Linea Besu beta image tags and points operators to the canonical monorepo compose file as the version source of truth.