### PR TITLE
docs: add Protocol security audit catalog

### DIFF
--- a/docs/network/build/contracts.mdx
+++ b/docs/network/build/contracts.mdx
@@ -215,4 +215,5 @@ For both mainnet and testnet:
 
 ## Audits
 
-You can view a complete list of Linea audits in the [Linea monorepo](https://github.com/LFDT-Lineth/lineth-monorepo/blob/2a8288f75a347104442f015b71262ab06a1e62f0/docs/audits.md).
+See the Protocol documentation for the published
+[security audit catalog](../../protocol/reference/security-audits).

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -13,7 +13,7 @@ Mainnet.
 ## Review the audit catalog
 
 The
-[Lineth audit catalog](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md)
+[Lineth and Linea audit catalog](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md)
 lists current and prior reports for:
 
 - The Prover, proving libraries, cryptographic primitives, and verifier contracts.

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -1,0 +1,32 @@
+---
+title: Security audits
+description: >-
+  Find published security audits for Lineth protocol components and Linea
+  Mainnet contracts.
+sidebar_position: 8
+image: /img/socialCards/security-audits.jpg
+---
+
+This page points to published security reviews for the components that make up Lineth and Linea
+Mainnet.
+
+## Review the audit catalog
+
+The
+[Lineth audit catalog](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md)
+lists current and prior reports for:
+
+- The Prover, proving libraries, cryptographic primitives, and verifier contracts.
+- Linea Mainnet rollup, message service, bridge, and feature-specific smart contracts.
+
+Review each report's target repository, commit, component, and date before applying its findings to
+a deployment.
+An audit of one component or version does not establish assurance for the full stack, later changes,
+or a specific operator deployment.
+
+## See also
+
+- [Prover architecture](../architecture/prover)
+- [Smart contracts](../architecture/smart-contracts)
+- [Security and assurance](/stack/evaluate/security)
+- [Trust and responsibilities](/stack/evaluate/trust-model)

--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -15,7 +15,7 @@ For trust boundaries and privileged authority, see
 
 This page does **not** include:
 
-- A complete audit catalog or proof-system maturity statement.
+- Proof-system maturity statements.
 - Production operations guidance (monitoring, incident response, disaster
   recovery).
 - Commercial support or SLA commitments.
@@ -67,6 +67,8 @@ mechanics, see the
 
 What is published today:
 
+- [Security audits](../../protocol/reference/security-audits): the published audit catalog
+  for Lineth protocol components and Linea Mainnet contracts
 - [Linea Mainnet Security Council transaction record](../../changelog/security-council-record.mdx):
   a public example of multisig-governed security and upgrade operations for
   Linea Mainnet
@@ -77,8 +79,6 @@ What is published today:
 
 What is not published here:
 
-- A consolidated audit or assurance hub covering component, version, and
-  deployment scope
 - Proof-system maturity statements or current security-review conclusions
 - Per-deployment assurance artifacts
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -412,23 +412,6 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Mechanisms",
-      collapsible: false,
-      items: [
-        "protocol/eip-7702",
-        "protocol/forced-transactions",
-      ],
-    },
-    {
-      type: "category",
-      label: "How to",
-      collapsible: false,
-      items: [
-        "protocol/how-to/forced-transactions",
-      ],
-    },
-    {
-      type: "category",
       label: "Reference",
       collapsible: false,
       items: [
@@ -443,6 +426,23 @@ const sidebars = {
           id: "protocol/reference/zero-knowledge-glossary",
           label: "Glossary",
         },
+      ],
+    },
+    {
+      type: "category",
+      label: "Mechanisms",
+      collapsible: false,
+      items: [
+        "protocol/eip-7702",
+        "protocol/forced-transactions",
+      ],
+    },
+    {
+      type: "category",
+      label: "How to",
+      collapsible: false,
+      items: [
+        "protocol/how-to/forced-transactions",
       ],
     },
   ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -437,6 +437,7 @@ const sidebars = {
           id: "protocol/reference/repos",
           label: "Linea repositories",
         },
+        "protocol/reference/security-audits",
         {
           type: "doc",
           id: "protocol/reference/zero-knowledge-glossary",


### PR DESCRIPTION
## Summary

- add a Protocol entry point for published Lineth and Linea security audits
- link to the canonical audit catalog without duplicating report content
- connect the existing contracts and security pages to the new reference

Closes #1630

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation changes only; no application or contract logic.
> 
> **Overview**
> Introduces **`protocol/reference/security-audits`** as the docs entry point for published Lineth and Linea audits, linking to the canonical monorepo catalog without duplicating report content.
> 
> **Network contracts** and **stack/evaluate/security** now point readers to that page instead of a bare GitHub URL or implying no consolidated audit hub. The **protocol sidebar** is reordered so **Reference** (repos, security audits, glossary) appears before Mechanisms and How to.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2683bc2f14a3dd103e7c1afd54cd1a2a04ef462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->