### PR TITLE
docs: clarify Lineth control boundaries

### DIFF
--- a/docs/stack/evaluate/trust-model.mdx
+++ b/docs/stack/evaluate/trust-model.mdx
@@ -45,15 +45,14 @@ Contracts are upgradeable via the [OpenZeppelin Transparent Upgradeable Proxy pa
 ## Protocol rules and configurable controls
 
 "Immutable" can be misleading for an upgradeable deployment.
-The current implementation enforces some rules without an operator override, but authorized
-upgrades can replace that implementation and change the rules for future state transitions.
-Evaluate a deployment across three control classes:
+The following classification brings together controls described across the deployment,
+configuration, and contract documentation:
 
 | Control class | Examples | How it changes |
 | --- | --- | --- |
 | Enforced by the deployed protocol version | State-transition constraints, proof verification, message authentication, and role checks | Not bypassable through ordinary configuration. Changes require a protocol or contract upgrade. |
 | Fixed when a network or contract is deployed | Chain and genesis settings, deployment model, finalization layer, initial role holders, and contract initializer values | Requires genesis changes, contract redeployment, reinitialization where supported, or an upgrade, depending on the value. |
-| Configurable by authorized operators | Component configuration, validator and node topology, data availability operations, role assignments, pauses, verifier selection, and rate limits | Changes through deployment configuration, operational procedures, or role-gated onchain transactions. |
+| Configurable by authorized operators | Component configuration, validator and node topology, data availability operations, and role-gated contract controls | Changes through deployment configuration, operational procedures, or authorized onchain transactions. |
 
 An operator cannot change an enforced rule through a runtime setting merely because the operator
 runs the infrastructure.
@@ -62,7 +61,8 @@ party that controls the software release and deployment process can propose chan
 protocol components.
 The deployment's governance process determines who approves and executes those changes.
 
-For exposed component settings, see the
+For the underlying details, see [Deployment models](./deployment-models),
+[Deployment components](../deployment/core-components), and the
 [Linea Besu plugin configuration](/reference/component-configuration/linea-besu-plugin-options)
 and [Prover configuration](/reference/component-configuration/linea-prover-options) references.
 The presence of a configuration key does not mean that changing it is safe or supported for every

--- a/docs/stack/evaluate/trust-model.mdx
+++ b/docs/stack/evaluate/trust-model.mdx
@@ -44,9 +44,9 @@ Contracts are upgradeable via the [OpenZeppelin Transparent Upgradeable Proxy pa
 
 ## Protocol rules and configurable controls
 
-"Immutable" can be misleading for an upgradeable deployment.
-The following classification brings together controls described across the deployment,
-configuration, and contract documentation:
+Lineth controls fall into three categories based on when and how they can change.
+This distinction identifies changes available through configuration, changes fixed during
+deployment, and changes that require a protocol or contract upgrade.
 
 | Control class | Examples | How it changes |
 | --- | --- | --- |

--- a/docs/stack/evaluate/trust-model.mdx
+++ b/docs/stack/evaluate/trust-model.mdx
@@ -42,6 +42,32 @@ The Stack contracts ship with a fixed set of roles. Holders are decided by the o
 
 Contracts are upgradeable via the [OpenZeppelin Transparent Upgradeable Proxy pattern](/protocol/architecture/smart-contracts#contract-versioning). Proxy upgrade authority is separate from `DEFAULT_ADMIN_ROLE` and depends on who controls the proxy admin or governance contract for the deployment. Operators should place upgrade authority behind an appropriate multisig, governance contract, or timelock. The [Linea Security Council transaction record](/changelog/security-council-record) shows a public Linea example of multisig-governed security and upgrade operations.
 
+## Protocol rules and configurable controls
+
+"Immutable" can be misleading for an upgradeable deployment.
+The current implementation enforces some rules without an operator override, but authorized
+upgrades can replace that implementation and change the rules for future state transitions.
+Evaluate a deployment across three control classes:
+
+| Control class | Examples | How it changes |
+| --- | --- | --- |
+| Enforced by the deployed protocol version | State-transition constraints, proof verification, message authentication, and role checks | Not bypassable through ordinary configuration. Changes require a protocol or contract upgrade. |
+| Fixed when a network or contract is deployed | Chain and genesis settings, deployment model, finalization layer, initial role holders, and contract initializer values | Requires genesis changes, contract redeployment, reinitialization where supported, or an upgrade, depending on the value. |
+| Configurable by authorized operators | Component configuration, validator and node topology, data availability operations, role assignments, pauses, verifier selection, and rate limits | Changes through deployment configuration, operational procedures, or role-gated onchain transactions. |
+
+An operator cannot change an enforced rule through a runtime setting merely because the operator
+runs the infrastructure.
+However, a party that controls upgrade authority can replace upgradeable contract logic, and a
+party that controls the software release and deployment process can propose changes to offchain
+protocol components.
+The deployment's governance process determines who approves and executes those changes.
+
+For exposed component settings, see the
+[Linea Besu plugin configuration](/reference/component-configuration/linea-besu-plugin-options)
+and [Prover configuration](/reference/component-configuration/linea-prover-options) references.
+The presence of a configuration key does not mean that changing it is safe or supported for every
+deployment.
+
 :::warning
 
 `DEFAULT_ADMIN_ROLE` cannot be assigned through `__Permissions_init`. The initial holder is set via the explicit `defaultAdmin` initializer field. Plan the initial holder before initialization.


### PR DESCRIPTION
## Summary

- classify behavior enforced by the deployed protocol version
- distinguish values fixed during deployment from operator-configurable controls
- link the classification to deployment and component configuration references

Closes #1632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to trust-model guidance; no runtime, contract, or security logic is modified.
> 
> **Overview**
> Adds a **Protocol rules and configurable controls** section to the trust model doc, placed after admin keys and upgrade authority and before the existing `DEFAULT_ADMIN_ROLE` warning.
> 
> The new content groups Lineth controls into three classes—protocol-enforced rules, deployment-fixed values, and operator-configurable settings—and explains that running infrastructure does not let operators bypass enforced rules, while upgrade authority and release/deployment control remain governance-governed paths for deeper change.
> 
> It links readers to deployment models, core components, and Besu/Prover configuration references, and notes that a config key being documented does not imply every deployment may safely change it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05b89652978bd83ea8932bf914bb3fcb1be02c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->