### PR TITLE
Add OpenChainBench to analytics tools

### DIFF
--- a/docs/network/build/tools/analytics/openchainbench.mdx
+++ b/docs/network/build/tools/analytics/openchainbench.mdx
@@ -1,0 +1,46 @@
+---
+title: OpenChainBench
+image: /img/socialCards/analytics.jpg
+---
+
+[OpenChainBench](https://openchainbench.com) is an open-source, continuously-running benchmark suite
+for EVM chain infrastructure. It measures RPC provider latency, L1 finality time, and block time
+across multiple regions, giving developers neutral, reproducible data to compare providers and
+monitor network health.
+
+## Why OpenChainBench?
+
+- **Live, multi-region RPC benchmarks**: Sends identical probes to every major RPC provider from
+  three global regions every 15 seconds, reporting p50/p90/p99 latency, error rates, and stale
+  block ratios. For Linea this covers all public and paid endpoints listed on
+  [chainlist.org](https://chainlist.org).
+
+- **L1 finality and block time tracking**: Measures the wall-clock time from L2 block creation to
+  L1 finality confirmation, and tracks sequencer block time to detect anomalies in real time.
+
+- **Fully open methodology**: Every metric is a literal PromQL query against a public Prometheus
+  endpoint. The harness source is MIT licensed, data is published under CC-BY-4.0, and results are
+  reproducible locally with `docker compose up`.
+
+- **No paid tiers or sponsored rankings**: All providers are measured with the same methodology.
+  The project is vendor-neutral; no placement is sold or influenced by commercial relationships.
+
+## Get started
+
+Explore live Linea benchmarks and compare RPC providers at
+[openchainbench.com](https://openchainbench.com).
+
+**Additional resources:**
+
+- **[Methodology](https://openchainbench.com/methodology)** - Detailed explanation of probe design,
+  sampling intervals, and statistical aggregation.
+
+- **[Public API](https://openchainbench.com/api)** - OpenAPI spec for programmatic access to all
+  benchmark data.
+
+- **[GitHub repository](https://github.com/ChainBench/OpenChainBench)** - MIT-licensed harness
+  source code, open to contributions and community audits.
+
+**X:** https://x.com/OpenChainBench
+
+**GitHub:** https://github.com/ChainBench/OpenChainBench


### PR DESCRIPTION
## Description

Adds an OpenChainBench page to the analytics tools section, following the same structure as the existing Mobula page.

OpenChainBench is an open-source (MIT harnesses, CC-BY-4.0 data), continuously-running benchmark suite that measures:

- RPC provider latency (p50/p90/p99) from 3 global probe regions, sampled every 15 seconds
- L1 finality time from Linea L2 block creation to L1 confirmation
- Sequencer block time anomaly detection

All metrics are backed by literal PromQL queries against a public Prometheus endpoint. No paid tiers, no sponsored rankings, fully reproducible with `docker compose up`.

**GitHub:** https://github.com/ChainBench/OpenChainBench (MIT)
**Live benchmarks:** https://openchainbench.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application, auth, or infrastructure code changes.
> 
> **Overview**
> Adds a new **OpenChainBench** entry under analytics tools (`openchainbench.mdx`), mirroring the Mobula page layout (intro, “Why…?”, get started, links).
> 
> The page describes OpenChainBench as an open-source, continuously running EVM infra benchmark: multi-region RPC latency (p50/p90/p99), L1 finality and block-time tracking for Linea, public PromQL/Prometheus methodology, and vendor-neutral provider comparison. It links to live benchmarks, methodology, API docs, and the GitHub harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1a3a428dc90fc4c3a9a115ab418440556f973a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->