### PR TITLE
Improve tabs UX

### DIFF
--- a/docs/api/reference/index.mdx
+++ b/docs/api/reference/index.mdx
@@ -69,7 +69,7 @@ Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 or [yarn](https://yarnpkg.com/getting-started/install) as the package manager. Then, in your project
 folder, initialise your new project:
 
-    <Tabs>
+    <Tabs groupId="package-manager">
       <TabItem value="npm">
 
       ```bash
@@ -88,7 +88,7 @@ folder, initialise your new project:
 
 1. In your project folder, install the `node-fetch` package:
 
-    <Tabs>
+    <Tabs groupId="package-manager">
       <TabItem value="npm">
 
       ```bash
@@ -139,7 +139,7 @@ folder, initialise your new project:
 
 1. In your project folder, install the `axios` package:
 
-    <Tabs>
+    <Tabs groupId="package-manager">
       <TabItem value="npm">
 
       ```bash
@@ -184,7 +184,7 @@ folder, initialise your new project:
 
 1. In your project folder, install the `viem` package:
 
-    <Tabs>
+    <Tabs groupId="package-manager">
       <TabItem value="npm">
 
       ```bash

--- a/docs/network/build/connect.mdx
+++ b/docs/network/build/connect.mdx
@@ -67,7 +67,7 @@ or connect your [wallet](#connect-your-wallet) to Linea.
   </TabItem> 
 </Tabs>
 
-### Connect with node providers
+### Connect to node providers
 
 If your dapp is using public endpoints, it may encounter rate limiting. You can find private RPC Linea node providers
 [here](../build/tools/node-providers/index.mdx). 

--- a/docs/network/build/connect.mdx
+++ b/docs/network/build/connect.mdx
@@ -10,13 +10,10 @@ image: /img/socialCards/connect.jpg
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::tip
+Connect to the [RPC providers](#connect-to-rpc-providers) for Linea Mainnet and Linea Sepolia,
+or connect your [wallet](#connect-your-wallet) to Linea.
 
-Use the Wallet tab for a walkthrough on how to add Linea to your wallet.
-
-:::  
-<Tabs groupId="connect-rpc-wallet" className="my-tabs">
-  <TabItem value="rpc" label="RPC" default>
+## Connect to RPC providers
 
 <Tabs groupId="Mainnet-Testnet" className="my-tabs">
   <TabItem 
@@ -70,116 +67,113 @@ Use the Wallet tab for a walkthrough on how to add Linea to your wallet.
   </TabItem> 
 </Tabs>
 
-## Connect with node providers
+### Connect with node providers
 
 If your dapp is using public endpoints, it may encounter rate limiting. You can find private RPC Linea node providers
 [here](../build/tools/node-providers/index.mdx). 
 
 Alternatively, consider running your [own RPC](../../protocol/architecture/rpc-services#why-run-your-own-rpc).
 
-</TabItem>
-  <TabItem value="wallet" label="Wallet">
+## Connect your wallet
 
-        ## Connect your wallet
+### MetaMask
 
-        ### MetaMask
+MetaMask automatically displays all your crypto assets across enabled networks, which includes Linea by default. If you want to filter out other networks to specifically view your Linea activity, you can easily do so on both extension and mobile.
 
-        MetaMask automatically displays all your crypto assets across enabled networks, which includes Linea by default. If you want to filter out other networks to specifically view your Linea activity, you can easily do so on both extension and mobile.
-
-        <Tabs className="my-tabs">
-            <TabItem value="extension" label="MetaMask Extension">
-
-                **Linea Mainnet**
-
-                In the top-right dropdown menu, click here to see your available networks.
-        
-                <div class="center-container">
-                  <div class="img-small">
-                    <img
-                      src="/img/get_started/connect/MetaMask_extension_locate_networks_menu_dropdown.png"
-                      alt="MetaMask extension locate networks menu dropdown"
-                    />
-                  </div>
-                </div>
-
-                Select "Linea" to switch to Linea Mainnet.
-
-                <div class="center-container">
-                  <div class="img-small">
-                    <img
-                      src="/img/get_started/connect/MetaMask_extension_locate_networks_list_linea.png"
-                      alt="MetaMask extension locate networks list Linea"
-                    />
-                  </div>
-                </div>
-
-                If you don't see Linea Mainnet in the "Enabled networks" list, scroll to the "Additional
-                networks" section, and click "Add".
-
-                <div class="center-container">
-                  <div class="img-small">
-                    <img
-                      src="/img/get_started/connect/MetaMask_extension_networks_list_additional_networks_add_linea.png"
-                      alt="MetaMask extension networks list additional networks add Linea"
-                    />
-                  </div>
-                </div>
-
-                **Linea Sepolia**
-
-                In the networks menu, scroll until you see the "Show test networks" toggle. If it's off,
-                switch it on; you should see Linea Sepolia in the list. Select it to get started.
-
-                <div class="center-container">
-                  <div class="img-small">
-                    <img
-                      src="/img/get_started/connect/MetaMask_extension_networks_list_show_test_networks_add_linea_sepolia.png"
-                      alt="MetaMask extension networks list show test networks add Linea Sepolia"
-                    />
-                  </div>
-                </div>
-
-    </TabItem>
-    <TabItem value="mobile" label="MetaMask Mobile">
+<Tabs className="my-tabs">
+    <TabItem value="extension" label="MetaMask Extension">
 
         **Linea Mainnet**
 
-        Find the network selector at the top of the "Tokens" tab. Tap it to open the networks menu.
+        In the top-right dropdown menu, click here to see your available networks.
 
         <div class="center-container">
           <div class="img-small">
             <img
-              src="/img/get_started/connect/MetaMask_mobile_locate_networks_dropdown_selector.png"
-              alt="MetaMask mobile locate networks dropdown selector"
+              src="/img/get_started/connect/MetaMask_extension_locate_networks_menu_dropdown.png"
+              alt="MetaMask extension locate networks menu dropdown"
             />
           </div>
         </div>
 
         Select "Linea" to switch to Linea Mainnet.
-        
+
         <div class="center-container">
           <div class="img-small">
             <img
-              src="/img/get_started/connect/MetaMask_mobile_networks_list_linea.png"
-              alt="MetaMask mobile networks list Linea"
+              src="/img/get_started/connect/MetaMask_extension_locate_networks_list_linea.png"
+              alt="MetaMask extension locate networks list Linea"
+            />
+          </div>
+        </div>
+
+        If you don't see Linea Mainnet in the "Enabled networks" list, scroll to the "Additional
+        networks" section, and click "Add".
+
+        <div class="center-container">
+          <div class="img-small">
+            <img
+              src="/img/get_started/connect/MetaMask_extension_networks_list_additional_networks_add_linea.png"
+              alt="MetaMask extension networks list additional networks add Linea"
             />
           </div>
         </div>
 
         **Linea Sepolia**
 
-        From the networks list, tap the "Custom" tab to view test networks. Select Linea Sepolia to get started.
+        In the networks menu, scroll until you see the "Show test networks" toggle. If it's off,
+        switch it on; you should see Linea Sepolia in the list. Select it to get started.
 
         <div class="center-container">
           <div class="img-small">
             <img
-              src="/img/get_started/connect/MetaMask_mobile_custom_networks_switch_to_linea_sepolia.png"
-              alt="MetaMask mobile custom networks switch to linea sepolia"
+              src="/img/get_started/connect/MetaMask_extension_networks_list_show_test_networks_add_linea_sepolia.png"
+              alt="MetaMask extension networks list show test networks add Linea Sepolia"
             />
           </div>
         </div>
 
-    </TabItem>
+  </TabItem>
+  <TabItem value="mobile" label="MetaMask Mobile">
+
+      **Linea Mainnet**
+
+      Find the network selector at the top of the "Tokens" tab. Tap it to open the networks menu.
+
+      <div class="center-container">
+        <div class="img-small">
+          <img
+            src="/img/get_started/connect/MetaMask_mobile_locate_networks_dropdown_selector.png"
+            alt="MetaMask mobile locate networks dropdown selector"
+          />
+        </div>
+      </div>
+
+      Select "Linea" to switch to Linea Mainnet.
+      
+      <div class="center-container">
+        <div class="img-small">
+          <img
+            src="/img/get_started/connect/MetaMask_mobile_networks_list_linea.png"
+            alt="MetaMask mobile networks list Linea"
+          />
+        </div>
+      </div>
+
+      **Linea Sepolia**
+
+      From the networks list, tap the "Custom" tab to view test networks. Select Linea Sepolia to get started.
+
+      <div class="center-container">
+        <div class="img-small">
+          <img
+            src="/img/get_started/connect/MetaMask_mobile_custom_networks_switch_to_linea_sepolia.png"
+            alt="MetaMask mobile custom networks switch to linea sepolia"
+          />
+        </div>
+      </div>
+
+  </TabItem>
 </Tabs>
 
 :::note
@@ -202,9 +196,6 @@ for instructions on how to add RPC endpoints. You can find most networks and add
 - [Ledger](https://support.ledger.com/article/17822826153757-zd)
 - [Trust Wallet](https://community.trustwallet.com/t/how-to-add-a-custom-network-on-the-trust-wallet-mobile-app/626781)
 - [Rainbow](https://rainbow.me/support/extension/custom-networks-on-the-browser-extension)
-
-</TabItem>
-</Tabs>
 
 ## Status page
 

--- a/docs/network/build/contracts.mdx
+++ b/docs/network/build/contracts.mdx
@@ -144,7 +144,7 @@ and click on the **Bridge** button to show all that are available.
 
 ## Token Bridge contracts
 
-<Tabs className="my-tabs">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
 
 <TabItem value="Mainnet" label="Mainnet">
 

--- a/docs/network/build/tools/libraries/multicall.mdx
+++ b/docs/network/build/tools/libraries/multicall.mdx
@@ -15,14 +15,14 @@ return the block number the values are from (giving them important context so
 that results from old blocks can be ignored if they're from an out-of-date
 node).
 
-<Tabs className="my-tabs">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
   <TabItem value="Mainnet" label="Mainnet">
 
 The Multicall contract V3 is deployed on Linea Mainnet at the standard contract
 address: [0xcA11bde05977b3631167028862bE2a173976CA11](https://explorer.linea.build/address/0xcA11bde05977b3631167028862bE2a173976CA11)
 
 </TabItem>
- <TabItem value="Linea Sepolia" label="Sepolia">
+ <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 The Multicall contract V3 is deployed on Linea Sepolia at the standard contract 
 address: [0xcA11bde05977b3631167028862bE2a173976CA11](https://sepolia.lineascan.build/address/0xca11bde05977b3631167028862be2a173976ca11)

--- a/docs/network/how-to/deploy-smart-contract/cookbook.mdx
+++ b/docs/network/how-to/deploy-smart-contract/cookbook.mdx
@@ -158,7 +158,45 @@ do not need any arguments, leave the array empty.
 
 ### Deploy the smart contract
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
+
+<TabItem value="Mainnet" label="Mainnet" default>
+
+1. In your `.env` file, add your Infura Linea API key and add your wallet private key.
+
+    ```
+    INFURA_API_KEY_LINEA = "<YOUR API KEY HERE>"
+    PRIVATE_KEY = "<YOUR PRIVATE KEY HERE>"
+    ```
+
+1. In the `hardhat.config.js` file, add the following lines:
+
+    ```js
+    const INFURA_API_KEY_LINEA = process.env.INFURA_API_KEY_LINEA;
+    ```
+
+    ```js
+    linea: {
+    url: `https://linea-mainnet.infura.io/v3/${INFURA_API_KEY_LINEA}`,
+    accounts: [PRIVATE_KEY],
+    },
+    ```
+
+1. In the `hardhat.config.js` file, uncomment the following line:
+
+    ```js
+    const PRIVATE_KEY = process.env.PRIVATE_KEY;
+    ```
+
+1. Deploy the smart contract to the Linea Mainnet:
+
+```
+npx hardhat run --network linea scripts/deploy.js
+```
+
+Hardhat will return the deployed smart contract address in your terminal. View and verify your smart contract
+on the [Linea Mainnet block explorer](https://lineascan.build/). 
+</TabItem> 
 
 <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
@@ -196,44 +234,6 @@ npx hardhat run --network lineaSepolia scripts/deploy.js
 
 Hardhat will return the deployed smart contract address in your terminal. View and verify your smart contract
 on the [Linea Sepolia block explorer](https://sepolia.lineascan.build/).
-</TabItem> 
-
-<TabItem value="Mainnet" label="Mainnet">
-
-1. In your `.env` file, add your Infura Linea API key and add your wallet private key.
-
-    ```
-    INFURA_API_KEY_LINEA = "<YOUR API KEY HERE>"
-    PRIVATE_KEY = "<YOUR PRIVATE KEY HERE>"
-    ```
-
-1. In the `hardhat.config.js` file, add the following lines:
-
-    ```js
-    const INFURA_API_KEY_LINEA = process.env.INFURA_API_KEY_LINEA;
-    ```
-
-    ```js
-    linea: {
-    url: `https://linea-mainnet.infura.io/v3/${INFURA_API_KEY_LINEA}`,
-    accounts: [PRIVATE_KEY],
-    },
-    ```
-
-1. In the `hardhat.config.js` file, uncomment the following line:
-
-    ```js
-    const PRIVATE_KEY = process.env.PRIVATE_KEY;
-    ```
-
-1. Deploy the smart contract to the Linea Mainnet:
-
-```
-npx hardhat run --network linea scripts/deploy.js
-```
-
-Hardhat will return the deployed smart contract address in your terminal. View and verify your smart contract
-on the [Linea Mainnet block explorer](https://lineascan.build/). 
 </TabItem> 
 
 </Tabs>

--- a/docs/network/how-to/deploy-smart-contract/foundry.mdx
+++ b/docs/network/how-to/deploy-smart-contract/foundry.mdx
@@ -107,7 +107,7 @@ linea-mainnet = "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}"
 
 To deploy the smart contract, run:
 
-<Tabs className="my-tabs">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```bash
@@ -116,7 +116,7 @@ forge create --rpc-url linea-mainnet src/Counter.sol:Counter --private-key $PRIV
 
 </TabItem>
 
-<TabItem value="Sepolia" label="Sepolia">
+<TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```bash
 forge create --rpc-url linea-sepolia src/Counter.sol:Counter --private-key $PRIVATE_KEY

--- a/docs/network/how-to/run-a-node/besu.mdx
+++ b/docs/network/how-to/run-a-node/besu.mdx
@@ -42,8 +42,8 @@ The Besu Docker image doesn't run on Windows. For Windows machines, [run using t
 
 Download the configuration files for the relevant network from the Linea monorepo. These include the Docker Compose file and Besu configuration file.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   To follow Linea Mainnet with Besu, download:
 
@@ -110,8 +110,8 @@ using the instructions in the official documentation.
 
 Download the Besu configuration file.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   Find the configuration file [here](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet/besu).
 
@@ -164,8 +164,8 @@ Linea.
 
 Run the Besu client with the location of your configuration file. For example:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   ```bash
   besu --config-file=/Users/myuser/mainnet/linea-besu.config.toml

--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -55,8 +55,8 @@ official release image in the compose file instead.
 Use the Linea monorepo's `docs/getting-started` directory as the example Docker Compose
 configuration. The same directory contains the Geth genesis file that Erigon should initialize from.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   Download or clone the
   [`docs/getting-started/linea-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet)
@@ -177,8 +177,8 @@ Use the resulting `build/bin/erigon` binary in the commands below, or add it to 
 Download the genesis file for the relevant network. In the example, we'll download the file to the
 directory specified by [`datadir` in Step 4](#step-4-bootstrap-your-node).
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   Download the current Linea Mainnet
   [`geth-genesis.json`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/getting-started/linea-mainnet/geth/geth-genesis.json)
@@ -211,8 +211,8 @@ If you run out of space, or need to actively maintain how much space is being us
 
 Bootstrap the node using the following command:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     erigon --datadir $HOME/erigon-mainnet-data/ init $HOME/erigon-mainnet-data/genesis.json
@@ -233,8 +233,8 @@ Bootstrap the node using the following command:
 
 Start the node using the following command:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     erigon \

--- a/docs/network/how-to/run-a-node/geth.mdx
+++ b/docs/network/how-to/run-a-node/geth.mdx
@@ -36,8 +36,8 @@ Download and install [Docker](https://docker.com/products/docker-desktop/) and e
 Download the configuration files for the relevant network. Ensure that you download the files to the
 same directory.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   Head to the [`/docs/getting-started/linea-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet/)
   directory in the Linea monorepo for all the files you need. Make sure you download the contents of
@@ -90,8 +90,8 @@ client.
 
 Download the genesis file for the relevant network.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
   Mainnet [`genesis.json`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet/geth) file.
   
@@ -123,8 +123,8 @@ If you run out of space, or need to actively maintain how much space is being us
 
 Bootstrap the node using the following command:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     geth --datadir ./geth-linea-data init ./geth-genesis.json
@@ -145,8 +145,8 @@ Bootstrap the node using the following command:
 
 Start the node using the following command:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     geth \

--- a/docs/network/how-to/run-a-node/linea-besu.mdx
+++ b/docs/network/how-to/run-a-node/linea-besu.mdx
@@ -39,8 +39,8 @@ To run a Linea Besu node, access the [`/docker` directory](https://github.com/LF
 in the Linea Besu repository. This directory is the source of truth for Linea Besu compose profiles.
 Each profile supports different Linea Besu plugin configurations depending on your use case.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
 
     Download the appropriate `.yaml` file for your use case:
     - [`basic-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/linea-besu/package/docker/docker-compose-basic-mainnet.yaml): Creates a basic follower node on Linea Mainnet with no plugins enabled.
@@ -72,8 +72,8 @@ You can use [this page](https://whatismyip.com/) to find your public IP address.
 
 ### Step 3. Start the Linea Besu node
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
     In a terminal, navigate to your `.yaml` file's directory. Then start the node by running
     `docker compose`:
 
@@ -155,8 +155,8 @@ Ensure you mount the `data-path` to the custom volume when you start the node.
 In the extracted directory, find `profiles`. The `.toml` configuration files in this folder define
 the parameters for each possible profile you can select for your Linea Besu node.
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
     Select one according to your preferences:
     - `basic-mainnet`: Creates a basic follower node on Linea Mainnet with no plugins enabled.
     - `advanced-mainnet`: Creates an advanced node on Linea Mainnet with plugins that enable support
@@ -179,8 +179,8 @@ Now run Linea Besu, specifying your preferred profile. The `--plugin-linea-l1-rp
 only be defined if you are running an `advanced` node, since this is needed to query finalization on
 L1.
 
-<Tabs groupId="networks" className="my-tabs">
-    <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+    <TabItem value="Mainnet" label="Mainnet">
     ```bash
     bin/besu --profile=advanced-mainnet --plugin-linea-l1-rpc-endpoint=YOUR_L1_RPC_ENDPOINT
     ```

--- a/docs/network/how-to/run-a-node/nethermind.mdx
+++ b/docs/network/how-to/run-a-node/nethermind.mdx
@@ -46,8 +46,8 @@ instead.
 
 Start the node using the following command:
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     nethermind \
@@ -96,8 +96,8 @@ docker pull nethermind/nethermind:latest
 
 ### Step 2. Start the Nethermind node
 
-<Tabs groupId="networks" className="my-tabs">
-  <TabItem value="mainnet" label="Mainnet">
+<Tabs groupId="Mainnet-Testnet" className="my-tabs">
+  <TabItem value="Mainnet" label="Mainnet">
   
     ```bash
     docker run -it \

--- a/docs/network/how-to/verify-smart-contract/foundry.mdx
+++ b/docs/network/how-to/verify-smart-contract/foundry.mdx
@@ -25,7 +25,7 @@ Yul. If you would like to verify using Blockscout, please use the [Blockscout AP
 
 If you want to verify a contract that has already been deployed, you can use the following commands:
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```bash
@@ -33,7 +33,7 @@ forge verify-contract --etherscan-api-key LINEASCAN_API_KEY --verifier-url https
 ```
 
   </TabItem>
-  <TabItem value="Testnet" label="Testnet">
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```bash
 forge verify-contract --etherscan-api-key LINEASCAN_API_KEY --verifier-url https://api-sepolia.lineascan.build/api CONTRACT_ADDRESS path_to_contract:contract_name --watch
@@ -66,7 +66,7 @@ Contract successfully verified
 
 If you want to verify a contract as it is being deployed for the first time, you can use the following commands:
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```bash
@@ -74,7 +74,7 @@ forge create --rpc-url https://linea.infura.io/v3/INFURA_API_KEY src/Counter.sol
 ```
 
   </TabItem>
-  <TabItem value="Testnet" label="Testnet">
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```bash
 forge create --rpc-url https://linea-sepolia.infura.io/v3/INFURA_API_KEY src/Counter.sol:Counter --private-key YOUR_PRIVATE_KEY --verify --verifier-url https://api-sepolia.lineascan.build/api --etherscan-api-key LINEASCAN_API_KEY
@@ -113,7 +113,7 @@ linea-mainnet = { key = "${LINEASCAN_API_KEY}", chain = 59144, url = "https://ap
 
 Then, to verify your smart contracts, you can simply run:
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```bash
@@ -121,7 +121,7 @@ forge verify-contract --chain linea-mainnet YOUR_CONTRACT_ADDRESS path_to_contra
 ```
 
   </TabItem>
-  <TabItem value="Testnet" label="Testnet">
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```bash
 forge verify-contract --chain linea-sepolia YOUR_CONTRACT_ADDRESS path_to_contract:contract_name --watch

--- a/docs/network/how-to/verify-smart-contract/hardhat.mdx
+++ b/docs/network/how-to/verify-smart-contract/hardhat.mdx
@@ -47,7 +47,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 First, we'll need to add a custom chain like so:
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```javascript
@@ -74,7 +74,7 @@ etherscan: {
 ```
 
   </TabItem>
-  <TabItem value="Testnet" label="Testnet">
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```javascript
 networks: {
@@ -113,7 +113,7 @@ The Etherscan `apiKey` and network name for your custom chain must match the net
 
 To verify your contract, run the following command:
 
-<Tabs>
+<Tabs groupId="Mainnet-Testnet">
   <TabItem value="Mainnet" label="Mainnet" default>
 
 ```bash
@@ -121,7 +121,7 @@ npx hardhat verify --network linea_mainnet <DEPLOYED_CONTRACT_ADDRESS> <CONTRACT
 ```
 
   </TabItem>
-  <TabItem value="Testnet" label="Testnet">
+  <TabItem value="Linea Sepolia" label="Linea Sepolia">
 
 ```bash
 npx hardhat verify --network linea_sepolia <DEPLOYED_CONTRACT_ADDRESS> <CONTRACT_ARGUMENTS>

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -2132,9 +2132,19 @@ details > div {
   color: #a78bfa;
 }
 
-/* Tabs styling per Figma */
+/*
+ * Tabs styling per Figma, plus the "common region" selection indicator
+ * (NN/g "Tabs, Used Right"): https://www.nngroup.com/articles/tabs-used-right/
+ * The selected tab and its panel share one background fill (a surface
+ * color distinct from the page background) so the boundary of the tabbed
+ * content stays visible for its entire length, however long. Unselected
+ * tabs sit directly on the page background for contrast.
+ */
 .tabs {
   border-bottom: none;
+  gap: 4px;
+  margin-bottom: 0;
+  padding: 0 20px;
 }
 
 .tabs__item {
@@ -2143,8 +2153,10 @@ details > div {
   font-weight: 400;
   padding: 10px 16px;
   border-bottom: 1px solid transparent;
+  border-radius: var(--linea-radius-sm) var(--linea-radius-sm) 0 0;
   color: var(--linea-text-secondary);
   transition: all 0.2s ease;
+  margin-bottom: 0;
 }
 
 .tabs__item:hover {
@@ -2152,39 +2164,9 @@ details > div {
 }
 
 .tabs__item--active {
-  border-bottom-color: var(--linea-brand-purple);
-  color: var(--linea-text-primary);
-}
-
-/*
- * "Common region" selection indicator (NN/g "Tabs, Used
- * Right"): https://www.nngroup.com/articles/tabs-used-right/
- * The selected tab and its panel share one background fill (a surface
- * color distinct from the page background) so the boundary of the tabbed
- * content stays visible for its entire length, however long. Unselected
- * tabs sit directly on the page background for contrast.
- */
-.tabs {
-  gap: 4px;
-  margin-bottom: 0;
-  /* Indent past the panel's border-radius so a leftmost active tab's
-     square bottom-left corner never overlaps the panel's rounded
-     top-left corner (which otherwise leaves a small background gap
-     peeking through at the seam). Matches the panel's own 20px padding
-     below so the tab and panel content edges line up. */
-  padding: 0 20px;
-}
-
-.tabs__item {
-  border-radius: var(--linea-radius-sm) var(--linea-radius-sm) 0 0;
-  /* Overrides the generic `article li { margin-bottom: 0.5rem }` rule,
-     which otherwise leaks onto tab list items and pushes the panel down. */
-  margin-bottom: 0;
-}
-
-.tabs__item--active {
-  background-color: var(--linea-surface-elevated);
   border-bottom-color: transparent;
+  color: var(--linea-text-primary);
+  background-color: var(--linea-surface-elevated);
   font-weight: 600;
 }
 
@@ -2192,12 +2174,8 @@ details > div {
   background-color: var(--linea-surface-elevated);
   border-radius: var(--linea-radius-md);
   padding: 20px;
-  /* Infima's `.margin-top--md` sets `margin-top: 1rem !important`, so this
-     needs !important too in order to zero out the gap and connect the
-     panel directly to the selected tab above it. */
   margin-top: 0 !important;
 }
-/* END EXPERIMENTAL common-region block */
 
 /* Pills/badges styling per Figma */
 .badge {

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -2135,7 +2135,6 @@ details > div {
 /* Tabs styling per Figma */
 .tabs {
   border-bottom: none;
-  margin-bottom: 24px;
 }
 
 .tabs__item {
@@ -2156,6 +2155,49 @@ details > div {
   border-bottom-color: var(--linea-brand-purple);
   color: var(--linea-text-primary);
 }
+
+/*
+ * "Common region" selection indicator (NN/g "Tabs, Used
+ * Right"): https://www.nngroup.com/articles/tabs-used-right/
+ * The selected tab and its panel share one background fill (a surface
+ * color distinct from the page background) so the boundary of the tabbed
+ * content stays visible for its entire length, however long. Unselected
+ * tabs sit directly on the page background for contrast.
+ */
+.tabs {
+  gap: 4px;
+  margin-bottom: 0;
+  /* Indent past the panel's border-radius so a leftmost active tab's
+     square bottom-left corner never overlaps the panel's rounded
+     top-left corner (which otherwise leaves a small background gap
+     peeking through at the seam). Matches the panel's own 20px padding
+     below so the tab and panel content edges line up. */
+  padding: 0 20px;
+}
+
+.tabs__item {
+  border-radius: var(--linea-radius-sm) var(--linea-radius-sm) 0 0;
+  /* Overrides the generic `article li { margin-bottom: 0.5rem }` rule,
+     which otherwise leaks onto tab list items and pushes the panel down. */
+  margin-bottom: 0;
+}
+
+.tabs__item--active {
+  background-color: var(--linea-surface-elevated);
+  border-bottom-color: transparent;
+  font-weight: 600;
+}
+
+.tabs-container > div.margin-top--md {
+  background-color: var(--linea-surface-elevated);
+  border-radius: var(--linea-radius-md);
+  padding: 20px;
+  /* Infima's `.margin-top--md` sets `margin-top: 1rem !important`, so this
+     needs !important too in order to zero out the gap and connect the
+     panel directly to the selected tab above it. */
+  margin-top: 0 !important;
+}
+/* END EXPERIMENTAL common-region block */
 
 /* Pills/badges styling per Figma */
 .badge {

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -2170,11 +2170,13 @@ details > div {
   font-weight: 600;
 }
 
+/* Panel sits flush under the active tab; Infima's .margin-top--md otherwise
+   leaves a gap that breaks the shared background with the tab. */
 .tabs-container > div.margin-top--md {
   background-color: var(--linea-surface-elevated);
   border-radius: var(--linea-radius-md);
   padding: 20px;
-  margin-top: 0 !important;
+  margin-top: 0 !important; /* override Infima utility margin */
 }
 
 /* Pills/badges styling per Figma */


### PR DESCRIPTION
Improves the visual design of tabbed content site-wide and syncs related tab groups so choices persist across pages.

- The selected tab now shares a background fill with its panel, and both stay visually connected with no gap — making the boundary of tabbed content clear even for long panels.

- Unified 17 tab instances across 12 files under a single `groupId="Mainnet-Testnet"`, with consistent `"Mainnet"` / `"Linea Sepolia"` labels and ordering (previously a mix of `mainnet`, `Testnet`, `Sepolia`, and inconsistent ordering, split across two unrelated `groupId`s). Selecting a network on any page now carries over to every other page.

- Added `groupId="package-manager"` to the 4 npm/yarn install blocks in `docs/api/reference/index.mdx` so picking `yarn` once applies to all install steps on the page.

- Removed the nested tabs on `docs/network/build/connect.mdx` (RPC/Wallet tabs wrapping the network and device tabs) in favor of a flat structure with clear `##` headings and an intro paragraph linking directly to each section.

Fixes #1611 

Preview: https://doc-linea-git-1611-tabs-consensys-ddffed67.vercel.app/network/build/connect


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CSS-only UX changes; no runtime application or security-sensitive logic.
> 
> **Overview**
> Improves **tabbed content** across the docs site with clearer visuals and **persistent tab choices** via Docusaurus `groupId`.
> 
> **CSS** (`docusaurus-overrides.css`): The active tab and its panel share `var(--linea-surface-elevated)` with no gap between them (Infima margin override), rounded tab tops, and bolder active labels—replacing the purple bottom-border-only style.
> 
> **Synced tab groups**: Many network-specific tab blocks now use `groupId="Mainnet-Testnet"` with consistent **Mainnet** / **Linea Sepolia** values and labels (replacing mixed `networks`, `Sepolia`/`Testnet`, and lowercase `mainnet`). A network picked on one page should carry to deploy, verify, node-run, contracts, multicall, and related guides. The API reference adds `groupId="package-manager"` on four npm/yarn install blocks so one package-manager choice applies across that page.
> 
> **Connect page**: Drops the outer RPC vs Wallet tab wrapper in favor of a short intro plus `##` sections for RPC providers and wallet setup; RPC network tabs stay on `Mainnet-Testnet`.
> 
> **Cookbook deploy**: Mainnet tab is listed first as default; tab order/content is unchanged aside from grouping alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c00816da8c87b38246607e2f3a85f2309a40ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->