### PR TITLE
Edit remaining protocol architecture pages

### DIFF
--- a/.agents/skills/author-doc-page/SKILL.md
+++ b/.agents/skills/author-doc-page/SKILL.md
@@ -60,7 +60,7 @@ conventions for headings, frontmatter fields, and intro style.
 
 Create the file with frontmatter (`title`, `description`; no `image`, see
 `markdown-formatting.mdc`) and the structure from `content-structure.mdc` for the content
-type: an opening (no heading, doesn't restate the title), then content sections, then
+type: an opening (no heading), then content sections, then
 verified code samples, then a resources section for links. How-to and tutorial pages use
 numbered steps with prerequisites listed first instead.
 
@@ -81,8 +81,7 @@ Fill in the scaffold with content based on what the user provides:
 Before finishing, check:
 
 - [ ] Frontmatter has `title` and `description`, no manual `image` field.
-- [ ] Opening answers "what" and "why" in one to two sentences, without restating the
-  title.
+- [ ] Opening answers "what" and "why" in one to two sentences.
 - [ ] Structure matches the content type and neighboring pages.
 - [ ] Terminology and casing match `terminology.mdc` and the canonical
   `/protocol/linea-vs-lineth` page.

--- a/.agents/skills/pr-content-review/SKILL.md
+++ b/.agents/skills/pr-content-review/SKILL.md
@@ -62,7 +62,7 @@ of truth for full criteria:
 ### Voice and clarity (`editorial-voice.mdc`)
 
 - Active voice, sentence-case and imperative headings.
-- Opening sentence doesn't restate the title.
+- Opening orients the reader in one to two sentences.
 - Jargon defined on first use.
 - No filler or promotional language.
 - Any unverified number, address, version, or date is marked `[VERIFY]`, not stated as

--- a/.cursor/rules/content-structure.mdc
+++ b/.cursor/rules/content-structure.mdc
@@ -35,7 +35,7 @@ title: [Short, descriptive: matches the URL slug]
 description: [One sentence: what is this, why does it matter, who cares]
 ---
 
-[One to two sentence opening: the big picture. No heading. Don't restate the title.]
+[One to two sentence opening: the big picture. No heading.]
 
 ## What it is
 ## Why it matters
@@ -63,8 +63,8 @@ title: [Short, descriptive, action-oriented: matches the URL slug]
 description: [One sentence: what you'll build or do]
 ---
 
-[One to two sentence opening: what the reader will build or do. No heading. Don't restate
-the title. Prefer "This tutorial walks you through..." over "In this tutorial, we will...".]
+[One to two sentence opening: what the reader will build or do. No heading. Prefer "This
+tutorial walks you through..." over "In this tutorial, we will...".]
 
 ## Prerequisites
 

--- a/.cursor/rules/editorial-voice.mdc
+++ b/.cursor/rules/editorial-voice.mdc
@@ -15,7 +15,6 @@ The rules below are the most actionable subset for AI-assisted editing.
   "Key Benefits").
 - Use imperative tense for headings (for example, "Configure a node", not "Configuring a
   node" or "How to configure a node"). Keep headings as concise as possible.
-- Never restate the page title as the page's opening sentence.
 
 ## Voice and clarity
 

--- a/docs/protocol/architecture/interoperability/canonical-message-service.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-message-service.mdx
@@ -1,63 +1,84 @@
 ---
 title: Canonical message service
 description: How Lineth's canonical message service passes arbitrary messages between networks.
-sidebar_position: 9
 image: /img/socialCards/canonical-message-service.jpg
 ---
 
 import GlossaryTerm from '@theme/GlossaryTerm';
 
+The canonical message service passes arbitrary messages (that is, user-specified data and native currency)
+between a <GlossaryTerm term="Lineth" /> network and its
+<GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm>.
+It is general-purpose infrastructure: the [canonical token bridge](./canonical-token-bridge.mdx) is built on it,
+and any contract or dapp can call it directly.
+
 <div class="center-container">
   <div class="img-large">
     <img
       src="/img/get_started/concepts/message_service/Linea_message_service_2.png"
-      alt="Linea message service architecture"
+      alt="Message service contracts on each chain, with an operator and an offchain claiming actor"
     />
   </div>
 </div>
 
-## What is it?
+## How it works
 
-The canonical message service is a combination of smart contracts and other protocols which work together to pass "arbitrary messages"--that is, user-specified data--between a <GlossaryTerm term="Lineth" /> network and other networks.
+The service is a pair of message service contracts, one deployed on the network and one on the finalization
+layer, plus the **postman**: an offchain service that watches both contracts and relays what it sees.
 
-## What does it do?
+1. A caller invokes `sendMessage` on the origin contract with a destination address, a calldata payload, any
+    native value to transfer, and an optional delivery fee.
+    The contract records the message and emits an event.
+2. The destination contract receives a [commitment](#message-commitments) to the messages the origin chain sent.
+3. Claiming the message executes it: the destination contract checks the claim against that commitment, then
+    calls the destination address with the payload and the value.
 
-If you've ever used a bridge between two blockchains, you may be used to what feels like a fairly restrictive experience; you can only send certain tokens, for example. The canonical message service itself isn't like an end-user bridge interface. It's a system through which data and assets can be permissionlessly and reliably transferred from one blockchain to another. The service, as a whole, receives requests to move something from one network to the other, and then carries that request out, delivering the message as submitted to an established smart contract on the destination network.
+Claiming is permissionless: anyone can submit the claim.
+This gives senders two delivery modes:
 
-One of the most important things that the message service transfers is information about the current state of the <GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm>, from that layer to the Lineth network, and in return, an updated [Merkle tree](../state-manager.mdx#merkle-trees) and a <GlossaryTerm term="Zero-knowledge proof">ZK proof</GlossaryTerm> from the network back to the finalization layer, every time the network reports back about its activity. In other words, the canonical message service transmits the rollup data.
+- **Push**: The sender pays a fee up front, and the postman claims on their behalf, pushing the message to
+  the recipient without them doing anything.
+- **Pull**: No fee is paid, so the message sits unclaimed until the recipient, or anyone else, pulls it by
+  submitting the claim and paying the gas.
 
-However, the service is not limited or restricted to use by the network's core functionality. It is general-purpose, public infrastructure which can be used by developers, integrated into dapps, and triggered by end users.
+Push relies on the postman for convenience, not for correctness.
+The fee goes to whoever submits the claim, so if the postman is unavailable, the recipient or a third party
+can claim the message and collect the fee instead.
 
-<div class="center-container">
-  <div class="img-large">
-    <img
-      src="/img/get_started/concepts/message_service/Linea_bridge_architecture.png"
-      alt="Linea bridge architecture"
-    />
-  </div>
-</div>
+## Message commitments
 
-## How does it do it?
+Each direction commits to its messages differently, because only one of the two chains sits behind a proof.
 
-The canonical message service consists of three main elements: two smart contracts, and the postman service in between. One smart contract is deployed on the Lineth network and one on the finalization layer, and they are almost exactly the same. On Linea Mainnet, these are the [contracts on Linea and Ethereum](../../../network/build/send-receive-messages.mdx#contracts). They allow for ETH to be minted on the target network, for example, though they are not limited to that.
+**Network to finalization layer.**
+Finalizing a range of blocks verifies its
+<GlossaryTerm term="Zero-knowledge proof">ZK proof</GlossaryTerm> and anchors the Merkle root of the messages
+those blocks sent.
+A claim carries a Merkle proof, and the contract rejects it unless the proof places the message under an anchored root.
+Messages are therefore only claimable once the blocks that sent them are finalized.
 
-A user initiates a network-to-network transfer by executing a call on one of the contract's methods--that is, invoking a function built into the smart contract. The user could do this on their own, if they have the knowledge of how to interact with a smart contract directly, or they could do so through a frontend. If properly formulated, the smart contract will accept the request from the user, and pass it off to the postman.
-
-The postman service is currently centralized, but will be decentralized. The postman "listens" for calls being made to one of the contracts, either on the network or the finalization layer, and passes the submitted information to the other network.
-
-Once the information is delivered to the destination smart contract, the code contained in the request is executed. If the message being transferred carried orders to mint tokens, users can either choose to manually _pull_ the transferred assets out of the destination end of the bridge, or pay up-front and allow the assets to be _pushed_ directly to the destination address.
-
-There's an additional layer of logic, though, which serves to ensure that the message delivered to the Lineth network is valid. Essentially, a message is sent from the finalization layer, relayed through the message service, and is delivered to the smart contract on the network. That smart contract checks the message received against the list of messages sent on the finalization layer side, verifies that it exists there, and only then accepts it as a valid message:
+**Finalization layer to network.**
+The [coordinator](../coordinator/index.mdx) anchors incoming message hashes on the network as a rolling hash, so
+these messages are claimable without waiting for the next finalization.
+The network's rolling hash is submitted with that finalization and checked against the one the finalization-layer
+contract computed when the messages were sent, so a network that accepted messages nobody sent cannot finalize.
+In the following diagram, the check labeled "Does message exist on L1?" is the destination contract testing the
+message against the hashes already anchored on the network.
 
 <div class="center-container">
   <div class="img-large">
     <img
       src="/img/get_started/concepts/message_service/Linea_message_service_1.png"
-      alt="Linea message service verification"
+      alt="Message execution on the destination chain, gated on confirmation from the origin chain"
     />
   </div>
 </div>
 
-## Next steps
+## See also
 
-- See how to send and recover messages from the [Public Linea network](../../../network/build/send-receive-messages.mdx)
+- See [Messaging](../../../network/build/send-receive-messages.mdx) for the contract addresses, interfaces, and
+  claim workflow on Linea Mainnet.
+- Configure postman behavior using the
+  [Linea Postman options](../../../stack/reference/linea-postman-options.mdx).
+- See the [messaging contract source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/contracts/src/messaging)
+  and the [postman source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/postman) in the
+  `lineth-monorepo`.

--- a/docs/protocol/architecture/interoperability/canonical-message-service.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-message-service.mdx
@@ -24,7 +24,7 @@ and any contract or dapp can call it directly.
 ## How it works
 
 The service is a pair of message service contracts, one deployed on the network and one on the finalization
-layer, plus the **postman**: an offchain service that watches both contracts and relays what it sees.
+layer, plus the **Postman**: an offchain service that watches both contracts and relays what it sees.
 
 1. A caller invokes `sendMessage` on the origin contract with a destination address, a calldata payload, any
     native value to transfer, and an optional delivery fee.
@@ -36,13 +36,13 @@ layer, plus the **postman**: an offchain service that watches both contracts and
 Claiming is permissionless: anyone can submit the claim.
 This gives senders two delivery modes:
 
-- **Push**: The sender pays a fee up front, and the postman claims on their behalf, pushing the message to
+- **Push**: The sender pays a fee up front, and the Postman claims on their behalf, pushing the message to
   the recipient without them doing anything.
 - **Pull**: No fee is paid, so the message sits unclaimed until the recipient, or anyone else, pulls it by
   submitting the claim and paying the gas.
 
-Push relies on the postman for convenience, not for correctness.
-The fee goes to whoever submits the claim, so if the postman is unavailable, the recipient or a third party
+Push relies on the Postman for convenience, not for correctness.
+The fee goes to whoever submits the claim, so if the Postman is unavailable, the recipient or a third party
 can claim the message and collect the fee instead.
 
 ## Message commitments
@@ -93,8 +93,8 @@ messages were sent, so Linea can't finalize having accepted messages Ethereum ne
 
 - See [Messaging](../../../network/build/send-receive-messages.mdx) for the contract addresses, interfaces, and
   claim workflow on Linea Mainnet.
-- Configure postman behavior using the
+- Configure Postman behavior using the
   [Linea Postman options](../../../stack/reference/linea-postman-options.mdx).
 - See the [messaging contract source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/contracts/src/messaging)
-  and the [postman source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/postman) in the
+  and the [Postman source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/postman) in the
   `lineth-monorepo`.

--- a/docs/protocol/architecture/interoperability/canonical-message-service.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-message-service.mdx
@@ -73,6 +73,22 @@ message against the hashes already anchored on the network.
   </div>
 </div>
 
+:::note Linea Mainnet example
+
+On [Linea Mainnet](../../../network/index.mdx), the Ethereum side of the service lives in the
+[`LineaRollup`](../../../network/build/contracts.mdx) contract, which serves as both the rollup and the L1 message
+service for messages passed across the two domains, such as token transfers, contract calls, or state
+synchronization.
+Linea-to-Ethereum (L2 to L1) messages can be claimed on Ethereum only after the L2 batch is finalized:
+finalization verifies the batch's zk-SNARK proof and anchors the corresponding L2 message Merkle root on L1.
+The message is then accepted once a Merkle proof verifies its inclusion in that finalized root.
+Ethereum-to-Linea (L1 to L2) messages don't wait for a finalization: the coordinator anchors their hashes on
+Linea as a rolling hash, and they become claimable once anchored.
+That rolling hash is submitted with the next finalization and must match the one `LineaRollup` computed when the
+messages were sent, so Linea can't finalize having accepted messages Ethereum never sent.
+
+:::
+
 ## See also
 
 - See [Messaging](../../../network/build/send-receive-messages.mdx) for the contract addresses, interfaces, and

--- a/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
@@ -12,7 +12,7 @@ The canonical token bridge is a pair of lock-and-mint contracts, one on the
 <GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm>, that bridges any ERC-20 token.
 It carries no cross-chain machinery of its own: every transfer is a message sent through the
 [canonical message service](./canonical-message-service.mdx), and inherits that service's verification and
-delivery guarantees.
+delivery model.
 
 <div className="img-large">
   <LineaBridgeGraphic />

--- a/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
+++ b/docs/protocol/architecture/interoperability/canonical-token-bridge.mdx
@@ -1,25 +1,61 @@
 ---
 title: Canonical token bridge
 description: How Lineth's canonical token bridge uses lock-and-mint contracts and the message service for ERC-20 transfers.
-sidebar_position: 8
 image: /img/socialCards/canonical-token-bridge.jpg
 ---
+
+import GlossaryTerm from '@theme/GlossaryTerm';
 import LineaBridgeGraphic from "/img/get_started/concepts/canonical_token_bridge/Linea_canonical_token_bridge.svg";
+
+The canonical token bridge is a pair of lock-and-mint contracts, one on the
+<GlossaryTerm term="Lineth" /> network and one on its
+<GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm>, that bridges any ERC-20 token.
+It carries no cross-chain machinery of its own: every transfer is a message sent through the
+[canonical message service](./canonical-message-service.mdx), and inherits that service's verification and
+delivery guarantees.
 
 <div className="img-large">
   <LineaBridgeGraphic />
 </div>
 
-The canonical token bridge is the pair of [“lock & mint” contracts](../../../network/build/contracts.mdx#token-bridge-contracts) that allow bridging of any 
-ERC-20 token. The bridge relies on the
-[message service](./canonical-message-service.mdx)
-for cross-chain interactions.
+Native currency isn't bridged here.
+It moves through the message service directly, as the value attached to a message.
 
-## Next steps
+## How it works
 
-- See the UI for the [official public Linea bridge](https://linea.build/hub/bridge/).
+Bridging a token away from its original chain involves locking and minting as follows:
 
-- For the public network's workflow, ABI references, and bridge interfaces, see the
-[canonical token bridge guide](../../../network/build/bridge.mdx) and
-[contracts](../../../network/build/contracts.mdx).
+1. The bridge escrows the tokens in its own contract and sends a message instructing the bridge on the
+    destination chain to complete the transfer.
+2. That bridge mints an equivalent amount of a `BridgedToken`, an ERC-20 it controls, to the recipient.
+    The first time a given token is bridged, the destination bridge deploys the `BridgedToken` contract for it,
+    carrying over the escrowed token's name, symbol, and decimals.
 
+Bridging back reverses this: the bridge burns the `BridgedToken` and sends a message releasing the escrowed
+tokens on the original chain.
+Because minted supply on one side is always matched by escrowed supply on the other, the bridge can't mint tokens
+that were never locked.
+
+Operators can reserve token addresses so they can't be bridged, which is how tokens that need a dedicated bridge
+are kept off the canonical one.
+A token can only be reserved before it has been bridged.
+
+The following diagram illustrates a full round trip, including the
+[message service](./canonical-message-service.mdx#message-commitments) steps that sit between the two bridge contracts:
+
+<div class="center-container">
+  <div class="img-large">
+    <img
+      src="/img/get_started/concepts/message_service/Linea_bridge_architecture.png"
+      alt="Token bridge contracts locking and minting on each chain via the message service"
+    />
+  </div>
+</div>
+
+## See also
+
+- See the [bridge guide](../../../network/build/bridge.mdx) and
+  [contracts](../../../network/build/contracts.mdx) for the workflow, ABIs, and addresses on Linea
+  Mainnet, and the [Linea bridge](https://linea.build/hub/bridge/) for the public UI.
+- See the [token bridge source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/contracts/src/bridging/token)
+  in the `lineth-monorepo`.

--- a/docs/protocol/architecture/interoperability/index.mdx
+++ b/docs/protocol/architecture/interoperability/index.mdx
@@ -15,7 +15,12 @@ A <GlossaryTerm term="Lineth" /> network exchanges data and value with its
   arbitrary messages and native currency in both directions.
   The token bridge is built on it.
 
-In both directions, delivery is gated on state that has been verified onchain rather than on an offchain relayer
-behaving honestly.
-A message only executes on the destination chain once the contract there can check it against a commitment to the
-messages the origin chain actually sent.
+In both directions, a message executes on the destination chain only once that chain holds an onchain record of
+it, and anyone can submit the claim that triggers execution.
+
+What differs is when that record is checked against the origin chain.
+From the Lineth network to the finalization layer, messages are recorded on the finalization layer only once the
+blocks that sent them are finalized.
+From the finalization layer to the Lineth network, messages are recorded on the network first, and checked against
+the finalization layer at the next finalization.
+See [Message commitments](./canonical-message-service.mdx#message-commitments) for more information.

--- a/docs/protocol/architecture/interoperability/index.mdx
+++ b/docs/protocol/architecture/interoperability/index.mdx
@@ -1,19 +1,35 @@
 ---
 title: Interoperability
-description: Cross-chain messaging and canonical bridging mechanisms in Lineth
-sidebar_position: 5
+description: Cross-chain messaging and canonical token bridging between a Lineth network and its finalization layer.
 image: /img/socialCards/interoperability.jpg
 ---
 
 import GlossaryTerm from '@theme/GlossaryTerm';
 
-Interoperability in <GlossaryTerm term="Lineth" /> is enabled by:
+A <GlossaryTerm term="Lineth" /> network exchanges data and value with its
+<GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm> through two protocol components:
 
-- [Canonical token bridge](./canonical-token-bridge.mdx): a protocol contract and process that allows token transfers with
-  finalization guarantees.
-- [Message service](./canonical-message-service.mdx): a generalized cross-chain messaging primitive for application data.
+- [Canonical token bridge](./canonical-token-bridge.mdx): A pair of lock-and-mint contracts for bridging any
+  ERC-20 token.
+- [Canonical message service](./canonical-message-service.mdx): A general-purpose primitive that carries
+  arbitrary messages and native currency in both directions.
+  The token bridge is built on it.
 
-The [Linea public network](../../../network/index.mdx) leverages the [`LineaRollup`](../../../network/build/contracts.mdx) to support these functions. This smart contract provides the rollup and L1 message service for messages passed across the two domains, such as token transfers, contract calls, or state synchronization. Linea-to-Ethereum (L2 to L1) messages can be claimed on Ethereum only after the L2 batch is finalized: finalization verifies the batch's zk-SNARK proof and anchors the corresponding L2 message Merkle root on L1. The message is then accepted once a Merkle proof verifies its inclusion in that finalized root. Ethereum-to-Linea (L1 to L2) messages execute on Linea after the originating Ethereum transaction is verified against L1 state and finalized.
+In both directions, delivery is gated on state that has been verified onchain rather than on an offchain relayer
+behaving honestly.
+A message only executes on the destination chain once the contract there can check it against a commitment to the
+messages the origin chain actually sent.
 
-By anchoring messages to verified state roots, the contract facilitates cross-chain communication, ensuring Ethereum-level security and full transparency, while preserving the scalability benefits of Linea. The following sections cover in detail the protocol-level mechanisms that enable secure cross-chain communication,
-value transfer, and message verification between a Lineth network and other chains.
+:::note Linea Mainnet example
+
+On [Linea Mainnet](../../../network/index.mdx), the Ethereum side of both mechanisms lives in the
+[`LineaRollup`](../../../network/build/contracts.mdx) contract.
+This contract provides the rollup and L1 message service for messages passed across the two domains, such as
+token transfers, contract calls, or state synchronization.
+Linea-to-Ethereum (L2 to L1) messages can be claimed on Ethereum only after the L2 batch is finalized:
+finalization verifies the batch's zk-SNARK proof and anchors the corresponding L2 message Merkle root on L1.
+The message is then accepted once a Merkle proof verifies its inclusion in that finalized root.
+Ethereum-to-Linea (L1 to L2) messages execute on Linea after the originating Ethereum transaction is verified
+against L1 state and finalized.
+
+:::

--- a/docs/protocol/architecture/interoperability/index.mdx
+++ b/docs/protocol/architecture/interoperability/index.mdx
@@ -19,17 +19,3 @@ In both directions, delivery is gated on state that has been verified onchain ra
 behaving honestly.
 A message only executes on the destination chain once the contract there can check it against a commitment to the
 messages the origin chain actually sent.
-
-:::note Linea Mainnet example
-
-On [Linea Mainnet](../../../network/index.mdx), the Ethereum side of both mechanisms lives in the
-[`LineaRollup`](../../../network/build/contracts.mdx) contract.
-This contract provides the rollup and L1 message service for messages passed across the two domains, such as
-token transfers, contract calls, or state synchronization.
-Linea-to-Ethereum (L2 to L1) messages can be claimed on Ethereum only after the L2 batch is finalized:
-finalization verifies the batch's zk-SNARK proof and anchors the corresponding L2 message Merkle root on L1.
-The message is then accepted once a Merkle proof verifies its inclusion in that finalized root.
-Ethereum-to-Linea (L1 to L2) messages execute on Linea after the originating Ethereum transaction is verified
-against L1 state and finalized.
-
-:::

--- a/docs/protocol/architecture/rpc-services.mdx
+++ b/docs/protocol/architecture/rpc-services.mdx
@@ -1,6 +1,5 @@
 ---
 title: RPC services
-sidebar_position: 5
 description: >-
   JSON-RPC services exposed by Lineth nodes, enabling access to near-head state
   and full historical blockchain data.
@@ -9,25 +8,13 @@ image: /img/socialCards/rpc-services.jpg
 
 import GlossaryTerm from '@theme/GlossaryTerm';
 
-## What are they?
+RPC services expose the JSON-RPC interfaces that applications, users, and internal services use to read network
+data and submit transactions.
+Any <GlossaryTerm term="Lineth" /> node can serve them, publicly or only within the operator's network, and RPC
+nodes are typically placed behind load balancers and access controls
+(<GlossaryTerm term="Role-based access control (RBAC)">RBAC</GlossaryTerm>).
 
-RPC services expose JSON-RPC APIs to applications and users. Any Lineth node can serve RPC requests.
 What distinguishes one RPC node from another is how much state history it retains.
-
-Most end users use their [wallet](../../network/how-to/connect-wallet.mdx) as a user interface to
-interact with the public blockchain through an RPC service.
-Most developers use [public RPC services](../../network/build/tools/node-providers/index.mdx), or
-[run their own RPC node](../../network/how-to/run-a-node/index.mdx).
-
-## What do they do?
-
-RPC services provide the JSON-RPC interfaces that applications and users rely on to access network
-data. RPC nodes may be deployed behind load balancers and access controls (<GlossaryTerm term="Role-based access control (RBAC)">RBAC</GlossaryTerm>).
-
-## How do they do it?
-
-RPC services are provided by RPC nodes. Operators decide how much state history each node retains,
-depending on the queries the network needs to answer.
 
 ## State retention
 
@@ -46,46 +33,30 @@ themselves, so it can reconstruct the chain state at any past block height. It t
 and modest storage requirements for completeness, and acts as the source of truth for historical
 state, supporting auditing, forensics, analytics, and historical consistency checks.
 
-## Why run your own RPC?
+## Why run your own RPC
 
-While public RPC endpoints are convenient for development and light usage, running your own RPC node
-gives operators stronger guarantees and greater control over how they interact with the network.
+Public RPC endpoints are convenient for development, testing, and low-volume usage.
+As usage grows, or as requirements around reliability, trust, or data access get stricter, a dedicated RPC node
+becomes more valuable:
 
-For quick experimentation, testing, or low-volume usage, public RPC services may be sufficient. As
-usage grows or requirements around reliability, trust, or data access become stricter, running a
-dedicated RPC node becomes increasingly valuable.
+- **Reliability**: Public endpoints are shared infrastructure, subject to rate limits, request prioritization,
+  and maintenance windows outside your control.
+  Your own node lets you size resources and manage uptime to your application's needs.
+- **Performance**: A self-hosted node can be tuned for one workload, whether that's low-latency access to recent
+  state or high-throughput historical queries, without contention from other users.
+- **Correctness**: Querying a public endpoint means trusting a third party to serve accurate and complete data.
+  Your own node validates chain data directly from the protocol.
+- **Historical data**: Public endpoints often restrict archive access because of its storage cost.
+  Your own [archive node](#archive-nodes) has no such limits.
+- **Operational control**: A self-hosted node can sit inside a private network behind load balancers and RBAC,
+  which matters for backend services, indexers, and internal tooling that need predictable access patterns and
+  tighter security boundaries.
 
-### Reliability and availability
+## See also
 
-Public RPC services are shared infrastructure and may enforce rate limits, request prioritization,
-or maintenance windows outside your control. Operating your own RPC allows you to size resources,
-tune performance, and manage uptime according to your application’s needs.
-
-### Performance and latency
-
-A self-hosted RPC node can be optimized for your specific workload, whether that's low-latency access
-to recent state or high-throughput historical queries. This avoids contention with other users and
-can significantly reduce response times for latency-sensitive applications.
-
-### Trust and correctness
-
-When using a public RPC, applications implicitly trust a third party to serve accurate and complete
-data. Running your own RPC allows you to validate chain data directly from the protocol, reducing
-reliance on external operators and improving assurance around data integrity.
-
-### Access to historical data
-
-Public RPC endpoints often restrict access to archive data due to storage and cost constraints.
-Operating your own archive node enables unrestricted historical queries, supporting use cases such as
-analytics, auditing, and forensics.
-
-### Operational control and security
-
-Self-hosted RPC nodes can be deployed behind private networks, load balancers, and access controls (RBAC).
-This is especially important for backend services, indexers, and internal tooling that require predictable
-access patterns and tighter security boundaries.
-
-## Next steps
-
-For operational deployment details, see the
-[Lineth architecture](../../stack/deployment/index.mdx).
+- See [Deployment architecture](../../stack/deployment/index.mdx) for how RPC nodes fit into an
+  operator's footprint.
+- On Linea Mainnet, most users reach RPC services through their
+  [wallet](../../network/how-to/connect-wallet.mdx), and developers either use a
+  [node provider](../../network/build/tools/node-providers/index.mdx) or
+  [run their own node](../../network/how-to/run-a-node/index.mdx).

--- a/docs/protocol/architecture/smart-contracts.mdx
+++ b/docs/protocol/architecture/smart-contracts.mdx
@@ -1,102 +1,87 @@
 ---
 title: Smart contracts
-description: Onchain system contracts and auxiliary services for Lineth
-sidebar_position: 3
+description: The onchain system contracts Lineth deploys on the finalization layer and on the network.
 image: /img/socialCards/smart-contracts.jpg
 ---
 
 import GlossaryTerm from '@theme/GlossaryTerm';
 
-As an <GlossaryTerm term="Ethereum Virtual Machine (EVM)">EVM</GlossaryTerm>-equivalent environment, smart contracts can be written in any language that compiles to EVM bytecode.
+<GlossaryTerm term="Lineth" /> deploys system contracts on two chains: the
+<GlossaryTerm term="Finalization layer">finalization layer</GlossaryTerm>, where state transitions are verified
+and recorded, and the network itself.
+Together they establish what the network's state is and move messages and tokens between the two.
 
-<GlossaryTerm term="Lineth" /> includes onchain system contracts deployed on the finalization layer and on the
-deployed network itself, as well as auxiliary services that support network operations. Understanding
-these contracts and services is essential for operators managing deployments.
+Because the network is an <GlossaryTerm term="Ethereum Virtual Machine (EVM)">EVM</GlossaryTerm>-equivalent
+environment, these contracts, and any application contracts deployed on the network, can be written in any
+language that compiles to EVM bytecode.
 
-### Finalization contract
+## Finalization contract
 
-:::info
+Deployed on the [finalization layer](../../stack/deployment/data-availability-finalization.mdx), this contract
+is the network's onchain root of trust: nothing the network claims about its own state is accepted elsewhere
+until this contract has recorded it.
+The finalization contract:
 
-In the Linea Public Mainnet deployment, this contract is referred to as the [`LineaRollup`](../../network/build/contracts.mdx). It provides rollup settlement and messaging functionality. Operators running private or hybrid
-networks may reuse the same contract pattern or deploy functionally equivalent contracts as part of
-their finalization design.
+- Verifies the <GlossaryTerm term="zk-SNARK" /> proof submitted for each range of blocks, and records the
+  resulting finalized state.
+- Accepts the transaction data the network publishes, through whichever
+  [data submission model](./index.mdx#transaction-lifecycle) the deployment uses.
+- Anchors the Merkle roots of the messages the finalized blocks sent, and verifies the rolling hash of the
+  messages the network received.
+  See [Message commitments](./interoperability/canonical-message-service.mdx#message-commitments).
+- Queues [forced transactions](../forced-transactions.mdx) submitted on the finalization layer, so they can be
+  proven to have been processed by their deadline.
+
+:::note Linea Mainnet
+
+In the Linea Mainnet deployment, this contract is [`LineaRollup`](../../network/build/contracts.mdx) on Ethereum,
+which also serves as the L1 message service.
+Operators running other deployments can reuse the same contract or deploy an equivalent that satisfies the
+interfaces their finalization design requires.
 
 :::
 
-This contract is deployed to the [finalization layer](../../stack/deployment/data-availability-finalization.mdx).
+## Message service contracts
 
-**Purpose:**  
-It enables secure interactions between the deployed network and the finalization layer.
+A message service contract is deployed on each chain.
+Together they carry arbitrary calldata and native currency in both directions, and only deliver a message once
+it can be checked against a commitment recorded by the finalization contract.
 
-**Functionality:**
+Everything else that crosses chains, including the token bridge, is built on this pair.
+See [Canonical message service](./interoperability/canonical-message-service.mdx).
 
-- Validates <GlossaryTerm term="zk-SNARK" /> proofs attesting to correct state transitions for batches of transactions
-- Records finalized state roots on the finalization layer
-- Acts as a [canonical protocol contract for message passing](./interoperability/canonical-message-service.mdx)
-  between the deployed network and the finalization layer
-- Anchors L2 message Merkle roots as part of a successful batch finalization
-- When an L2-to-L1 message is claimed, verifies its Merkle proof against an anchored root before delivering the message
+## Token bridge contracts
 
-### Native message bridge smart contract
+A token bridge contract is deployed on each chain.
+They bridge ERC-20 tokens by escrowing the original on its home chain and minting a bridged equivalent on the
+other, sending each instruction through the message service.
+Minted supply is always matched by escrowed supply, so the bridge cannot mint tokens that were never locked.
+See [Canonical token bridge](./interoperability/canonical-token-bridge.mdx).
 
-**Purpose:** Facilitates secure, proven communication of arbitrary messages and data between the
-finalization layer and the <GlossaryTerm term="zkEVM" />.
+## Contract versioning
 
-**Functionality:**
+Contracts are immutable once deployed unless they're explicitly designed to be upgraded.
+Lineth's upgradeable contracts, including the finalization contract, message service, and token bridge, use the
+[OpenZeppelin Transparent Upgradeable Proxy](https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy)
+pattern (v4.x): state lives in a proxy, and an upgrade replaces the implementation the proxy delegates to.
 
-- Enables crosschain calls, instructing the deployed network to perform specific operations (minting,
-  contract interaction, data relay)
-- Sends proofs or withdrawal requests back to the finalization layer
-- Supports functionality beyond token transfers
+Who holds upgrade authority is a deployment decision, not a protocol one.
+See [Trust and responsibilities](../../stack/evaluate/trust-model.mdx) for how that authority is scoped.
 
-### Native token bridge smart contract
+:::note Linea Mainnet
 
-**Purpose:** Secure gateway for moving ETH and ERC-20 tokens to and from the finalization layer.
+Linea contracts are written in [Solidity](https://www.soliditylang.org/) and audited by two to three external
+auditors before release, alongside static analysis and, where applicable, formal verification.
+The auditors also confirm the deployment on the target environment.
+Upgrading the system requires signatures from both the Linea Operational Safe and the Linea Security Council Safe
+multisignature accounts.
 
-**Functionality:**
+:::
 
-- Uses non-custodial escrow, event tracking, and zk-SNARK proof validation to reduce bridge trust
-  assumptions
-- Enables the deployed network to interoperate directly with Ethereum while preserving protocol-level asset security
+## See also
 
-**Deposit flow (finalization layer → deployed network):**
-
-- Users send ETH or ERC-20 tokens to the Native Token Bridge contract on the finalization layer
-- Contract locks (escrows) these assets and emits an event
-- Once observed by the contract on the deployed network, an equivalent amount is minted or released to the
-  user's account
-
-**Withdrawal flow (deployed network → finalization layer):**
-
-- Users request withdrawal from the deployed network
-- Withdrawal is processed in a batch and proven valid using zk-SNARKs
-- Proof and withdrawal claim are submitted to the bridge contract on the finalization layer
-- Upon verification, the bridge contract unlocks and releases the withdrawn assets
-
-**Security:**
-
-- Enforces strict verification rules (only proven withdrawals can be processed)
-- Replay and fraud protection through state roots, proofs, and event tracking across both layers
-- Maintains a registry of supported tokens and tracks total supply to ensure minted amounts never
-  exceed locked amounts
-
-## Linea public network smart contract release
-
-Before each Linea Smart Contract release that targets the [public network](../../network/index.mdx), the new version is prepared and tested. Testing includes static code analysis, formal verification is conducted where applicable, and documentation is updated. 
-
-Linea developers write in [Solidity](https://www.soliditylang.org/). Each smart contract is audited by 2-3 external auditors. Smart contracts are deployed on target environments using production deployment keys and the auditors confirm the correct deployment of the contracts.
-
-The Linea Operational Safe multisignature account and the Linea Security Council Safe multisignature account must both sign to upgrade the system.
-
-### Contract versioning
-
-For upgradeable contracts, Linea adopts the [OpenZeppelin Transparent Upgradeable Proxy](https://docs.openzeppelin.com/contracts/5.x/api/proxy#TransparentUpgradeableProxy) pattern (v4.x). This pattern is used consistently across the platform’s core components, including but not limited to:
-
-- Core protocol contracts
-- Token Bridge contracts deployed on both Linea and Ethereum
-- Layer 2 Message Service
-
-
-## Next steps
-
-- Discover the Public Linea network's [smart contracts](../../network/build/contracts)
+- See the [contracts reference](../../network/build/contracts.mdx) for the deployed addresses and roles on Linea
+  Mainnet, and the [Security Council transaction record](../../changelog/security-council-record.mdx) for its
+  upgrade history.
+- See the [contract source code](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/contracts/src) in the
+  `lineth-monorepo`.

--- a/docs/protocol/architecture/smart-contracts.mdx
+++ b/docs/protocol/architecture/smart-contracts.mdx
@@ -73,6 +73,7 @@ See [Trust and responsibilities](../../stack/evaluate/trust-model.mdx) for how t
 Linea contracts are written in [Solidity](https://www.soliditylang.org/) and audited by two to three external
 auditors before release, alongside static analysis and, where applicable, formal verification.
 The auditors also confirm the deployment on the target environment.
+See [Security audits](../reference/security-audits.mdx) for the published reports.
 Upgrading the system requires signatures from both the Linea Operational Safe and the Linea Security Council Safe
 multisignature accounts.
 

--- a/docs/stack/deployment/core-components.mdx
+++ b/docs/stack/deployment/core-components.mdx
@@ -73,7 +73,7 @@ Common examples include:
 
 - [Block explorer](../../protocol/architecture/index.mdx#block-explorer)
 - [Archive node service](../../protocol/architecture/rpc-services.mdx#archive-nodes)
-- [RPC load balancers](../../protocol/architecture/rpc-services.mdx#what-do-they-do)
+- [RPC load balancers](../../protocol/architecture/rpc-services.mdx)
 - Monitoring and metrics
 - Indexer
 - API portal


### PR DESCRIPTION
Follow up to #1654. Edit pass over interoperability (token bridge and message service), smart contract, and RPC services pages, for accuracy, conciseness, style, and consistency.

Preview: https://doc-linea-git-interop-contracts-rpc-consensys-ddffed67.vercel.app/protocol/architecture/interoperability


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and editorial-guidance only; no application or protocol code changes.
> 
> **Overview**
> **Editorial rules** drop the “don’t restate the title” rule in favor of a one–two sentence opening that orients the reader (`content-structure.mdc`, `editorial-voice.mdc`, and the author/PR review skills).
> 
> **Protocol architecture** gets a follow-up edit pass (after #1654) on interoperability, onchain contracts, and RPC:
> 
> - **Interoperability hub and children** reframe cross-chain flow around the message service (Postman, permissionless claiming, push vs pull) and **message commitments** (Merkle roots vs rolling hash by direction). The token bridge page explains lock/mint/`BridgedToken`, native currency via the message service, and operator reservations; **Next steps** become **See also** with source links.
> - **`smart-contracts.mdx`** is reorganized into finalization, message service, token bridge, and versioning, with Linea Mainnet specifics in admonitions instead of long inline lists.
> - **`rpc-services.mdx`** is shortened: near-head/archive retention stays; the “why run your own” material is a bullet list; wallet/node-provider pointers move to **See also**.
> 
> **Stack:** `core-components.mdx` updates the RPC load balancer link after heading changes on the RPC page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2379e8568088a8015c97158fe06625c1f9c6b892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->