### PR TITLE
Fix link css

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -49,16 +49,6 @@ abbr:where([title]) {
   text-decoration: underline dotted;
 }
 
-/* :where() keeps this selector's specificity pinned to the bare `a` element
-   (0,0,1), matching :not()'s Selectors Level 4 spec. Without it, the
-   production build's browser-compat CSS processing (needed for the old
-   browsers in our browserslist config, e.g. iOS Safari 11) downlevels the
-   :not() selector list into a chain of individual :not()s. That chain is
-   spec-valid for matching, but it also sums each :not()'s specificity
-   (0,5,1) instead of taking the max, which then outranks the `.theme-doc-markdown a`
-   / `article a` link-styling rules below and silently reintroduces this
-   inherited (usually "none") text-decoration in prod only, not in local dev
-   (`npm start`, which skips that compat pass). */
 a:not(:where(.navbar__link, .footer__link-item, .menu__link, .support-link, .table-of-contents__link)) {
   font-family: inherit;
   color: var(--linea-link-highlight-color);

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -49,7 +49,17 @@ abbr:where([title]) {
   text-decoration: underline dotted;
 }
 
-a:not(.navbar__link, .footer__link-item, .menu__link, .support-link, .table-of-contents__link) {
+/* :where() keeps this selector's specificity pinned to the bare `a` element
+   (0,0,1), matching :not()'s Selectors Level 4 spec. Without it, the
+   production build's browser-compat CSS processing (needed for the old
+   browsers in our browserslist config, e.g. iOS Safari 11) downlevels the
+   :not() selector list into a chain of individual :not()s. That chain is
+   spec-valid for matching, but it also sums each :not()'s specificity
+   (0,5,1) instead of taking the max, which then outranks the `.theme-doc-markdown a`
+   / `article a` link-styling rules below and silently reintroduces this
+   inherited (usually "none") text-decoration in prod only, not in local dev
+   (`npm start`, which skips that compat pass). */
+a:not(:where(.navbar__link, .footer__link-item, .menu__link, .support-link, .table-of-contents__link)) {
   font-family: inherit;
   color: var(--linea-link-highlight-color);
   text-decoration: inherit;

--- a/src/css/docusaurus-overrides.css
+++ b/src/css/docusaurus-overrides.css
@@ -2205,9 +2205,8 @@ details > div > div {
 
 article a,
 .theme-doc-markdown a {
-  color: var(--linea-text-primary) !important;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  color: var(--linea-inline-link-color) !important;
+  text-decoration: none;
   font-family: AtypText, sans-serif;
   font-weight: 400;
   font-size: inherit;
@@ -2229,13 +2228,18 @@ article a.submission-button:hover,
 
 article a:hover,
 .theme-doc-markdown a:hover {
-  color: var(--linea-link-highlight-color) !important;
+  color: var(--linea-inline-link-hover) !important;
   opacity: 1;
+}
+
+article a code,
+.theme-doc-markdown a code {
+  color: var(--linea-inline-link-color) !important;
 }
 
 article a:hover code,
 .theme-doc-markdown a:hover code {
-  color: var(--linea-link-highlight-color) !important;
+  color: var(--linea-inline-link-hover) !important;
 }
 
 /* Headings styling per Figma - EXACT specs */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -162,6 +162,8 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #10b981;
   --linea-error-accent: #f87171;
+  --linea-inline-link-color: #7edff5;
+  --linea-inline-link-hover: #2eb9dc;
 
   /* Mermaid diagram palette (deployment-models + sequence highlights) */
   --linea-mermaid-cluster-bg: rgb(64 69 76);
@@ -280,6 +282,8 @@
   --linea-code-text: #d1d1d1;
   --linea-success-accent: #0f9d6f;
   --linea-error-accent: #dc2626;
+  --linea-inline-link-color: #4f24c4;
+  --linea-inline-link-hover: #8e5dff;
 
   /* Mermaid diagram palette (deployment-models + sequence highlights) */
   --linea-mermaid-cluster-bg: #e8e9eb;

--- a/src/theme/GlossaryTerm/styles.module.css
+++ b/src/theme/GlossaryTerm/styles.module.css
@@ -3,8 +3,8 @@
   display: inline;
 }
 
-.glossaryTerm {
-  color: var(--linea-text-primary);
+.glossaryTermWrapper .glossaryTerm {
+  color: var(--linea-text-primary) !important;
   text-decoration: underline dotted !important;
   text-underline-offset: 2px;
   cursor: help;
@@ -12,8 +12,8 @@
   font-weight: inherit !important;
 }
 
-.glossaryTerm:hover {
-  color: var(--linea-link-highlight-color);
+.glossaryTermWrapper .glossaryTerm:hover {
+  color: var(--linea-link-highlight-color) !important;
 }
 
 .tooltip {


### PR DESCRIPTION
Preview: https://doc-linea-git-fix-links-consensys-ddffed67.vercel.app/network/overview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes with no auth, data, or runtime logic; main risk is visual regressions on links, glossary terms, or nav exclusions in edge cases.
> 
> **Overview**
> **Doc body links** now use dedicated theme tokens (`--linea-inline-link-color` / `--linea-inline-link-hover`) instead of body text color, with **no default underline** and matching colors on **nested `code` inside links**.
> 
> **Light and dark themes** each define distinct purple/cyan inline link and hover values in `tokens.css`.
> 
> The global anchor rule in `base.css` switches to `:not(:where(...))` so nav/footer/menu links stay excluded without `:not()` list specificity fighting component styles.
> 
> **Glossary terms** are re-scoped under `.glossaryTermWrapper` with `!important` so they keep primary text + dotted underline (not the new inline link look).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b6a4e5307f2665a94bd144df02dbff20b655dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->