### PR TITLE
docs: clarify security audit coverage

### DIFF
--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -10,14 +10,20 @@ image: /img/socialCards/security-audits.jpg
 This page points to published security reviews for the components that make up Lineth and Linea
 Mainnet.
 
-## Review the audit catalog
+## Audit coverage
 
 The
 [Lineth and Linea audit catalog](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md)
 lists current and prior reports for:
 
-- The Prover, proving libraries, cryptographic primitives, and verifier contracts.
-- Linea Mainnet rollup, message service, bridge, and feature-specific smart contracts.
+- The Prover and proving libraries.
+- Cryptographic primitives.
+- Verifier contracts.
+- Linea Mainnet rollup and message service contracts.
+- Token bridges and feature-specific contracts.
+
+The catalog includes reports from independent security firms, including Consensys Diligence,
+OpenZeppelin, Cyfrin, Least Authority, ZKSecurity, Sigma Prime, and Kudelski Security.
 
 Each report identifies the component and code revision reviewed at the time of the audit.
 

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -22,8 +22,7 @@ lists reports for:
 - Linea Mainnet rollup and message service contracts.
 - Token bridges and feature-specific contracts.
 
-The catalog includes reports from independent security firms, including Consensys Diligence,
-OpenZeppelin, Cyfrin, Least Authority, ZKSecurity, Sigma Prime, and Kudelski Security.
+The catalog includes reports from independent security firms, including OpenZeppelin, Cyfrin, Least Authority, ZKSecurity, Sigma Prime, Kudelski Security and Consensys Diligence.
 
 Each report identifies the component and code revision reviewed at the time of the audit.
 

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -19,11 +19,6 @@ lists current and prior reports for:
 - The Prover, proving libraries, cryptographic primitives, and verifier contracts.
 - Linea Mainnet rollup, message service, bridge, and feature-specific smart contracts.
 
-Review each report's target repository, commit, component, and date before applying its findings to
-a deployment.
-An audit of one component or version does not establish assurance for the full stack, later changes,
-or a specific operator deployment.
-
 ## See also
 
 - [Prover architecture](../architecture/prover)

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -14,7 +14,7 @@ Mainnet.
 
 The
 [Lineth and Linea audit catalog](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md)
-lists current and prior reports for:
+lists reports for:
 
 - The Prover and proving libraries.
 - Cryptographic primitives.

--- a/docs/protocol/reference/security-audits.mdx
+++ b/docs/protocol/reference/security-audits.mdx
@@ -19,6 +19,8 @@ lists current and prior reports for:
 - The Prover, proving libraries, cryptographic primitives, and verifier contracts.
 - Linea Mainnet rollup, message service, bridge, and feature-specific smart contracts.
 
+Each report identifies the component and code revision reviewed at the time of the audit.
+
 ## See also
 
 - [Prover architecture](../architecture/prover)


### PR DESCRIPTION
## Summary

- clarify the components covered by published security audits
- identify the independent security firms represented in the catalog
- simplify the report scope description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a reference page with no runtime, contract, or security logic changes.
> 
> **Overview**
> Updates the **Security audits** reference page to make audit scope and sourcing clearer for readers evaluating assurance evidence.
> 
> The section **Review the audit catalog** is renamed to **Audit coverage**, and the bullet list is split into discrete lines (prover, crypto primitives, verifiers, rollup/message service, bridges/feature contracts) instead of two combined bullets. Wording around the GitHub catalog is tightened from “current and prior reports” to “reports for”.
> 
> The page **adds** an explicit list of independent firms represented in the catalog (OpenZeppelin, Cyfrin, Least Authority, ZKSecurity, Sigma Prime, Kudelski Security, Consensys Diligence) and replaces longer guidance about applying findings and deployment scope with a short note that each report states the component and code revision reviewed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e65ec434e59668b5dad58897a8891462f9589a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->